### PR TITLE
Enforce types in AdapterPluginEvents.onNetworkChange

### DIFF
--- a/.changeset/curly-melons-retire.md
+++ b/.changeset/curly-melons-retire.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/wallet-adapter-core": minor
+---
+
+Update the onNetworkChange type interface to conform with `WalletCore`'s usage of the callback

--- a/.changeset/curly-melons-retire.md
+++ b/.changeset/curly-melons-retire.md
@@ -2,4 +2,4 @@
 "@aptos-labs/wallet-adapter-core": minor
 ---
 
-Update the onNetworkChange type interface to conform with `WalletCore`'s usage of the callback
+Update the `onNetworkChange` type interface to conform with `WalletCore`'s usage of the callback

--- a/apps/nextjs-example/components/AppContext.tsx
+++ b/apps/nextjs-example/components/AppContext.tsx
@@ -35,7 +35,9 @@ const WalletContextProvider: FC<{ children: ReactNode }> = ({ children }) => {
     new MSafeWalletAdapter(),
     new NightlyWallet(),
     new OpenBlockWallet(),
-    new PetraWallet(),
+    // TODO: Depends on [this PR](https://github.com/aptos-labs/petra-plugin-wallet-adapter/pull/7)
+    // to re-enable
+    // new PetraWallet(),
     new PontemWallet(),
     new RiseWallet(),
     new TokenPocketWallet(),

--- a/packages/wallet-adapter-core/src/types.ts
+++ b/packages/wallet-adapter-core/src/types.ts
@@ -24,7 +24,7 @@ export interface AptosWalletErrorResult {
   message: string;
 }
 
-type OnNetworkChange = (
+export type OnNetworkChange = (
   callBack: (networkInfo: NetworkInfo) => Promise<void>
 ) => Promise<void>;
 

--- a/packages/wallet-adapter-core/src/types.ts
+++ b/packages/wallet-adapter-core/src/types.ts
@@ -25,17 +25,7 @@ export interface AptosWalletErrorResult {
 }
 
 type OnNetworkChange = (
-  callBack: (
-    networkInfo: NetworkInfo & {
-      /**
-       * @deprecated Use the root level `networkInfo` instead because
-       * `networkName` will not be read in by the `WalletCore` provider.
-       * Historically, this was an unused type and is now left in for backwards
-       * compatibility.
-       */
-      networkName: NetworkInfo;
-    }
-  ) => Promise<void>
+  callBack: (networkInfo: NetworkInfo) => Promise<void>
 ) => Promise<void>;
 
 export interface PluginProvider {

--- a/packages/wallet-adapter-core/src/types.ts
+++ b/packages/wallet-adapter-core/src/types.ts
@@ -24,6 +24,20 @@ export interface AptosWalletErrorResult {
   message: string;
 }
 
+type OnNetworkChange = (
+  callBack: (
+    networkInfo: NetworkInfo & {
+      /**
+       * @deprecated Use the root level `networkInfo` instead because
+       * `networkName` will not be read in by the `WalletCore` provider.
+       * Historically, this was an unused type and is now left in for backwards
+       * compatibility.
+       */
+      networkName: NetworkInfo;
+    }
+  ) => Promise<void>
+) => Promise<void>;
+
 export interface PluginProvider {
   connect: () => Promise<AccountInfo>;
   account: () => Promise<AccountInfo>;
@@ -37,13 +51,11 @@ export interface PluginProvider {
   onAccountChange: (
     listener: (newAddress: AccountInfo) => Promise<void>
   ) => Promise<void>;
-  onNetworkChange: (
-    listener: (network: { networkName: NetworkInfo }) => Promise<void>
-  ) => Promise<void>;
+  onNetworkChange: OnNetworkChange;
 }
 
 export interface AdapterPluginEvents {
-  onNetworkChange(callback: any): Promise<any>;
+  onNetworkChange: OnNetworkChange;
   onAccountChange(callback: any): Promise<any>;
 }
 

--- a/packages/wallet-adapter-react/src/WalletProvider.tsx
+++ b/packages/wallet-adapter-react/src/WalletProvider.tsx
@@ -1,4 +1,5 @@
 import {
+  ErrorInfo,
   FC,
   ReactNode,
   useCallback,

--- a/packages/wallet-adapter-react/src/WalletProvider.tsx
+++ b/packages/wallet-adapter-react/src/WalletProvider.tsx
@@ -1,5 +1,4 @@
 import {
-  ErrorInfo,
   FC,
   ReactNode,
   useCallback,


### PR DESCRIPTION
# Description

Enforce types based on the way `WalletCore` calls `onNetworkChange`. This diff depends on [a PR in petra-plugin-wallet-adapter](https://github.com/aptos-labs/petra-plugin-wallet-adapter/pull/7) for the wallet to conform to the new type.