### PR TITLE
use `--no-frozen-lockfile` on pnpm install for release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
           version: 7
 
       - name: Install global dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --no-frozen-lockfile
 
       - name: Build global project
         run: pnpm run build


### PR DESCRIPTION
After changeset updates the versions, pnpm install should be executed to update the lockfile and not use the existing lockfile