### PR TITLE
[ant design] add an optional prop to handle modal open

### DIFF
--- a/.changeset/bright-jobs-tap.md
+++ b/.changeset/bright-jobs-tap.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/wallet-adapter-ant-design": minor
+---
+
+Add an optional prop for WalletSelector to handle modal open

--- a/packages/wallet-adapter-ant-design/src/WalletSelector.tsx
+++ b/packages/wallet-adapter-ant-design/src/WalletSelector.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useEffect, useState } from "react";
 import { Button, Menu, Modal, Typography } from "antd";
 import {
   isRedirectable,
@@ -11,8 +11,19 @@ import "./styles.css";
 import { truncateAddress } from "./utils";
 const { Text } = Typography;
 
-export function WalletSelector() {
+type WalletSelectorProps = {
+  isModalOpen?: boolean;
+};
+
+export function WalletSelector({ isModalOpen }: WalletSelectorProps) {
   const [walletSelectorModalOpen, setWalletSelectorModalOpen] = useState(false);
+
+  useEffect(() => {
+    if (isModalOpen !== undefined) {
+      setWalletSelectorModalOpen(isModalOpen);
+    }
+  }, [isModalOpen]);
+
   const { connect, disconnect, account, wallets, connected } = useWallet();
 
   const onWalletButtonClick = () => {


### PR DESCRIPTION
### context
this is to fulfill the requirement from our partner game dev shop in this flow so that client can control modal open: 
![game-wallet-support drawio](https://github.com/aptos-labs/aptos-wallet-adapter/assets/121921928/c51266b2-39e3-47c4-ba65-7d3b31d71d98)

### details
1. change's backward compatible as its optional
2. test it out locally in below screen recording


https://github.com/aptos-labs/aptos-wallet-adapter/assets/121921928/2503df36-5079-4a83-8911-ba1b04e37b0b
3. bump minor version 
4. decide to pass in boolean instead of actions cuz actions will make ant design code messy
