### PR TITLE
throw Sign Transaction is not supported error

### DIFF
--- a/.changeset/friendly-mugs-move.md
+++ b/.changeset/friendly-mugs-move.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/wallet-adapter-core": patch
+---
+
+Throw Sign Transaction is not supported error

--- a/apps/nextjs-example/pages/index.tsx
+++ b/apps/nextjs-example/pages/index.tsx
@@ -63,6 +63,7 @@ export default function App() {
     };
     try {
       const response = await signTransaction(payload);
+      setSuccessAlertMessage(JSON.stringify(response));
       console.log("response", response);
     } catch (error: any) {
       console.log("error", error);

--- a/packages/wallet-adapter-core/src/WalletCore.ts
+++ b/packages/wallet-adapter-core/src/WalletCore.ts
@@ -14,6 +14,7 @@ import {
   WalletNotConnectedError,
   WalletNotReadyError,
   WalletNotSelectedError,
+  WalletNotSupportedMethod,
   WalletSignAndSubmitMessageError,
   WalletSignMessageAndVerifyError,
   WalletSignMessageError,
@@ -240,8 +241,13 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
   async signTransaction(
     transaction: Types.TransactionPayload
   ): Promise<Uint8Array | null> {
+    if (this._wallet && !("signTransaction" in this._wallet)) {
+      throw new WalletNotSupportedMethod(
+        `Sign Transaction is not supported by ${this.wallet?.name}`
+      ).message;
+    }
+
     try {
-      if (this._wallet && !("signTransaction" in this._wallet)) return null;
       this.doesWalletExist();
       const response = await (this._wallet as any).signTransaction(transaction);
       return response;

--- a/packages/wallet-adapter-core/src/error/index.ts
+++ b/packages/wallet-adapter-core/src/error/index.ts
@@ -98,3 +98,7 @@ export class WalletWindowClosedError extends WalletError {
 export class WalletResponseError extends WalletError {
   name = "WalletResponseError";
 }
+
+export class WalletNotSupportedMethod extends WalletError {
+  name = "WalletNotSupportedMethod";
+}


### PR DESCRIPTION
1. When trying to Sign a message with a wallet that doesnt support it, the adapter throws a WalletNotSupportedMethod.
2. When Sign Message succeed, display the return message

<img width="1938" alt="Screen Shot 2023-01-10 at 6 42 41 PM" src="https://user-images.githubusercontent.com/29798064/211612733-18bdcb34-4455-4465-9444-bf9d01138ef7.png">
