### PR TITLE
add getting started title on main readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A monorepo modular wallet adapter developed and maintained by Aptos for wallet and dapp builders that includes:
 
+#### Getting Started
+
 - [Example app](https://github.com/aptos-labs/aptos-wallet-adapter/tree/main/apps/nextjs-example)
 - [For Aptos Dapps](https://github.com/aptos-labs/aptos-wallet-adapter/tree/main/packages/wallet-adapter-react)
 - [For Aptos Wallets](https://github.com/aptos-labs/wallet-adapter-plugin-template)


### PR DESCRIPTION
https://github.com/aptos-labs/aptos-wallet-adapter/issues/93 asks to add installation tips. 
@hariria and I talked off-line and agreed on adding a "Getting Started" title to the main readme to make it easier to locate instructions.