### PR TITLE
Add optional chainId and url properties to NetworkInfo type

### DIFF
--- a/.changeset/plenty-laws-laugh.md
+++ b/.changeset/plenty-laws-laugh.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/wallet-adapter-core": minor
+---
+
+Add chainId and url propoerties to NetworkInfo type

--- a/packages/wallet-adapter-core/src/types.ts
+++ b/packages/wallet-adapter-core/src/types.ts
@@ -7,8 +7,8 @@ export type WalletName<T extends string = string> = T & {
 };
 export type NetworkInfo = {
   name: NetworkName;
-  chainId: string;
-  url: string;
+  chainId?: string;
+  url?: string;
 };
 
 export type AccountInfo = {

--- a/packages/wallet-adapter-core/src/types.ts
+++ b/packages/wallet-adapter-core/src/types.ts
@@ -7,7 +7,7 @@ export type WalletName<T extends string = string> = T & {
 };
 export type NetworkInfo = {
   name: NetworkName;
-  chainId: number;
+  chainId: string;
   url: string;
 };
 

--- a/packages/wallet-adapter-core/src/types.ts
+++ b/packages/wallet-adapter-core/src/types.ts
@@ -6,7 +6,9 @@ export type WalletName<T extends string = string> = T & {
   __brand__: "WalletName";
 };
 export type NetworkInfo = {
-  name: NetworkName | undefined;
+  name: NetworkName;
+  chainId: number;
+  url: string;
 };
 
 export type AccountInfo = {


### PR DESCRIPTION
Add `chainId` and `url` properties to NetworkInfo type for
1. `chainId` can help dapps to identify and differentiate between Aptos networks (i.e if they want to know what network the account/wallet is on, they can use the chainId for that)
2. `url` can be used by the adapter for future features that need to know the `url` for such as - waitForTransaction, interact with full nodes or with the indexer in the future.
3. Some wallets already expose those properties, but making it optional for now to not introduce breaking changes.