### PR TITLE
[HOT FIX] have connect() simply return if wallet is not installed

### DIFF
--- a/.changeset/eight-peaches-rush.md
+++ b/.changeset/eight-peaches-rush.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/wallet-adapter-core": patch
+---
+
+connect() to simply return if wallet is not installed

--- a/packages/wallet-adapter-core/src/WalletCore.ts
+++ b/packages/wallet-adapter-core/src/WalletCore.ts
@@ -180,8 +180,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
         (selectedWallet.readyState !== WalletReadyState.Installed &&
           selectedWallet.readyState !== WalletReadyState.Loadable)
       ) {
-        throw new WalletConnectionError(`${walletName} wallet not found`)
-          .message;
+        return;
       }
 
       if (this._connected) {


### PR DESCRIPTION
previously (https://github.com/aptos-labs/aptos-wallet-adapter/pull/60) we changed this method to throw an error if wallet is not installed, this causes the pooling process to stop and not keep looking for wallets. Since on first load wallets can still be under "not detected" mode (b/c of race condition) we need to have the scopePollingDetectionStrategy to keep running to detect wallets.