### PR TITLE
run `build` action only on pull request

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,12 +1,9 @@
 name: Build
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
 
-concurrency: 
+concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 


### PR DESCRIPTION
we have `build` and `release` actions running whenever we merge PRs to `main` branch, we should run the `build` action only when there is a new PR and the `release` action when we merge a PR to `main`.