### PR TITLE
Add Support to submit bcs serialized transactions

### DIFF
--- a/.changeset/good-ravens-build.md
+++ b/.changeset/good-ravens-build.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/wallet-adapter-core": minor
+---
+
+Support to submit bcs serialized transactions

--- a/packages/wallet-adapter-core/src/WalletCore.ts
+++ b/packages/wallet-adapter-core/src/WalletCore.ts
@@ -233,8 +233,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
   }
 
   /** 
-  Sign and submit transaction to chain.
-  This function supports submitting a non-bcs serialized transaction
+  Sign and submit an entry (not bcs serialized) transaction type to chain.
   @param transaction a non-bcs serialized transaction
   @return response from the wallet's signAndSubmitTransaction function
   @throws WalletSignAndSubmitMessageError
@@ -256,7 +255,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
   }
 
   /** 
-  Sign and submit a bcs serialized transaction to chain.
+  Sign and submit a bsc serialized transaction type to chain.
   @param transaction a bcs serialized transaction
   @return response from the wallet's signAndSubmitBCSTransaction function
   @throws WalletSignAndSubmitMessageError

--- a/packages/wallet-adapter-core/src/WalletCore.ts
+++ b/packages/wallet-adapter-core/src/WalletCore.ts
@@ -1,4 +1,4 @@
-import { HexString, Types } from "aptos";
+import { HexString, TxnBuilderTypes, Types } from "aptos";
 import EventEmitter from "eventemitter3";
 import nacl from "tweetnacl";
 import { Buffer } from "buffer";
@@ -29,7 +29,6 @@ import {
   Wallet,
   WalletInfo,
   WalletCoreEvents,
-  TransactionPayload,
 } from "./types";
 import {
   removeLocalStorage,
@@ -257,22 +256,23 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
   }
 
   /** 
-  Sign and submit transaction to chain.
-  This function supports submitting a bcs serialized transaction and non-bcs serialized transaction
+  Sign and submit a bcs serialized transaction to chain.
   @param transaction a bcs serialized transaction or non-bcs serialized transaction
   @return response from the wallet's submitTransaction function
   @throws WalletSignAndSubmitMessageError
   */
-  async submitTransaction(transaction: TransactionPayload): Promise<any> {
-    if (this._wallet && !("submitTransaction" in this._wallet)) {
+  async signAndSubmitBCSTransaction(
+    transaction: TxnBuilderTypes.TransactionPayload
+  ): Promise<any> {
+    if (this._wallet && !("signAndSubmitBCSTransaction" in this._wallet)) {
       throw new WalletNotSupportedMethod(
-        `Submit Transaction is not supported by ${this.wallet?.name}`
+        `Submit a BCS Transaction is not supported by ${this.wallet?.name}`
       ).message;
     }
 
     try {
       this.doesWalletExist();
-      const response = await (this._wallet as any).submitTransaction(
+      const response = await (this._wallet as any).signAndSubmitBCSTransaction(
         transaction
       );
       return response;

--- a/packages/wallet-adapter-core/src/WalletCore.ts
+++ b/packages/wallet-adapter-core/src/WalletCore.ts
@@ -257,8 +257,8 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
 
   /** 
   Sign and submit a bcs serialized transaction to chain.
-  @param transaction a bcs serialized transaction or non-bcs serialized transaction
-  @return response from the wallet's submitTransaction function
+  @param transaction a bcs serialized transaction
+  @return response from the wallet's signAndSubmitBCSTransaction function
   @throws WalletSignAndSubmitMessageError
   */
   async signAndSubmitBCSTransaction(

--- a/packages/wallet-adapter-core/src/types.ts
+++ b/packages/wallet-adapter-core/src/types.ts
@@ -1,4 +1,4 @@
-import { Types } from "aptos";
+import { TxnBuilderTypes, Types } from "aptos";
 import { NetworkName, WalletReadyState } from "./constants";
 
 // WalletName is a nominal type that wallet adapters should use, e.g. `'MyCryptoWallet' as WalletName<'MyCryptoWallet'>`
@@ -24,6 +24,9 @@ export interface AptosWalletErrorResult {
   message: string;
 }
 
+export type TransactionPayload =
+  | Types.TransactionPayload
+  | TxnBuilderTypes.TransactionPayload;
 export interface PluginProvider {
   connect: () => Promise<AccountInfo>;
   account: () => Promise<AccountInfo>;

--- a/packages/wallet-adapter-core/src/types.ts
+++ b/packages/wallet-adapter-core/src/types.ts
@@ -1,4 +1,4 @@
-import { TxnBuilderTypes, Types } from "aptos";
+import { Types } from "aptos";
 import { NetworkName, WalletReadyState } from "./constants";
 
 // WalletName is a nominal type that wallet adapters should use, e.g. `'MyCryptoWallet' as WalletName<'MyCryptoWallet'>`
@@ -24,9 +24,6 @@ export interface AptosWalletErrorResult {
   message: string;
 }
 
-export type TransactionPayload =
-  | Types.TransactionPayload
-  | TxnBuilderTypes.TransactionPayload;
 export interface PluginProvider {
   connect: () => Promise<AccountInfo>;
   account: () => Promise<AccountInfo>;


### PR DESCRIPTION
This PR adds a new `signAndSubmitBCSTransaction` method to the `wallet-adapter-core` package. This function is not enforced in the wallet plugin interface and therefore will not cause any breaking changes.

**For wallets**
Migration plan for wallets would be to support this new function in their plugin code. 

**For dapps**
Next step would be to support the new `signAndSubmitBCSTransaction` in the `wallet-adapter-react` package.