### PR TITLE
Support multisig wallet

### DIFF
--- a/.changeset/dull-onions-rule.md
+++ b/.changeset/dull-onions-rule.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/wallet-adapter-core": patch
+---
+
+Add multisig support for AccountInfo

--- a/packages/wallet-adapter-core/src/types.ts
+++ b/packages/wallet-adapter-core/src/types.ts
@@ -11,7 +11,8 @@ export type NetworkInfo = {
 
 export type AccountInfo = {
   address: string;
-  publicKey: string;
+  publicKey: string | string[];
+  minKeysRequired?: number
 };
 
 export interface AptosWalletErrorResult {


### PR DESCRIPTION
Support multisig wallet, like https://github.com/hippospace/aptos-wallet-adapter/pull/69

Before we integrate with Blocto, we need to change the interface first.