### PR TITLE
fix deeplink redirect

### DIFF
--- a/.changeset/plenty-apes-sniff.md
+++ b/.changeset/plenty-apes-sniff.md
@@ -1,0 +1,6 @@
+---
+"@aptos-labs/wallet-adapter-core": minor
+"@aptos-labs/wallet-adapter-nextjs-example": patch
+---
+
+Fix deeplink redirect

--- a/apps/nextjs-example/components/WalletButtons.tsx
+++ b/apps/nextjs-example/components/WalletButtons.tsx
@@ -41,6 +41,7 @@ const walletView = (wallet: Wallet) => {
           className={`bg-blue-500 text-white font-bold py-2 px-4 rounded mr-4 hover:bg-blue-700`}
           disabled={false}
           key={wallet.name}
+          onClick={() => connect(wallet.name)}
         >
           <>{wallet.name}</>
         </button>

--- a/packages/wallet-adapter-core/src/WalletCore.ts
+++ b/packages/wallet-adapter-core/src/WalletCore.ts
@@ -187,13 +187,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
         (wallet: Wallet) => wallet.name === walletName
       );
 
-      if (
-        !selectedWallet ||
-        (selectedWallet.readyState !== WalletReadyState.Installed &&
-          selectedWallet.readyState !== WalletReadyState.Loadable)
-      ) {
-        return;
-      }
+      if (!selectedWallet) return;
 
       if (this._connected) {
         // if the selected wallet is already connected, we don't need to connect again
@@ -201,7 +195,9 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
 
         await this.disconnect();
       }
+
       // check if we are in a redirectable view (i.e on mobile AND not in an in-app browser) and
+      // since wallet readyState can be NotDetected, we check it before the next check
       if (isRedirectable()) {
         // use wallet deep link
         if (selectedWallet.deeplinkProvider) {
@@ -210,6 +206,13 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
           window.location.href = location;
         }
       }
+      if (
+        selectedWallet.readyState !== WalletReadyState.Installed &&
+        selectedWallet.readyState !== WalletReadyState.Loadable
+      ) {
+        return;
+      }
+
       this._connecting = true;
       this.setWallet(selectedWallet);
       const account = await selectedWallet.connect();


### PR DESCRIPTION
on mobile, a wallet's `readyState` can be `NotDetected`. Move `isRedirectable()` check before checking for wallet ready state.