### PR TITLE
improvement: allow WalletCore and WalletProvider (AptosWalletAdapterProvider) to receive read-only array of wallets

### DIFF
--- a/.changeset/wild-peas-own.md
+++ b/.changeset/wild-peas-own.md
@@ -1,0 +1,6 @@
+---
+"@aptos-labs/wallet-adapter-core": minor
+"@aptos-labs/wallet-adapter-react": minor
+---
+
+Support ReadonlyArray of Wallets in AptosWalletAdapterProvider and WalletCore

--- a/packages/wallet-adapter-core/src/WalletCore.ts
+++ b/packages/wallet-adapter-core/src/WalletCore.ts
@@ -39,7 +39,7 @@ import {
 import { getNameByAddress } from "./ans";
 
 export class WalletCore extends EventEmitter<WalletCoreEvents> {
-  private _wallets: Wallet[] = [];
+  private _wallets: ReadonlyArray<Wallet> = [];
   private _wallet: Wallet | null = null;
   private _account: AccountInfo | null = null;
   private _network: NetworkInfo | null = null;
@@ -47,7 +47,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
   private _connecting: boolean = false;
   private _connected: boolean = false;
 
-  constructor(plugins: Wallet[]) {
+  constructor(plugins: ReadonlyArray<Wallet>) {
     super();
     this._wallets = plugins;
     this.scopePollingDetectionStrategy();
@@ -123,7 +123,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
     return this._connected;
   }
 
-  get wallets(): Wallet[] {
+  get wallets(): ReadonlyArray<Wallet> {
     return this._wallets;
   }
 

--- a/packages/wallet-adapter-react/src/WalletProvider.tsx
+++ b/packages/wallet-adapter-react/src/WalletProvider.tsx
@@ -21,7 +21,7 @@ import { TxnBuilderTypes, Types } from "aptos";
 
 export interface AptosWalletProviderProps {
   children: ReactNode;
-  plugins: Wallet[];
+  plugins: ReadonlyArray<Wallet>;
   autoConnect?: boolean;
 }
 
@@ -48,7 +48,7 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
   const [isLoading, setIsLoading] = useState<boolean>(true);
 
   const walletCore = useMemo(() => new WalletCore(plugins), []);
-  const [wallets, setWallets] = useState<Wallet[]>(walletCore.wallets);
+  const [wallets, setWallets] = useState<ReadonlyArray<Wallet>>(walletCore.wallets);
 
   const connect = (walletName: WalletName) => {
     try {

--- a/packages/wallet-adapter-react/src/useWallet.tsx
+++ b/packages/wallet-adapter-react/src/useWallet.tsx
@@ -32,7 +32,7 @@ export interface WalletContextState {
   connect(walletName: WalletName): void;
   disconnect(): void;
   wallet: WalletInfo | null;
-  wallets: Wallet[];
+  wallets: ReadonlyArray<Wallet>;
   signAndSubmitTransaction<T extends Types.TransactionPayload, V>(
     transaction: T,
     options?: V


### PR DESCRIPTION
When an interface receives a non readonly array it tells the user of the interface that this array is intended to be modified which is not the case for `WalletCore`, `WalletProvider` and `useWallet`.

This PR changes `WalletCore` constructor, `useWallet` return and `AptosWalletAdapterProviderProps` types. This is mostly backward compatible change because non read-only `Array` type can be used when `ReadonlyArray` is required but `get wallets(): ReadonlyArray<Wallet>` change is not backward compatible if WalletCore use returned type to modify wallet array. So this might be considered as a major/breaking change because external users of the package will be affected if so maybe we need to bump a major version for `WalletCore`.