### PR TITLE
Add ANS support

### DIFF
--- a/.changeset/six-mails-fold.md
+++ b/.changeset/six-mails-fold.md
@@ -1,0 +1,6 @@
+---
+"@aptos-labs/wallet-adapter-ant-design": major
+"@aptos-labs/wallet-adapter-core": major
+---
+
+Add ANS support

--- a/packages/wallet-adapter-ant-design/src/WalletSelector.tsx
+++ b/packages/wallet-adapter-ant-design/src/WalletSelector.tsx
@@ -25,11 +25,13 @@ export function WalletSelector() {
     connect(wallet);
     setWalletSelectorModalOpen(false);
   };
-
+  const buttonText = account?.ansName
+    ? account?.ansName
+    : truncateAddress(account?.address);
   return (
     <>
       <Button className="wallet-button" onClick={() => onWalletButtonClick()}>
-        {connected ? truncateAddress(account?.address) : "Connect Wallet"}
+        {connected ? buttonText : "Connect Wallet"}
       </Button>
       <Modal
         title={<div className="wallet-modal-title">Connect Wallet</div>}
@@ -46,7 +48,8 @@ export function WalletSelector() {
                 <Menu.Item
                   key={wallet.name}
                   onClick={
-                    wallet.readyState === WalletReadyState.Installed || wallet.readyState === WalletReadyState.Loadable
+                    wallet.readyState === WalletReadyState.Installed ||
+                    wallet.readyState === WalletReadyState.Loadable
                       ? () => onWalletSelected(wallet.name)
                       : () => window.open(wallet.url)
                   }
@@ -62,7 +65,8 @@ export function WalletSelector() {
                         {wallet.name}
                       </Text>
                     </div>
-                    {wallet.readyState === WalletReadyState.Installed || wallet.readyState === WalletReadyState.Loadable ? (
+                    {wallet.readyState === WalletReadyState.Installed ||
+                    wallet.readyState === WalletReadyState.Loadable ? (
                       <Button className="wallet-connect-button">
                         <Text className="wallet-connect-button-text">
                           Connect

--- a/packages/wallet-adapter-core/src/WalletCore.ts
+++ b/packages/wallet-adapter-core/src/WalletCore.ts
@@ -35,6 +35,7 @@ import {
   setLocalStorage,
   scopePollingDetectionStrategy,
 } from "./utils";
+import { getNameByAddress } from "./ans";
 
 export class WalletCore extends EventEmitter<WalletCoreEvents> {
   private _wallets: Wallet[] = [];
@@ -192,6 +193,14 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
       this.setAccount({ ...account });
       const network = await selectedWallet.network();
       this.setNetwork({ ...network });
+      if (this._network?.chainId && this._account) {
+        const name = await getNameByAddress(
+          this._network.chainId,
+          this._account.address
+        );
+        console.log(name);
+        this._account.ansName = name;
+      }
       setLocalStorage(selectedWallet.name);
       this._connected = true;
       this.emit("connect", account);

--- a/packages/wallet-adapter-core/src/__tests__/WalletCore.test.ts
+++ b/packages/wallet-adapter-core/src/__tests__/WalletCore.test.ts
@@ -1,4 +1,5 @@
 import { AptosAccount } from "aptos";
+import { getNameByAddress } from "../ans";
 import {
   SignMessagePayload,
   SignMessageResponse,
@@ -102,5 +103,15 @@ describe("signMessageAndVerify", () => {
       mockSignMessagePayload
     );
     expect(verified).toBeFalsy();
+  });
+});
+
+describe("ans", () => {
+  it("should fetch the correct name", async () => {
+    const name = await getNameByAddress(
+      "2",
+      "0x54fac6e5d52953c75e749a8ad260bc450cad0b8ed2f06c1e98707879e13956d1"
+    );
+    expect(name).toBe("adapter");
   });
 });

--- a/packages/wallet-adapter-core/src/ans.ts
+++ b/packages/wallet-adapter-core/src/ans.ts
@@ -1,35 +1,19 @@
-import { AptosClient } from "aptos";
-
 const ChainIdToAnsContractAddressMap: Record<string, string> = {
-  "1": "0x867ed1f6bf916171b1de3ee92849b8978b7d1b9e0a8cc982a3d19d535dfd9c0c", // mainnet
-  "2": "0x5f8fd2347449685cf41d4db97926ec3a096eaf381332be4f1318ad4d16a8497c", // testnet
-};
-
-type ANSResponse = {
-  name: string;
+  "1": "mainnet", // mainnet
+  "2": "testnet", // testnet
 };
 
 export const getNameByAddress = async (
   chainId: string,
   address: string
 ): Promise<string | null> => {
-  const client = new AptosClient("https://fullnode.testnet.aptoslabs.com/v1");
-
   try {
-    const ansResource = await client.getAccountResource(
-      ChainIdToAnsContractAddressMap[chainId],
-      `${ChainIdToAnsContractAddressMap[chainId]}::domains::ReverseLookupRegistryV1`
+    if (!ChainIdToAnsContractAddressMap[chainId]) return null;
+    const response = await fetch(
+      `https://www.aptosnames.com/api/${ChainIdToAnsContractAddressMap[chainId]}/v1/name/${address}`
     );
-
-    const handle = (ansResource as any).data.registry.handle;
-    const domainsTableItemRequest = {
-      key_type: "address",
-      value_type: `${ChainIdToAnsContractAddressMap[chainId]}::domains::NameRecordKeyV1`,
-      key: address,
-    };
-
-    const item = await client.getTableItem(handle, domainsTableItemRequest);
-    return item.domain_name;
+    const data = await response.json();
+    return data.name;
   } catch (e) {
     console.log("error", e);
     return null;

--- a/packages/wallet-adapter-core/src/ans.ts
+++ b/packages/wallet-adapter-core/src/ans.ts
@@ -1,0 +1,37 @@
+import { AptosClient } from "aptos";
+
+const ChainIdToAnsContractAddressMap: Record<string, string> = {
+  "1": "0x867ed1f6bf916171b1de3ee92849b8978b7d1b9e0a8cc982a3d19d535dfd9c0c", // mainnet
+  "2": "0x5f8fd2347449685cf41d4db97926ec3a096eaf381332be4f1318ad4d16a8497c", // testnet
+};
+
+type ANSResponse = {
+  name: string;
+};
+
+export const getNameByAddress = async (
+  chainId: string,
+  address: string
+): Promise<string | null> => {
+  const client = new AptosClient("https://fullnode.testnet.aptoslabs.com/v1");
+
+  try {
+    const ansResource = await client.getAccountResource(
+      ChainIdToAnsContractAddressMap[chainId],
+      `${ChainIdToAnsContractAddressMap[chainId]}::domains::ReverseLookupRegistryV1`
+    );
+
+    const handle = (ansResource as any).data.registry.handle;
+    const domainsTableItemRequest = {
+      key_type: "address",
+      value_type: `${ChainIdToAnsContractAddressMap[chainId]}::domains::NameRecordKeyV1`,
+      key: address,
+    };
+
+    const item = await client.getTableItem(handle, domainsTableItemRequest);
+    return item.domain_name;
+  } catch (e) {
+    console.log("error", e);
+    return null;
+  }
+};

--- a/packages/wallet-adapter-core/src/types.ts
+++ b/packages/wallet-adapter-core/src/types.ts
@@ -14,7 +14,8 @@ export type NetworkInfo = {
 export type AccountInfo = {
   address: string;
   publicKey: string | string[];
-  minKeysRequired?: number
+  minKeysRequired?: number;
+  ansName?: string | null;
 };
 
 export interface AptosWalletErrorResult {
@@ -50,7 +51,7 @@ export interface AdapterPluginProps<Name extends string = string> {
   name: WalletName<Name>;
   url: string;
   icon: `data:image/${"svg+xml" | "webp" | "png" | "gif"};base64,${string}`;
-  providerName?: string
+  providerName?: string;
   provider: any;
   connect(): Promise<any>;
   disconnect: () => Promise<any>;


### PR DESCRIPTION
This PR adds support for ANS names. 
When a user connects a wallet, the adapter fetches the account ANS name by the account address and the current network - ANS supports testnet and mainnet only.
If a name exists for the current account - it would be available for dapps as part of the `AccountInfo` type as `ansName` prop.
If a name is not available - `ansName` prop on `AccountInfo` type would be `null`.


https://user-images.githubusercontent.com/29798064/217095312-9d18fdc4-efcb-4bbd-af99-b57dd692716b.mov
