### PR TITLE
Export WalletReadyState enum

### DIFF
--- a/.changeset/popular-crabs-work.md
+++ b/.changeset/popular-crabs-work.md
@@ -1,0 +1,6 @@
+---
+"@aptos-labs/wallet-adapter-nextjs-example": patch
+"@aptos-labs/wallet-adapter-react": patch
+---
+
+Export WalletReadyState enum from react package

--- a/apps/nextjs-example/components/WalletButtons.tsx
+++ b/apps/nextjs-example/components/WalletButtons.tsx
@@ -1,4 +1,4 @@
-import { useWallet } from "@aptos-labs/wallet-adapter-react";
+import { useWallet, WalletReadyState } from "@aptos-labs/wallet-adapter-react";
 
 const WalletButtons = () => {
   const { wallets, connect } = useWallet();
@@ -12,7 +12,7 @@ const WalletButtons = () => {
               ? "opacity-50 cursor-not-allowed"
               : "hover:bg-blue-700"
           }`}
-          disabled={wallet.readyState !== "Installed"}
+          disabled={wallet.readyState !== WalletReadyState.Installed}
           key={wallet.name}
           onClick={() => connect(wallet.name)}
         >

--- a/apps/nextjs-example/package.json
+++ b/apps/nextjs-example/package.json
@@ -11,7 +11,6 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@aptos-labs/wallet-adapter-core": "workspace:*",
     "@aptos-labs/wallet-adapter-react": "workspace:*",
     "@martianwallet/aptos-wallet-adapter": "^0.0.2",
     "@pontem/wallet-adapter-plugin": "^0.1.4",

--- a/packages/wallet-adapter-react/src/index.tsx
+++ b/packages/wallet-adapter-react/src/index.tsx
@@ -1,3 +1,3 @@
 import * as React from "react";
-export { useWallet } from "./useWallet";
+export { useWallet, WalletReadyState } from "./useWallet";
 export * from "./WalletProvider";

--- a/packages/wallet-adapter-react/src/index.tsx
+++ b/packages/wallet-adapter-react/src/index.tsx
@@ -1,3 +1,4 @@
 import * as React from "react";
 export { useWallet, WalletReadyState } from "./useWallet";
+export type { WalletName } from "./useWallet";
 export * from "./WalletProvider";

--- a/packages/wallet-adapter-react/src/useWallet.tsx
+++ b/packages/wallet-adapter-react/src/useWallet.tsx
@@ -6,11 +6,13 @@ import {
   SignMessagePayload,
   SignMessageResponse,
   Wallet,
+  WalletReadyState,
 } from "@aptos-labs/wallet-adapter-core";
 import { createContext, useContext } from "react";
 import { Types } from "aptos";
 
 export type { WalletName };
+export { WalletReadyState };
 
 export interface WalletContextState {
   connected: boolean;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,6 @@ importers:
 
   apps/nextjs-example:
     specifiers:
-      '@aptos-labs/wallet-adapter-core': workspace:*
       '@aptos-labs/wallet-adapter-react': workspace:*
       '@babel/core': ^7.0.0
       '@martianwallet/aptos-wallet-adapter': ^0.0.2
@@ -41,7 +40,6 @@ importers:
       tailwindcss: ^3.2.4
       typescript: ^4.5.3
     dependencies:
-      '@aptos-labs/wallet-adapter-core': link:../../packages/wallet-adapter-core
       '@aptos-labs/wallet-adapter-react': link:../../packages/wallet-adapter-react
       '@martianwallet/aptos-wallet-adapter': 0.0.2
       '@pontem/wallet-adapter-plugin': 0.1.4


### PR DESCRIPTION
Export `WalletReadyState` enum so dapps can import and use it without the need to install `core` package as a dependency