### PR TITLE
Add optional `onError` to catch errors on actions

### DIFF
--- a/.changeset/six-pants-teach.md
+++ b/.changeset/six-pants-teach.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/wallet-adapter-react": minor
+---
+
+Add an optional `onError` prop to error handle wallet callbacks

--- a/apps/nextjs-example/components/AppContext.tsx
+++ b/apps/nextjs-example/components/AppContext.tsx
@@ -16,10 +16,7 @@ import {
   NetworkName,
 } from "@aptos-labs/wallet-adapter-react";
 
-import {
-  AutoConnectProvider,
-  useAutoConnect,
-} from "./AutoConnectProvider";
+import { AutoConnectProvider, useAutoConnect } from "./AutoConnectProvider";
 import { FC, ReactNode } from "react";
 import face from "../lib/faceInitialization";
 
@@ -47,7 +44,14 @@ const WalletContextProvider: FC<{ children: ReactNode }> = ({ children }) => {
   ];
 
   return (
-    <AptosWalletAdapterProvider plugins={wallets} autoConnect={autoConnect}>
+    <AptosWalletAdapterProvider
+      plugins={wallets}
+      autoConnect={autoConnect}
+      onError={(error) => {
+        console.log("Custom error handling", error);
+        throw new Error(error.message);
+      }}
+    >
       {children}
     </AptosWalletAdapterProvider>
   );

--- a/packages/wallet-adapter-react/src/WalletProvider.tsx
+++ b/packages/wallet-adapter-react/src/WalletProvider.tsx
@@ -1,5 +1,4 @@
 import {
-  ErrorInfo,
   FC,
   ReactNode,
   useCallback,

--- a/packages/wallet-adapter-react/src/WalletProvider.tsx
+++ b/packages/wallet-adapter-react/src/WalletProvider.tsx
@@ -1,4 +1,5 @@
 import {
+  ErrorInfo,
   FC,
   ReactNode,
   useCallback,
@@ -24,6 +25,7 @@ export interface AptosWalletProviderProps {
   children: ReactNode;
   plugins: ReadonlyArray<Wallet>;
   autoConnect?: boolean;
+  onError?: (error: any) => void;
 }
 
 const initialState: {
@@ -42,6 +44,7 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
   children,
   plugins,
   autoConnect = false,
+  onError,
 }: AptosWalletProviderProps) => {
   const [{ connected, account, network, wallet }, setState] =
     useState(initialState);
@@ -61,7 +64,8 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
       await walletCore.connect(walletName);
     } catch (error: any) {
       console.log("connect error", error);
-      throw error;
+      if (onError) onError(error);
+      else throw error;
     } finally {
       setIsLoading(false);
     }
@@ -72,6 +76,7 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
       await walletCore.disconnect();
     } catch (e) {
       console.log("disconnect error", e);
+      if (onError) onError(e);
     }
   };
 
@@ -82,7 +87,8 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
     try {
       return await walletCore.signAndSubmitTransaction(transaction, options);
     } catch (error: any) {
-      throw error;
+      if (onError) onError(error);
+      else throw error;
     }
   };
 
@@ -104,7 +110,8 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
     try {
       return await walletCore.signTransaction(transaction, options);
     } catch (error: any) {
-      throw error;
+      if (onError) onError(error);
+      else throw error;
     }
   };
 
@@ -112,7 +119,9 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
     try {
       return await walletCore.signMessage(message);
     } catch (error: any) {
-      throw error;
+      if (onError) onError(error);
+      else throw error;
+      return null;
     }
   };
 
@@ -120,7 +129,9 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
     try {
       return await walletCore.signMessageAndVerify(message);
     } catch (error: any) {
-      throw error;
+      if (onError) onError(error);
+      else throw error;
+      return false;
     }
   };
 


### PR DESCRIPTION
# Description

Currently, `connect` throws an error when something goes wrong. This frequently happens when a user cancels the wallet connection process. When a dApp has their own connect wallet modal, the dApp can catch and handle the error. However, when a dApp is using the given Antd modal from this library, there is no way to control the unhandled errors. This diff adds an optional `onError` prop that when provided, will use the `onError` handle rather than throwing an error.

# Test Plan

Apply this diff and test the error handling in the example app


```
diff --git a/apps/nextjs-example/components/AppContext.tsx b/apps/nextjs-example/components/AppContext.tsx
index a954c00..dfe6ee8 100644
--- a/apps/nextjs-example/components/AppContext.tsx
+++ b/apps/nextjs-example/components/AppContext.tsx
@@ -16,10 +16,7 @@ import {
   NetworkName,
 } from "@aptos-labs/wallet-adapter-react";
 
-import {
-  AutoConnectProvider,
-  useAutoConnect,
-} from "./AutoConnectProvider";
+import { AutoConnectProvider, useAutoConnect } from "./AutoConnectProvider";
 import { FC, ReactNode } from "react";
 import face from "../lib/faceInitialization";
 
@@ -47,7 +44,13 @@ const WalletContextProvider: FC<{ children: ReactNode }> = ({ children }) => {
   ];
 
   return (
-    <AptosWalletAdapterProvider plugins={wallets} autoConnect={autoConnect}>
+    <AptosWalletAdapterProvider
+      plugins={wallets}
+      autoConnect={autoConnect}
+      onError={(err) => {
+        console.error(err);
+      }}
+    >
       {children}
     </AptosWalletAdapterProvider>
   );
@@ -59,4 +62,4 @@ export const AppContext: FC<{ children: ReactNode }> = ({ children }) => {
       <WalletContextProvider>{children}</WalletContextProvider>
     </AutoConnectProvider>
   );
-};
\ No newline at end of file
+};
```

The error is properly caught and logged.