### PR TITLE
Convert errors to JSON, as they might not be strings

### DIFF
--- a/packages/wallet-adapter-react/src/WalletProvider.tsx
+++ b/packages/wallet-adapter-react/src/WalletProvider.tsx
@@ -62,7 +62,7 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
       setIsLoading(true);
       await walletCore.connect(walletName);
     } catch (error: any) {
-      console.log("connect error", error);
+      console.log(`connect error ${JSON.stringify(error)}`);
       if (onError) onError(error);
       else throw error;
     } finally {
@@ -73,9 +73,9 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
   const disconnect = async () => {
     try {
       await walletCore.disconnect();
-    } catch (e) {
-      console.log("disconnect error", e);
-      if (onError) onError(e);
+    } catch (error: any) {
+      console.log(`disconnect error ${JSON.stringify(error)}`);
+      if (onError) onError(error);
     }
   };
 


### PR DESCRIPTION
This happened to me while testing the wallet, it ended up getting an object error instead, which is problematic.  Since we don't control upstream errors, we need to normalize them as JSON.