### PR TITLE
BCS transaction support in react provider package

### DIFF
--- a/.changeset/sixty-waves-scream.md
+++ b/.changeset/sixty-waves-scream.md
@@ -1,0 +1,6 @@
+---
+"@aptos-labs/wallet-adapter-nextjs-example": patch
+"@aptos-labs/wallet-adapter-react": patch
+---
+
+BCS transaction support in react provider package

--- a/packages/wallet-adapter-react/src/WalletProvider.tsx
+++ b/packages/wallet-adapter-react/src/WalletProvider.tsx
@@ -17,7 +17,7 @@ import type {
 } from "@aptos-labs/wallet-adapter-core";
 import { WalletCore } from "@aptos-labs/wallet-adapter-core";
 
-import { Types } from "aptos";
+import { TxnBuilderTypes, Types } from "aptos";
 
 export interface AptosWalletProviderProps {
   children: ReactNode;
@@ -74,6 +74,16 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
   ) => {
     try {
       return await walletCore.signAndSubmitTransaction(transaction);
+    } catch (error: any) {
+      throw error;
+    }
+  };
+
+  const signAndSubmitBCSTransaction = async (
+    transaction: TxnBuilderTypes.TransactionPayload
+  ) => {
+    try {
+      return await walletCore.signAndSubmitBCSTransaction(transaction);
     } catch (error: any) {
       throw error;
     }
@@ -202,6 +212,7 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
         wallet,
         wallets,
         signAndSubmitTransaction,
+        signAndSubmitBCSTransaction,
         signTransaction,
         signMessage,
         signMessageAndVerify,

--- a/packages/wallet-adapter-react/src/useWallet.tsx
+++ b/packages/wallet-adapter-react/src/useWallet.tsx
@@ -10,7 +10,7 @@ import {
   NetworkName,
 } from "@aptos-labs/wallet-adapter-core";
 import { createContext, useContext } from "react";
-import { Types } from "aptos";
+import { TxnBuilderTypes, Types } from "aptos";
 
 export type { WalletName };
 export { WalletReadyState, NetworkName };
@@ -25,6 +25,10 @@ export interface WalletContextState {
   wallet: WalletInfo | null;
   wallets: Wallet[];
   signAndSubmitTransaction<T extends Types.TransactionPayload, V>(
+    transaction: T,
+    options?: V
+  ): Promise<any>;
+  signAndSubmitBCSTransaction<T extends TxnBuilderTypes.TransactionPayload, V>(
     transaction: T,
     options?: V
   ): Promise<any>;


### PR DESCRIPTION
following https://github.com/aptos-labs/aptos-wallet-adapter/pull/124 where we added support to bcs transaction, this PR adds support to the new `signAndSubmitBCSTransaction` in the `wallet-adapter-react` package and shows an example on how to use it in the demo app.