### PR TITLE
[fix] Fix wallet adapter auto reconnect

### DIFF
--- a/.changeset/tender-poets-taste.md
+++ b/.changeset/tender-poets-taste.md
@@ -1,0 +1,6 @@
+---
+"@aptos-labs/wallet-adapter-core": patch
+"@aptos-labs/wallet-adapter-react": patch
+---
+
+Fix wallet adapter auto reconnect on page refresh

--- a/packages/wallet-adapter-core/src/WalletCore.ts
+++ b/packages/wallet-adapter-core/src/WalletCore.ts
@@ -195,6 +195,9 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
       }
 
       if (this._connected) {
+        // if the selected wallet is already connected, we don't need to connect again
+        if (this.wallet?.name === walletName) return;
+
         await this.disconnect();
       }
       this._connecting = true;

--- a/packages/wallet-adapter-react/src/WalletProvider.tsx
+++ b/packages/wallet-adapter-react/src/WalletProvider.tsx
@@ -109,14 +109,14 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
         connect(localStorage.getItem("AptosWalletName") as WalletName);
       }
     }
-  }, [wallets]);
+  }, wallets);
 
   useEffect(() => {
     if (connected) {
       walletCore.onAccountChange();
       walletCore.onNetworkChange();
     }
-  }, [wallets, connected]);
+  }, [...wallets, connected]);
 
   // Handle the adapter's connect event
   const handleConnect = () => {
@@ -169,20 +169,11 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
     });
   }, [connected]);
 
-  // Handle the adapter's ready state change event
+  // Whenever the readyState of any supported wallet changes we produce a new wallets state array
+  // which in turn causes consumers of the `useWallet` hook to re-render.
+  // See https://github.com/aptos-labs/aptos-wallet-adapter/pull/129#issuecomment-1519026572 for reasoning.
   const handleReadyStateChange = (wallet: Wallet) => {
-    setWallets((prevWallets) => {
-      const index = prevWallets.findIndex(
-        (currWallet) => currWallet === wallet
-      );
-      if (index === -1) return prevWallets;
-
-      return [
-        ...prevWallets.slice(0, index),
-        wallet,
-        ...prevWallets.slice(index + 1),
-      ];
-    });
+    setWallets((wallets) => [...wallets]);
   };
 
   useEffect(() => {
@@ -198,7 +189,7 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
       walletCore.off("networkChange", handleNetworkChange);
       walletCore.off("readyStateChange", handleReadyStateChange);
     };
-  }, [wallets, connected]);
+  }, [...wallets, connected]);
 
   return (
     <WalletContext.Provider


### PR DESCRIPTION
This PR fixes the wallet adapter losing its connection on page reload and repeatedly asking the user to reconfirm the connection on both explorer and ANS.

In particular this fixes GP-221 (and partially WAL-341) and makes the workaround introduced in https://github.com/aptos-labs/explorer/pull/476 obsolete. See also https://aptos-org.slack.com/archives/C04EXV6UTR7/p1681963789169939?thread_ts=1681962123.674429&cid=C04EXV6UTR7 .

Previously upon page reload a sequence of events triggered a disconnect:
1. The dApp successfully connected to the wallet via autoconnect (which simply calls `connect(<walletName>` )
2. A readyStateChange event from WalletCore triggered a state change in the `wallets` component state by calling `setWallets` here https://github.com/aptos-labs/aptos-wallet-adapter/pull/129/files#diff-976f6ce28f5861155298dbb0cfae197c7ba5f62c12fb8d6c51f603841b8bbcfdR173-R186 , even though none of the items actually changed (but a new array identity had been constructed).
3. This in turn triggered a 2nd auto-reconnect effect under https://github.com/aptos-labs/aptos-wallet-adapter/pull/129/files#diff-976f6ce28f5861155298dbb0cfae197c7ba5f62c12fb8d6c51f603841b8bbcfdR106-R112  which called `connect(<walletName>)` again.
4. The 2nd `connect(<walletName>`)` disconnected the wallet https://github.com/aptos-labs/aptos-wallet-adapter/pull/129/files#diff-8a76cc616d7961765eb7ff494b4e86bc0e56cce6d0273caaa57af714ac95757eR201 and asked the user to reconfirm the connection in a new connection prompt.

This PR fixes 2 things:
1. Double triggering the auto reconnection effect is avoided by using the items in the `wallet` component state as trigger dependency instead of the array identity. So unless actually any of the items or their order changed this won't trigger a reconnect.
2. When `connect(<walletName>)` is called with the same wallet name that is already connected we simply return early from this function and do nothing.