### PR TITLE
Add isLoading state when wallet tries to connect

### DIFF
--- a/packages/wallet-adapter-react/src/WalletProvider.tsx
+++ b/packages/wallet-adapter-react/src/WalletProvider.tsx
@@ -45,14 +45,19 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
   const [{ connected, account, network, wallet }, setState] =
     useState(initialState);
 
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+
   const walletCore = useMemo(() => new WalletCore(plugins), []);
   const [wallets, setWallets] = useState<Wallet[]>(walletCore.wallets);
 
   const connect = (walletName: WalletName) => {
     try {
+      setIsLoading(true);
       walletCore.connect(walletName);
     } catch (e) {
       console.log("connect error", e);
+    } finally {
+      setIsLoading(false);
     }
   };
 
@@ -209,6 +214,7 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
         signTransaction,
         signMessage,
         signMessageAndVerify,
+        isLoading,
       }}
     >
       {children}

--- a/packages/wallet-adapter-react/src/useWallet.tsx
+++ b/packages/wallet-adapter-react/src/useWallet.tsx
@@ -7,7 +7,7 @@ import {
   SignMessageResponse,
   Wallet,
   WalletReadyState,
-  NetworkName
+  NetworkName,
 } from "@aptos-labs/wallet-adapter-core";
 import { createContext, useContext } from "react";
 import { Types } from "aptos";
@@ -17,6 +17,7 @@ export { WalletReadyState, NetworkName };
 
 export interface WalletContextState {
   connected: boolean;
+  isLoading: boolean;
   account: AccountInfo | null;
   network: NetworkInfo | null;
   connect(walletName: WalletName): void;


### PR DESCRIPTION
Following https://github.com/aptos-labs/aptos-wallet-adapter/issues/94 it can take a Wallet a couple of ms to connect, during that time we might want to handle the UI accordingly.

This PR adds `isLoading` state to react provider.
can use it like that
```
const { isLoading } = useWallet();
```