### PR TITLE
update core package version manually

### DIFF
--- a/packages/wallet-adapter-core/package.json
+++ b/packages/wallet-adapter-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aptos-labs/wallet-adapter-core",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Aptos Wallet Adapter Core",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
changesets action failed to update core package version so updating it manually
https://github.com/aptos-labs/aptos-wallet-adapter/actions/runs/4179100920