### PR TITLE
revert global tailwind config changes in demo app

### DIFF
--- a/apps/nextjs-example/pages/_app.tsx
+++ b/apps/nextjs-example/pages/_app.tsx
@@ -1,8 +1,9 @@
 import type { AppProps } from "next/app";
 import { AppContext } from "../components/AppContext";
 
-import "@aptos-labs/wallet-adapter-ant-design/dist/index.css";
+// order matters
 import "../styles/global.css";
+import "@aptos-labs/wallet-adapter-ant-design/dist/index.css";
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (

--- a/apps/nextjs-example/styles/global.css
+++ b/apps/nextjs-example/styles/global.css
@@ -1,29 +1,3 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-@layer base {
-  h3 {
-    @apply text-base;
-    @apply font-light;
-    @apply font-sans;
-  }
-  button {
-    @apply border-none;
-    @apply px-4;
-    @apply py-2;
-    @apply font-bold;
-    @apply text-lg;
-  }
-  div {
-    @apply font-sans;
-  }
-}
-
-@layer utilities {
-  td {
-    @apply border-t-gray-300;
-    @apply border-solid;
-    @apply border-0;
-  }
-}

--- a/apps/nextjs-example/tailwind.config.js
+++ b/apps/nextjs-example/tailwind.config.js
@@ -8,7 +8,4 @@ module.exports = {
     extend: {},
   },
   plugins: [],
-  corePlugins: {
-    preflight: false,
-  },
 };


### PR DESCRIPTION
Previous tailwind config changes were done to prevent collision when using different UI frameworks, this PR fixes it differently so we can still use different UI frameworks in the same app.