### PR TITLE
chore: pump openblock plugin version to latest for demo

### DIFF
--- a/apps/nextjs-example/package.json
+++ b/apps/nextjs-example/package.json
@@ -14,7 +14,7 @@
     "@aptos-labs/wallet-adapter-ant-design": "workspace:*",
     "@aptos-labs/wallet-adapter-mui-design": "workspace:*",
     "@aptos-labs/wallet-adapter-react": "workspace:*",
-    "@openblockhq/aptos-wallet-adapter": "^0.1.3",
+    "@openblockhq/aptos-wallet-adapter": "^0.1.5",
     "@blocto/aptos-wallet-adapter-plugin": "^0.1.2",
     "@martianwallet/aptos-wallet-adapter": "^0.0.3",
     "@nightlylabs/aptos-wallet-adapter-plugin": "0.2.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,7 +26,7 @@ importers:
       '@blocto/aptos-wallet-adapter-plugin': ^0.1.2
       '@martianwallet/aptos-wallet-adapter': ^0.0.3
       '@nightlylabs/aptos-wallet-adapter-plugin': 0.2.12
-      '@openblockhq/aptos-wallet-adapter': ^0.1.3
+      '@openblockhq/aptos-wallet-adapter': ^0.1.5
       '@pontem/wallet-adapter-plugin': ^0.1.4
       '@rise-wallet/wallet-adapter': ^0.1.2
       '@tp-lab/aptos-wallet-adapter': ^1.0.1
@@ -55,7 +55,7 @@ importers:
       '@blocto/aptos-wallet-adapter-plugin': 0.1.2
       '@martianwallet/aptos-wallet-adapter': 0.0.3
       '@nightlylabs/aptos-wallet-adapter-plugin': 0.2.12
-      '@openblockhq/aptos-wallet-adapter': 0.1.3
+      '@openblockhq/aptos-wallet-adapter': 0.1.5
       '@pontem/wallet-adapter-plugin': 0.1.4
       '@rise-wallet/wallet-adapter': 0.1.2
       '@tp-lab/aptos-wallet-adapter': 1.0.1
@@ -2124,12 +2124,13 @@ packages:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.13.0
 
-  /@openblockhq/aptos-wallet-adapter/0.1.3:
-    resolution: {integrity: sha512-xLuwdGPyvfTytHFzpu4kau53VcXbQZ1Ks4ojTGFG8mG4KH/KQzV77LK1vuQvISzm55TFD+JHNV6LIRvBAbG2fA==}
+  /@openblockhq/aptos-wallet-adapter/0.1.5:
+    resolution: {integrity: sha512-+iMKuEk2L7tLVGsySI8ve8JM650A7Q0gFAXs173PZlYKxxR0ZlbmNcHCMqGRsz8dd+nV+XoMkNSyrqleEGGPEA==}
     dependencies:
       '@aptos-labs/wallet-adapter-core': 0.2.3
       '@openblockhq/dappsdk': 5.0.7
       aptos: 1.4.0
+      regenerator-runtime: 0.13.11
     transitivePeerDependencies:
       - bufferutil
       - debug


### PR DESCRIPTION
## changes
- pump `@openblockhq/aptos-wallet-adapter` version to latest in order to fix that `regeneratorRuntime` issue which can break wallet from initializing normally.

https://github.com/aptos-labs/aptos-wallet-adapter/pull/100#issuecomment-1459939867