### PR TITLE
Add onError prop to react provider and expose fetch ANS name method

### DIFF
--- a/.changeset/healthy-tips-poke.md
+++ b/.changeset/healthy-tips-poke.md
@@ -1,0 +1,10 @@
+---
+"@aptos-labs/wallet-adapter-core": major
+"@aptos-labs/wallet-adapter-react": major
+"@aptos-labs/wallet-adapter-nextjs-example": minor
+---
+
+- Add isLoading state to react provider when wallet tries to connect
+- Add onError prop to react provider to catch and display adapter errors
+- Expose fetch ANS name method
+- Separate ANS name fetch request and connect wallet action to make it undepandable

--- a/.changeset/healthy-tips-poke.md
+++ b/.changeset/healthy-tips-poke.md
@@ -4,7 +4,7 @@
 "@aptos-labs/wallet-adapter-nextjs-example": minor
 ---
 
-- Add isLoading state to react provider when wallet tries to connect
+- Add isLoading state to react provider when wallet tries to connect https://github.com/aptos-labs/aptos-wallet-adapter/pull/99
 - Add onError prop to react provider to catch and display adapter errors
 - Expose fetch ANS name method
 - Separate ANS name fetch request and connect wallet action to make it undepandable

--- a/apps/nextjs-example/components/AppContext.tsx
+++ b/apps/nextjs-example/components/AppContext.tsx
@@ -11,7 +11,7 @@ import { FewchaWallet } from "fewcha-plugin-wallet-adapter";
 import { MSafeWalletAdapter } from "msafe-plugin-wallet-adapter";
 import { BloctoWallet } from "@blocto/aptos-wallet-adapter-plugin";
 import { WelldoneWallet } from "@welldone-studio/aptos-wallet-adapter";
-import { NightlyWallet } from '@nightlylabs/aptos-wallet-adapter-plugin'
+import { NightlyWallet } from "@nightlylabs/aptos-wallet-adapter-plugin";
 import { TokenPocketWallet } from "@tp-lab/aptos-wallet-adapter";
 
 import {
@@ -42,7 +42,16 @@ const WalletContextProvider: FC<{ children: ReactNode }> = ({ children }) => {
   ];
 
   return (
-    <AptosWalletAdapterProvider plugins={wallets} autoConnect={autoConnect}>
+    <AptosWalletAdapterProvider
+      plugins={wallets}
+      autoConnect={autoConnect}
+      onError={(e) => {
+        // shows the error message coming from the adapter
+        alert(e.message);
+        // stack trace for the error
+        console.log(e);
+      }}
+    >
       {children}
     </AptosWalletAdapterProvider>
   );

--- a/packages/wallet-adapter-core/src/WalletCore.ts
+++ b/packages/wallet-adapter-core/src/WalletCore.ts
@@ -206,6 +206,11 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
     }
   }
 
+  /** 
+  Fetches AND name for the current connected account based on the current connected network,
+  and sets the account.ansName if the account has a ANS name.
+  @throws FetchAnsNameError
+  */
   async setAnsName(): Promise<void> {
     if (this._network?.chainId && this._account) {
       try {

--- a/packages/wallet-adapter-core/src/ans.ts
+++ b/packages/wallet-adapter-core/src/ans.ts
@@ -7,15 +7,11 @@ export const getNameByAddress = async (
   chainId: string,
   address: string
 ): Promise<string | null> => {
-  try {
-    if (!ChainIdToAnsContractAddressMap[chainId]) return null;
-    const response = await fetch(
-      `https://www.aptosnames.com/api/${ChainIdToAnsContractAddressMap[chainId]}/v1/name/${address}`
-    );
-    const data = await response.json();
-    return data.name;
-  } catch (e) {
-    console.log("error", e);
-    return null;
-  }
+  if (!ChainIdToAnsContractAddressMap[chainId]) return null;
+  // TODO use /primary-name endpoint
+  const response = await fetch(
+    `https://www.aptosnames.com/api/${ChainIdToAnsContractAddressMap[chainId]}/v1/name/${address}`
+  );
+  const data = await response.json();
+  return data?.name;
 };

--- a/packages/wallet-adapter-core/src/error/index.ts
+++ b/packages/wallet-adapter-core/src/error/index.ts
@@ -102,3 +102,7 @@ export class WalletResponseError extends WalletError {
 export class WalletNotSupportedMethod extends WalletError {
   name = "WalletNotSupportedMethod";
 }
+
+export class FetchAnsNameError extends WalletError {
+  name = "FetchAnsNameError";
+}

--- a/packages/wallet-adapter-core/src/index.ts
+++ b/packages/wallet-adapter-core/src/index.ts
@@ -1,3 +1,4 @@
 export { WalletCore } from "./WalletCore";
 export * from "./types";
 export * from "./constants";
+export { WalletError } from "./error";

--- a/packages/wallet-adapter-react/src/useWallet.tsx
+++ b/packages/wallet-adapter-react/src/useWallet.tsx
@@ -32,8 +32,13 @@ export interface WalletContextState {
     transaction: T,
     options?: V
   ): Promise<any>;
-  signMessage(message: SignMessagePayload): Promise<SignMessageResponse | null>;
-  signMessageAndVerify(message: SignMessagePayload): Promise<boolean>;
+  signMessage(
+    message: SignMessagePayload
+  ): Promise<SignMessageResponse | null | undefined>;
+  signMessageAndVerify(
+    message: SignMessagePayload
+  ): Promise<boolean | undefined>;
+  fetchANSname(): Promise<void>;
 }
 
 const DEFAULT_COUNTEXT = {


### PR DESCRIPTION
- Add onError prop to react provider to catch and display adapter errors
- Expose fetch ANS name method
- Separate ANS name fetch request and connect wallet action to make it undepandable