### PR TITLE
Support deeplink on React Provider and Nextjs demo app

### DIFF
--- a/.changeset/violet-pears-lie.md
+++ b/.changeset/violet-pears-lie.md
@@ -1,0 +1,6 @@
+---
+"@aptos-labs/wallet-adapter-nextjs-example": minor
+"@aptos-labs/wallet-adapter-react": minor
+---
+
+Support deeplink on React Provider and Nextjs demo app

--- a/apps/nextjs-example/components/WalletButtons.tsx
+++ b/apps/nextjs-example/components/WalletButtons.tsx
@@ -1,22 +1,54 @@
-import { useWallet, WalletReadyState } from "@aptos-labs/wallet-adapter-react";
+import {
+  useWallet,
+  WalletReadyState,
+  Wallet,
+  isRedirectable,
+} from "@aptos-labs/wallet-adapter-react";
 
 const WalletButtons = () => {
   const { wallets, connect } = useWallet();
 
   return (
     <>
-      {wallets.map((wallet) => {
-        const isWalletReady = wallet.readyState === WalletReadyState.Installed || wallet.readyState === WalletReadyState.Loadable
-        return (
+      {wallets.map((wallet: Wallet) => {
+        const isWalletReady =
+          wallet.readyState === WalletReadyState.Installed ||
+          wallet.readyState === WalletReadyState.Loadable;
+        /**
+         * If we are on a mobile browser, adapter checks whether a wallet has a `deeplinkProvider` property
+         * a. If it does, on connect it should redirect the user to the app by using the wallet's depplink url
+         * b. If it does not, up to the dapp to choose on the UI, but can simply disable the button
+         * c. If we are already in a in-app browser, we dont want to redirect anywhere, so connect should work as expected in the mobile app.
+         *
+         * !isWalletReady - ignore installed/sdk wallets that dont rely on window injection
+         * isRedirectable() - are we on mobile AND not in an in-app browser
+         * !wallet.deeplinkProvider - does wallet have deeplinkProvider property? i.e does it support a mobile app
+         */
+        return !isWalletReady &&
+          isRedirectable() &&
+          !wallet.deeplinkProvider ? (
           <button
-            className={`bg-blue-500  text-white font-bold py-2 px-4 rounded mr-4 ${isWalletReady ? "hover:bg-blue-700" : "opacity-50 cursor-not-allowed"}`}
+            className={`bg-blue-500 text-white font-bold py-2 px-4 rounded mr-4 opacity-50 cursor-not-allowed`}
+            disabled={true}
+            key={wallet.name}
+          >
+            <>{wallet.name} - Desktop Only</>
+          </button>
+        ) : (
+          // If we are on a desktop view, wallet connect should work as it is now for any wallet type (extension,sdk,etc)
+          <button
+            className={`bg-blue-500  text-white font-bold py-2 px-4 rounded mr-4 ${
+              isWalletReady
+                ? "hover:bg-blue-700"
+                : "opacity-50 cursor-not-allowed"
+            }`}
             disabled={!isWalletReady}
             key={wallet.name}
             onClick={() => connect(wallet.name)}
           >
             <>{wallet.name}</>
           </button>
-        )
+        );
       })}
     </>
   );

--- a/packages/wallet-adapter-react/src/index.tsx
+++ b/packages/wallet-adapter-react/src/index.tsx
@@ -1,4 +1,11 @@
 import * as React from "react";
-export { useWallet, WalletReadyState, NetworkName } from "./useWallet";
-export type { WalletName } from "./useWallet";
+export {
+  useWallet,
+  WalletReadyState,
+  NetworkName,
+  isInAppBrowser,
+  isMobile,
+  isRedirectable,
+} from "./useWallet";
+export type { WalletName, Wallet } from "./useWallet";
 export * from "./WalletProvider";

--- a/packages/wallet-adapter-react/src/useWallet.tsx
+++ b/packages/wallet-adapter-react/src/useWallet.tsx
@@ -8,12 +8,21 @@ import {
   Wallet,
   WalletReadyState,
   NetworkName,
+  isInAppBrowser,
+  isRedirectable,
+  isMobile,
 } from "@aptos-labs/wallet-adapter-core";
 import { createContext, useContext } from "react";
 import { TxnBuilderTypes, Types } from "aptos";
 
-export type { WalletName };
-export { WalletReadyState, NetworkName };
+export type { WalletName, Wallet };
+export {
+  WalletReadyState,
+  NetworkName,
+  isInAppBrowser,
+  isRedirectable,
+  isMobile,
+};
 
 export interface WalletContextState {
   connected: boolean;


### PR DESCRIPTION
adapter core supports deeplink https://github.com/aptos-labs/aptos-wallet-adapter/pull/135 
this PR adds support for the React provider and shows how to use it on the demo app so dapps can use it.