### PR TITLE
Add setSuccessAlertHash

### DIFF
--- a/.changeset/tender-eels-dress.md
+++ b/.changeset/tender-eels-dress.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/wallet-adapter-nextjs-example": patch
+---
+
+Use ReactNode for the AlertProvider success/error text

--- a/apps/nextjs-example/components/Alert.tsx
+++ b/apps/nextjs-example/components/Alert.tsx
@@ -1,8 +1,8 @@
-import { Dispatch, SetStateAction } from "react";
+import { Dispatch, ReactNode, SetStateAction } from "react";
 
 type Alert = {
-  text: string;
-  setText: Dispatch<SetStateAction<string | null>>;
+  text: ReactNode;
+  setText: Dispatch<SetStateAction<ReactNode | null>>;
 };
 
 export function SuccessAlert({ text, setText }: Alert) {
@@ -11,15 +11,7 @@ export function SuccessAlert({ text, setText }: Alert) {
       className="bg-teal-100 border border-teal-400 text-teal-900 px-4 py-3 rounded relative"
       role="alert"
     >
-      <span className="block sm:inline break-all right-3">
-        <a
-          className="underline"
-          target="_blank"
-          href={`${text}?network=devnet`}
-        >
-          {text}
-        </a>
-      </span>
+      <span className="block sm:inline break-all right-3">{text}</span>
       <span
         className="absolute top-0 bottom-0 right-0 px-4 py-3"
         onClick={() => setText(null)}

--- a/apps/nextjs-example/components/AlertProvider.tsx
+++ b/apps/nextjs-example/components/AlertProvider.tsx
@@ -4,16 +4,16 @@ import {
   FC,
   ReactNode,
   SetStateAction,
+  useCallback,
   useContext,
   useState,
 } from "react";
 import { ErrorAlert, SuccessAlert } from "./Alert";
 
 interface AlertContextState {
-  successAlertMessage: string | null;
-  setSuccessAlertMessage: Dispatch<SetStateAction<string | null>>;
-  errorAlertMessage: string | null;
-  setErrorAlertMessage: Dispatch<SetStateAction<string | null>>;
+  setSuccessAlertHash: (hash: string, networkName?: string) => void;
+  setSuccessAlertMessage: Dispatch<SetStateAction<ReactNode | null>>;
+  setErrorAlertMessage: Dispatch<SetStateAction<ReactNode | null>>;
 }
 
 export const AlertContext = createContext<AlertContextState | undefined>(
@@ -28,19 +28,34 @@ export function useAlert(): AlertContextState {
 }
 
 export const AlertProvider: FC<{ children: ReactNode }> = ({ children }) => {
-  const [successAlertMessage, setSuccessAlertMessage] = useState<string | null>(
+  const [successAlertMessage, setSuccessAlertMessage] =
+    useState<ReactNode | null>(null);
+  const [errorAlertMessage, setErrorAlertMessage] = useState<ReactNode | null>(
     null
   );
-  const [errorAlertMessage, setErrorAlertMessage] = useState<string | null>(
-    null
+
+  const setSuccessAlertHash = useCallback(
+    (hash: string, networkName?: string) => {
+      const explorerLink = `https://explorer.aptoslabs.com/txn/${hash}${
+        networkName ? `?network=${networkName.toLowerCase()}` : ""
+      }`;
+      setSuccessAlertMessage(
+        <>
+          View on Explorer:{" "}
+          <a className="underline" target="_blank" href={explorerLink}>
+            {explorerLink}
+          </a>
+        </>
+      );
+    },
+    []
   );
 
   return (
     <AlertContext.Provider
       value={{
-        successAlertMessage,
+        setSuccessAlertHash,
         setSuccessAlertMessage,
-        errorAlertMessage,
         setErrorAlertMessage,
       }}
     >

--- a/apps/nextjs-example/components/AppContext.tsx
+++ b/apps/nextjs-example/components/AppContext.tsx
@@ -51,7 +51,7 @@ const WalletContextProvider: FC<{ children: ReactNode }> = ({ children }) => {
       autoConnect={autoConnect}
       onError={(error) => {
         console.log("Custom error handling", error);
-        setErrorAlertMessage(error)
+        setErrorAlertMessage(error);
       }}
     >
       {children}

--- a/apps/nextjs-example/pages/index.tsx
+++ b/apps/nextjs-example/pages/index.tsx
@@ -40,7 +40,7 @@ export default function App() {
   } = useWallet();
 
   const { autoConnect, setAutoConnect } = useAutoConnect();
-  const { setSuccessAlertMessage } = useAlert();
+  const { setSuccessAlertMessage, setSuccessAlertHash } = useAlert();
 
   const onSignAndSubmitTransaction = async () => {
     const payload: Types.TransactionPayload = {
@@ -51,10 +51,8 @@ export default function App() {
     };
     const response = await signAndSubmitTransaction(payload);
     try {
-      await aptosClient.waitForTransaction(response?.hash || "");
-      setSuccessAlertMessage(
-        `https://explorer.aptoslabs.com/txn/${response?.hash}`
-      );
+      await aptosClient.waitForTransaction(response.hash);
+      setSuccessAlertHash(response.hash, network?.name);
     } catch (error) {
       console.error(error);
     }
@@ -81,10 +79,8 @@ export default function App() {
 
     const response = await signAndSubmitBCSTransaction(entryFunctionBCSPayload);
     try {
-      await aptosClient.waitForTransaction(response?.hash || "");
-      setSuccessAlertMessage(
-        `https://explorer.aptoslabs.com/txn/${response?.hash}`
-      );
+      await aptosClient.waitForTransaction(response.hash);
+      setSuccessAlertHash(response.hash, network?.name);
     } catch (error) {
       console.error(error);
     }


### PR DESCRIPTION
# Description

The `text` component is default to a `<a></a>` component which doesn't make sense for text like signed payload. 
 
- Use ReactNode instead of string
 - Support explorer links for other networks (even though we still really only support devnet)

# Test

[localhost_3001.webm](https://github.com/aptos-labs/aptos-wallet-adapter/assets/8957844/ba84c547-5a3f-4f63-b799-42f7910abb12)

