### PR TITLE
Add React as a dependency in wallet-adapter-react package

### DIFF
--- a/.changeset/pink-games-smoke.md
+++ b/.changeset/pink-games-smoke.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/wallet-adapter-react": patch
+---
+
+Add react package as a dependency

--- a/packages/wallet-adapter-react/package.json
+++ b/packages/wallet-adapter-react/package.json
@@ -34,9 +34,6 @@
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",
     "lint": "TIMING=1 eslint \"src/**/*.ts*\""
   },
-  "peerDependencies": {
-    "react": "*"
-  },
   "devDependencies": {
     "@aptos-labs/wallet-adapter-tsconfig": "workspace:*",
     "@types/react": "^18.0.17",
@@ -47,6 +44,7 @@
   },
   "dependencies": {
     "@aptos-labs/wallet-adapter-core": "*",
-    "aptos": "^1.3.17"
+    "aptos": "^1.3.17",
+    "react": "^18"
   }
 }

--- a/packages/wallet-adapter-react/src/WalletProvider.tsx
+++ b/packages/wallet-adapter-react/src/WalletProvider.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 import {
   FC,
   ReactNode,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,11 +152,13 @@ importers:
       '@types/react-dom': ^18.0.6
       aptos: ^1.3.17
       eslint: ^8.15.0
+      react: ^18
       tsup: ^5.10.1
       typescript: ^4.5.3
     dependencies:
       '@aptos-labs/wallet-adapter-core': link:../wallet-adapter-core
       aptos: 1.3.17
+      react: 18.2.0
     devDependencies:
       '@aptos-labs/wallet-adapter-tsconfig': link:../tsconfig
       '@types/react': 18.0.25


### PR DESCRIPTION
For some reason `React` was listed as a `peerDependency` and it can ends up with React package not being installed in `node_modules` - if it is not there, `pnpm` takes the references to whatever it has in the cache, and if it doesn't find it, the package doesnt know where to take it from and you end up with this error


![image](https://user-images.githubusercontent.com/29798064/211576217-27d91de9-5484-4af4-afff-c24c67320f27.png)


This PR adds `react` to the dependencies array (where it should be).

Before
<img width="712" alt="Screen Shot 2023-01-10 at 4 18 28 PM" src="https://user-images.githubusercontent.com/29798064/211576406-e691b326-7c49-4363-bd28-7272f3ed2a08.png">

After
<img width="735" alt="Screen Shot 2023-01-10 at 4 18 57 PM" src="https://user-images.githubusercontent.com/29798064/211576452-c1f62c3a-3aa1-4915-94bd-5d5bcb6aadad.png">
