### PR TITLE
Throw wallet not found error when trying to connect to an uninstalled wallet

### DIFF
--- a/.changeset/old-brooms-divide.md
+++ b/.changeset/old-brooms-divide.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/wallet-adapter-core": patch
+---
+
+Throw wallet not found error when trying to connect to an uninstalled wallet


### PR DESCRIPTION
PR to fix https://github.com/aptos-labs/aptos-wallet-adapter/issues/58
When wallet is not installed or not in the current connected wallets, throw a "not found" error instead of just return.

<img width="512" alt="Screen Shot 2023-01-18 at 11 19 20 AM" src="https://user-images.githubusercontent.com/29798064/213274993-47307904-8e1e-48b4-8100-423c9ac2a480.png">
