### PR TITLE
Import tweetnacl via default export to support common js

### DIFF
--- a/.changeset/strong-falcons-act.md
+++ b/.changeset/strong-falcons-act.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/wallet-adapter-core": patch
+---
+
+Import tweetnacl package via default export to support commonJS

--- a/packages/wallet-adapter-core/src/WalletCore.ts
+++ b/packages/wallet-adapter-core/src/WalletCore.ts
@@ -1,6 +1,6 @@
 import { HexString, Types } from "aptos";
 import EventEmitter from "eventemitter3";
-import { sign } from "tweetnacl";
+import nacl from "tweetnacl";
 import { Buffer } from "buffer";
 
 import { WalletReadyState } from "./constants";
@@ -338,7 +338,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
         );
         // support for when address doesnt have hex prefix (0x)
         const signature = new HexString(response.signature);
-        verified = sign.detached.verify(
+        verified = nacl.sign.detached.verify(
           Buffer.from(response.fullMessage),
           Buffer.from(signature.noPrefix(), "hex"),
           Buffer.from(currentAccountPublicKey.noPrefix(), "hex")


### PR DESCRIPTION
This PR should fix this reported issue https://github.com/aptos-labs/aptos-wallet-adapter/issues/56 where it imports the tweetnacl package via default export to support commonJS