### PR TITLE
 Define core package version to use

### DIFF
--- a/.changeset/cuddly-pigs-return.md
+++ b/.changeset/cuddly-pigs-return.md
@@ -1,0 +1,7 @@
+---
+"@aptos-labs/wallet-adapter-ant-design": patch
+"@aptos-labs/wallet-adapter-mui-design": patch
+"@aptos-labs/wallet-adapter-react": patch
+---
+
+Define core package version to use

--- a/packages/wallet-adapter-ant-design/package.json
+++ b/packages/wallet-adapter-ant-design/package.json
@@ -49,7 +49,7 @@
     "typescript": "^4.5.3"
   },
   "dependencies": {
-    "@aptos-labs/wallet-adapter-react": "*",
+    "@aptos-labs/wallet-adapter-react": "1.0.2",
     "antd": "^5.1.2",
     "aptos": "^1.3.17",
     "react": "^18",

--- a/packages/wallet-adapter-mui-design/package.json
+++ b/packages/wallet-adapter-mui-design/package.json
@@ -43,7 +43,7 @@
     "typescript": "^4.5.3"
   },
   "dependencies": {
-    "@aptos-labs/wallet-adapter-react": "*",
+    "@aptos-labs/wallet-adapter-react": "1.0.2",
     "@babel/core": "^7.0.0",
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",

--- a/packages/wallet-adapter-react/package.json
+++ b/packages/wallet-adapter-react/package.json
@@ -43,7 +43,7 @@
     "tsup": "^5.10.1"
   },
   "dependencies": {
-    "@aptos-labs/wallet-adapter-core": "*",
+    "@aptos-labs/wallet-adapter-core": "2.0.1",
     "aptos": "^1.3.17",
     "react": "^18"
   }


### PR DESCRIPTION
To prevent breaking changes because of chain of dependencies, we have the packages used by dapp to use a defined core package version so when we release a new core package version, we wont break dapps out there.