### PR TITLE
Fix Loadable wallet connection for mui-design

### DIFF
--- a/.changeset/eight-radios-worry.md
+++ b/.changeset/eight-radios-worry.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/wallet-adapter-mui-design": patch
+---
+
+Fix Loadable wallet connection for mui design

--- a/apps/nextjs-example/next.config.js
+++ b/apps/nextjs-example/next.config.js
@@ -8,4 +8,8 @@ module.exports = {
   experimental: {
     transpilePackages: ["wallet-adapter-react", "wallet-adapter-plugin"],
   },
+  webpack: (config) => {
+    config.resolve.fallback = { "@solana/web3.js": false };
+    return config;
+  },
 };

--- a/packages/wallet-adapter-mui-design/src/WalletModel.tsx
+++ b/packages/wallet-adapter-mui-design/src/WalletModel.tsx
@@ -44,7 +44,7 @@ export default function WalletsModal({
       const icon = option.icon;
       return (
         <Grid key={option.name} xs={12} paddingY={0.5} item>
-          {wallet.readyState === "Installed" ? (
+          {wallet.readyState === "Installed" || wallet.readyState === "Loadable" ? (
             <ListItem disablePadding>
               <ListItemButton
                 alignItems="center"


### PR DESCRIPTION
- Fix Loadable wallet connection for mui-design
- Suppress optional dependency warnings for next.js project:

The warning is:
```
@aptos-labs/wallet-adapter-nextjs-example:dev: warn  - ../../node_modules/.pnpm/@blocto+sdk@0.3.5_aptos@1.4.0/node_modules/@blocto/sdk/dist/blocto-sdk.umd.js
@aptos-labs/wallet-adapter-nextjs-example:dev: Module not found: Can't resolve '@solana/web3.js' in '/Users/scott/Documents/portto/aptos/aptos-labs-aptos-wallet-adapter/node_modules/.pnpm/@blocto+sdk@0.3.5_aptos@1.4.0/node_modules/@blocto/sdk/dist'
```

Reference: https://github.com/vercel/next.js/discussions/11511#discussioncomment-4848409