### PR TITLE
separate connect and connectWallet for SRP

### DIFF
--- a/.changeset/three-socks-drum.md
+++ b/.changeset/three-socks-drum.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/wallet-adapter-core": patch
+---
+
+Separate connect and connectWallet for SRP


### PR DESCRIPTION
If we try to connect an already connected wallet, the error thrown triggers "clearData" which disconnects the existing wallet. This is obviously not the expected behavior. 

This PR separates the `connect` method to `connect()` where we first make all the checks and validations and if all good we call the `connectWallet()` that actually connects to a wallet and throws any wallet connection error.