### PR TITLE
Add mobile view support on ant design wallet selector modal

### DIFF
--- a/.changeset/smooth-llamas-heal.md
+++ b/.changeset/smooth-llamas-heal.md
@@ -1,0 +1,6 @@
+---
+"@aptos-labs/wallet-adapter-nextjs-example": minor
+"@aptos-labs/wallet-adapter-ant-design": minor
+---
+
+Add mobile wallet support on Ant Design wallet selector modal

--- a/apps/nextjs-example/components/WalletSelectorAntDesign.tsx
+++ b/apps/nextjs-example/components/WalletSelectorAntDesign.tsx
@@ -1,0 +1,7 @@
+import { WalletSelector } from "@aptos-labs/wallet-adapter-ant-design";
+
+const WalletSelectorAntDesign = () => {
+  return <WalletSelector />;
+};
+
+export default WalletSelectorAntDesign;

--- a/apps/nextjs-example/pages/index.tsx
+++ b/apps/nextjs-example/pages/index.tsx
@@ -1,6 +1,5 @@
 import { AptosClient, BCS, TxnBuilderTypes, Types } from "aptos";
 import { useWallet } from "@aptos-labs/wallet-adapter-react";
-import { WalletSelector } from "@aptos-labs/wallet-adapter-ant-design";
 import { WalletConnector } from "@aptos-labs/wallet-adapter-mui-design";
 import { useState } from "react";
 import { ErrorAlert, SuccessAlert } from "../components/Alert";
@@ -12,6 +11,14 @@ const WalletButtons = dynamic(() => import("../components/WalletButtons"), {
   suspense: false,
   ssr: false,
 });
+
+const WalletSelectorAntDesign = dynamic(
+  () => import("../components/WalletSelectorAntDesign"),
+  {
+    suspense: false,
+    ssr: false,
+  }
+);
 
 export const DEVNET_NODE_URL = "https://fullnode.devnet.aptoslabs.com/v1";
 
@@ -168,7 +175,7 @@ export default function App() {
               <h3>Ant Design</h3>
             </td>
             <td className="px-8 py-4 w-3/4">
-              <WalletSelector />
+              <WalletSelectorAntDesign />
             </td>
           </tr>
           <tr>

--- a/packages/wallet-adapter-ant-design/src/WalletSelector.tsx
+++ b/packages/wallet-adapter-ant-design/src/WalletSelector.tsx
@@ -1,7 +1,9 @@
 import React, { useState } from "react";
 import { Button, Menu, Modal, Typography } from "antd";
 import {
+  isRedirectable,
   useWallet,
+  Wallet,
   WalletName,
   WalletReadyState,
 } from "@aptos-labs/wallet-adapter-react";
@@ -43,41 +45,8 @@ export function WalletSelector() {
       >
         {!connected && (
           <Menu>
-            {wallets.map((wallet) => {
-              return (
-                <Menu.Item
-                  key={wallet.name}
-                  onClick={
-                    wallet.readyState === WalletReadyState.Installed ||
-                    wallet.readyState === WalletReadyState.Loadable
-                      ? () => onWalletSelected(wallet.name)
-                      : () => window.open(wallet.url)
-                  }
-                >
-                  <div className="wallet-menu-wrapper">
-                    <div className="wallet-name-wrapper">
-                      <img
-                        src={wallet.icon}
-                        width={25}
-                        style={{ marginRight: 10 }}
-                      />
-                      <Text className="wallet-selector-text">
-                        {wallet.name}
-                      </Text>
-                    </div>
-                    {wallet.readyState === WalletReadyState.Installed ||
-                    wallet.readyState === WalletReadyState.Loadable ? (
-                      <Button className="wallet-connect-button">
-                        <Text className="wallet-connect-button-text">
-                          Connect
-                        </Text>
-                      </Button>
-                    ) : (
-                      <Text className="wallet-connect-install">Install</Text>
-                    )}
-                  </div>
-                </Menu.Item>
-              );
+            {wallets.map((wallet: Wallet) => {
+              return walletView(wallet, onWalletSelected);
             })}
           </Menu>
         )}
@@ -85,3 +54,72 @@ export function WalletSelector() {
     </>
   );
 }
+
+const walletView = (
+  wallet: Wallet,
+  onWalletSelected: (wallet: WalletName) => void
+) => {
+  const isWalletReady =
+    wallet.readyState === WalletReadyState.Installed ||
+    wallet.readyState === WalletReadyState.Loadable;
+  const mobileSupport = wallet.deeplinkProvider;
+
+  if (!isWalletReady && isRedirectable()) {
+    if (mobileSupport) {
+      return (
+        <Menu.Item
+          key={wallet.name}
+          onClick={() => onWalletSelected(wallet.name)}
+        >
+          <div className="wallet-menu-wrapper">
+            <div className="wallet-name-wrapper">
+              <img src={wallet.icon} width={25} style={{ marginRight: 10 }} />
+              <Text className="wallet-selector-text">{wallet.name}</Text>
+            </div>
+            <Button className="wallet-connect-button">
+              <Text className="wallet-connect-button-text">Connect</Text>
+            </Button>
+          </div>
+        </Menu.Item>
+      );
+    } else {
+      return (
+        <Menu.Item key={wallet.name} disabled={true}>
+          <div className="wallet-menu-wrapper">
+            <div className="wallet-name-wrapper">
+              <img src={wallet.icon} width={25} style={{ marginRight: 10 }} />
+              <Text className="wallet-selector-text">{wallet.name}</Text>
+            </div>
+          </div>
+        </Menu.Item>
+      );
+    }
+  } else {
+    return (
+      <Menu.Item
+        key={wallet.name}
+        onClick={
+          wallet.readyState === WalletReadyState.Installed ||
+          wallet.readyState === WalletReadyState.Loadable
+            ? () => onWalletSelected(wallet.name)
+            : () => window.open(wallet.url)
+        }
+      >
+        <div className="wallet-menu-wrapper">
+          <div className="wallet-name-wrapper">
+            <img src={wallet.icon} width={25} style={{ marginRight: 10 }} />
+            <Text className="wallet-selector-text">{wallet.name}</Text>
+          </div>
+          {wallet.readyState === WalletReadyState.Installed ||
+          wallet.readyState === WalletReadyState.Loadable ? (
+            <Button className="wallet-connect-button">
+              <Text className="wallet-connect-button-text">Connect</Text>
+            </Button>
+          ) : (
+            <Text className="wallet-connect-install">Install</Text>
+          )}
+        </div>
+      </Menu.Item>
+    );
+  }
+};


### PR DESCRIPTION
Wallet adapter supports deeplink. This PR adds a mobile view support to enable only mobile wallets on Ant Design wallet selector modal on mobile view.

check https://aptos-labs.github.io/aptos-wallet-adapter/ Ant Design - connect wallet on mobile,