### PR TITLE
Add initial fee payer / multi-agent along with website tests

### DIFF
--- a/apps/nextjs-example/package.json
+++ b/apps/nextjs-example/package.json
@@ -29,7 +29,7 @@
     "@trustwallet/aptos-wallet-adapter": "^0.1.6",
     "@welldone-studio/aptos-wallet-adapter": "^0.1.4",
     "antd": "^5.1.2",
-    "aptos": "^1.17.0",
+    "aptos": "^1.18.0",
     "ethers": "^5.7.2",
     "fewcha-plugin-wallet-adapter": "^0.1.3",
     "msafe-plugin-wallet-adapter": "^0.1.0",

--- a/apps/nextjs-example/package.json
+++ b/apps/nextjs-example/package.json
@@ -29,7 +29,7 @@
     "@trustwallet/aptos-wallet-adapter": "^0.1.6",
     "@welldone-studio/aptos-wallet-adapter": "^0.1.4",
     "antd": "^5.1.2",
-    "aptos": "^1.18.0",
+    "aptos": "^1.19.0",
     "ethers": "^5.7.2",
     "fewcha-plugin-wallet-adapter": "^0.1.3",
     "msafe-plugin-wallet-adapter": "^0.1.0",

--- a/apps/nextjs-example/pages/index.tsx
+++ b/apps/nextjs-example/pages/index.tsx
@@ -368,31 +368,6 @@ function OptionalFunctionality() {
         );
     };
 
-    const onSubmitScript = async () => {
-        const payload = {
-            type: "script_payload",
-            code: {
-                bytecode: DO_NOTHING_SCRIPT
-            },
-            type_arguments: [],
-            arguments: []
-        };
-
-        const response = await signAndSubmitTransaction(payload);
-        try {
-            if (response?.hash === undefined) {
-                throw new Error(`No response given ${response}`)
-            }
-            await aptosClient(network?.name.toLowerCase()).waitForTransaction(response.hash);
-            setSuccessAlertHash(response.hash, network?.name);
-        } catch (error) {
-            console.error(error);
-        }
-        setSuccessAlertMessage(
-            JSON.stringify({signAndSubmitTransaction: response})
-        );
-    };
-
     // TODO: Let's put this into a cookie or local storage so it only happens once
     const createFeePayerAccount = async (client: AptosClient) => {
         // Already exists, so lets not fund it
@@ -459,7 +434,6 @@ function OptionalFunctionality() {
         // Submit it TODO: the wallet possibly should send it instead?
         let response: undefined | Types.PendingTransaction = undefined;
             response = await provider.submitFeePayerTransaction(rawTxn, userAuthenticator, feePayerAuthenticator);
-            console.log(`HASH : ${response?.hash}`)
             if (response?.hash === undefined) {
                 throw new Error(`No response given ${response}`)
             }
@@ -481,8 +455,6 @@ function OptionalFunctionality() {
             <Button color={"blue"} onClick={onSignTransaction} disabled={!sendable} message={"Sign transaction"}/>
             <Button color={"blue"} onClick={onSignAndSubmitBCSTransaction} disabled={!sendable}
                     message={"Sign and submit BCS transaction"}/>
-            <Button color={"blue"} onClick={onSubmitScript} disabled={!sendable}
-                    message={"Sign and submit move script"}/>
             <Button color={"blue"} onClick={onSubmitFeePayer} disabled={!sendable}
                     message={"Sign and submit fee payer"}/>
         </Col>

--- a/apps/nextjs-example/pages/index.tsx
+++ b/apps/nextjs-example/pages/index.tsx
@@ -434,7 +434,7 @@ function OptionalFunctionality() {
 
         let chainId = await provider.getChainId();
         let accountResource = await provider.getAccount(account.address);
-        let now = Date.now() / 1000;
+        let now = Math.floor(Date.now() / 1000);
         let rawTxn = new TxnBuilderTypes.RawTransaction(
             TxnBuilderTypes.AccountAddress.fromHex(account.address),
             BigInt(accountResource.sequence_number),

--- a/apps/nextjs-example/pages/index.tsx
+++ b/apps/nextjs-example/pages/index.tsx
@@ -59,8 +59,8 @@ const faucet = (network?: string) => {
 
 const DEVNET_CLIENT = new Provider(Network.DEVNET);
 const TESTNET_CLIENT = new Provider(Network.TESTNET);
-const DEVNET_FAUCET = new FaucetClient("https://fullnode.devnet.aptoslabs.com/v1", "https://faucet.devnet.aptoslbas.com/");
-const TESTNET_FAUCET = new FaucetClient("https://fullnode.testnet.aptoslabs.com/v1", "https://faucet.testnet.aptoslbas.com/");
+const DEVNET_FAUCET = new FaucetClient("https://fullnode.devnet.aptoslabs.com", "https://faucet.devnet.aptoslabs.com");
+const TESTNET_FAUCET = new FaucetClient("https://fullnode.testnet.aptoslabs.com", "https://faucet.testnet.aptoslabs.com");
 
 const isSendableNetwork = (connected: boolean, network?: string): boolean => {
     return connected && (network?.toLowerCase() === NetworkName.Devnet.toLowerCase()
@@ -415,7 +415,7 @@ function OptionalFunctionality() {
         } catch (error: any) {
             // Swallow errors, likely due to account not existing
         }
-        await faucet(network?.name.toLowerCase()).fundAccount(feePayerAddress, 100000);
+        await (faucet(network?.name.toLowerCase()).fundAccount(feePayerAddress, 100000));
 
         return newAccount;
     }
@@ -435,7 +435,7 @@ function OptionalFunctionality() {
             arguments: [account.address, 1], // 1 is in Octas
         };
 
-        let prepResponse = await prepareFeePayerTransaction(payload, feePayerAccount.address().hex(), []);
+        let prepResponse = await prepareFeePayerTransaction(payload, feePayerAccount.address().hex(), feePayerAccount.pubKey().hex());
         if (!prepResponse) {
             // TODO: Handle error
             throw new Error("Failed to prepare fee payer transaction");

--- a/packages/wallet-adapter-core/package.json
+++ b/packages/wallet-adapter-core/package.json
@@ -45,7 +45,7 @@
     "typescript": "^4.5.3"
   },
   "dependencies": {
-    "aptos": "^1.18.0",
+    "aptos": "^1.19.0",
     "buffer": "^6.0.3",
     "eventemitter3": "^4.0.7",
     "tweetnacl": "^1.0.3"

--- a/packages/wallet-adapter-core/package.json
+++ b/packages/wallet-adapter-core/package.json
@@ -45,7 +45,7 @@
     "typescript": "^4.5.3"
   },
   "dependencies": {
-    "aptos": "^1.17.0",
+    "aptos": "^1.18.0",
     "buffer": "^6.0.3",
     "eventemitter3": "^4.0.7",
     "tweetnacl": "^1.0.3"

--- a/packages/wallet-adapter-core/src/WalletCore.ts
+++ b/packages/wallet-adapter-core/src/WalletCore.ts
@@ -481,35 +481,6 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
     }
   }
 
-  async prepareFeePayerTransaction<T extends Types.TransactionPayload>(
-      transaction: T,
-      feePayerAddress: string,
-      feePayerPublicKey: string,
-      additionalSignerAddresses?: string[],
-      additionalSignerPublicKeys?: string[],
-      options?: TransactionOptions
-  ): Promise<TxnBuilderTypes.FeePayerRawTransaction | undefined> {
-    if (this._wallet && !("prepareFeePayerTransaction" in this._wallet)) {
-      throw new WalletNotSupportedMethod(
-          `Fee payer transactions are not supported by ${this.wallet?.name}`
-      ).message;
-    }
-
-    try {
-      this.doesWalletExist();
-      const response = await (this._wallet as any).prepareFeePayerTransaction(
-          transaction,
-          options
-      );
-      return response;
-    } catch (error: any) {
-      const errMsg =
-          typeof error == "object" && "message" in error ? error.message : error;
-      // TODO: Maybe change error type
-      throw new WalletSignTransactionError(errMsg).message;
-    }
-  }
-
   async signAndSubmitFeePayerTransaction(
       transaction: TxnBuilderTypes.FeePayerRawTransaction,
       feePayerSignature: TxnBuilderTypes.AccountAuthenticator,
@@ -535,34 +506,6 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
           // TODO: Maybe change error type
           throw new WalletSignTransactionError(errMsg).message;
       }
-  }
-
-  async prepareMultiAgentTransaction<T extends Types.TransactionPayload>(
-      transaction: T,
-      additionalSignerAddresses?: string[],
-      additionalSignerPublicKeys?: string[],
-      options?: TransactionOptions
-  ): Promise<TxnBuilderTypes.MultiAgentRawTransaction | undefined>{
-
-    if (this._wallet && !("prepareMultiAgentTransaction" in this._wallet)) {
-      throw new WalletNotSupportedMethod(
-          `Multi agent transactions are not supported by ${this.wallet?.name}`
-      ).message;
-    }
-
-    try {
-      this.doesWalletExist();
-      const response = await (this._wallet as any).prepareMultiAgentTransaction(
-          transaction,
-          options
-      );
-      return response;
-    } catch (error: any) {
-      const errMsg =
-          typeof error == "object" && "message" in error ? error.message : error;
-      // TODO: Maybe change error type
-      throw new WalletSignTransactionError(errMsg).message;
-    }
   }
 
   async signAndSubmitMultiAgentTransaction(

--- a/packages/wallet-adapter-core/src/WalletCore.ts
+++ b/packages/wallet-adapter-core/src/WalletCore.ts
@@ -484,7 +484,9 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
   async prepareFeePayerTransaction<T extends Types.TransactionPayload>(
       transaction: T,
       feePayerAddress: string,
+      feePayerPublicKey: string,
       additionalSignerAddresses?: string[],
+      additionalSignerPublicKeys?: string[],
       options?: TransactionOptions
   ): Promise<TxnBuilderTypes.FeePayerRawTransaction | undefined> {
     if (this._wallet && !("prepareFeePayerTransaction" in this._wallet)) {
@@ -538,6 +540,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
   async prepareMultiAgentTransaction<T extends Types.TransactionPayload>(
       transaction: T,
       additionalSignerAddresses?: string[],
+      additionalSignerPublicKeys?: string[],
       options?: TransactionOptions
   ): Promise<TxnBuilderTypes.MultiAgentRawTransaction | undefined>{
 
@@ -563,7 +566,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
   }
 
   async signAndSubmitMultiAgentTransaction(
-      transaction: TxnBuilderTypes.FeePayerRawTransaction,
+      transaction: TxnBuilderTypes.MultiAgentRawTransaction,
       additionalSignatures?: TxnBuilderTypes.AccountAuthenticator[],
       options?: TransactionOptions
   ): Promise<any> {

--- a/packages/wallet-adapter-core/src/WalletCore.ts
+++ b/packages/wallet-adapter-core/src/WalletCore.ts
@@ -371,6 +371,27 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
     }
   }
 
+  async signMultiAgentTransaction(
+    transaction: TxnBuilderTypes.MultiAgentRawTransaction | TxnBuilderTypes.FeePayerRawTransaction
+  ): Promise<string | null> {
+    if (this._wallet && !("signMultiAgentTransaction" in this._wallet)) {
+      throw new WalletNotSupportedMethod(
+          `Multi agent & Fee payer transactions are not supported by ${this.wallet?.name}`
+      ).message;
+    }
+    try {
+      this.doesWalletExist();
+      const response = await (this._wallet as any).signMultiAgentTransaction(
+          transaction
+      );
+      return response;
+    } catch (error: any) {
+      const errMsg =
+          typeof error == "object" && "message" in error ? error.message : error;
+      throw new WalletSignTransactionError(errMsg).message;
+    }
+  }
+
   /**
   Event for when account has changed on the wallet
   @return the new account info
@@ -479,58 +500,5 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
         typeof error == "object" && "message" in error ? error.message : error;
       throw new WalletSignMessageAndVerifyError(errMsg).message;
     }
-  }
-
-  async signAndSubmitFeePayerTransaction(
-      transaction: TxnBuilderTypes.FeePayerRawTransaction,
-      feePayerSignature: TxnBuilderTypes.AccountAuthenticator,
-      additionalSignatures?: TxnBuilderTypes.AccountAuthenticator[],
-      options?: TransactionOptions
-  ): Promise<any> {
-      if (this._wallet && !("signAndSubmitFeePayerTransaction" in this._wallet)) {
-          throw new WalletNotSupportedMethod(
-              `Fee payer transactions are not supported by ${this.wallet?.name}`
-          ).message;
-      }
-
-      try {
-          this.doesWalletExist();
-          const response = await (this._wallet as any).signAndSubmitFeePayerTransaction(
-              transaction,
-              options
-          );
-          return response;
-      } catch (error: any) {
-          const errMsg =
-              typeof error == "object" && "message" in error ? error.message : error;
-          // TODO: Maybe change error type
-          throw new WalletSignTransactionError(errMsg).message;
-      }
-  }
-
-  async signAndSubmitMultiAgentTransaction(
-      transaction: TxnBuilderTypes.MultiAgentRawTransaction,
-      additionalSignatures?: TxnBuilderTypes.AccountAuthenticator[],
-      options?: TransactionOptions
-  ): Promise<any> {
-      if (this._wallet && !("signAndSubmitMultiAgentTransaction" in this._wallet)) {
-          throw new WalletNotSupportedMethod(
-              `Multi agent transactions are not supported by ${this.wallet?.name}`
-          ).message;
-      }
-
-      try {
-          this.doesWalletExist();
-          const response = await (this._wallet as any).signAndSubmitMultiAgentTransaction(
-              transaction,
-              options
-          );
-          return response;
-      } catch (error: any) {
-          const errMsg =
-              typeof error == "object" && "message" in error ? error.message : error;
-          // TODO: Maybe change error type
-          throw new WalletSignTransactionError(errMsg).message;
-      }
   }
 }

--- a/packages/wallet-adapter-core/src/WalletCore.ts
+++ b/packages/wallet-adapter-core/src/WalletCore.ts
@@ -1,4 +1,4 @@
-import { HexString, TxnBuilderTypes, Types } from "aptos";
+import {HexString, TxnBuilderTypes, Types} from "aptos";
 import EventEmitter from "eventemitter3";
 import nacl from "tweetnacl";
 import { Buffer } from "buffer";
@@ -244,8 +244,8 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
     }
   }
 
-  /** 
-  Disconnect the exisitng wallet. On success, we clear the 
+  /**
+  Disconnect the exisitng wallet. On success, we clear the
   current account, current network and LocalStorage data.
   @emit emits "disconnect" event
   @throws WalletDisconnectionError
@@ -263,7 +263,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
     }
   }
 
-  /** 
+  /**
   Sign and submit an entry (not bcs serialized) transaction type to chain.
   @param transaction a non-bcs serialized transaction
   @param options max_gas_amount and gas_unit_limit
@@ -288,7 +288,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
     }
   }
 
-  /** 
+  /**
   Sign and submit a bsc serialized transaction type to chain.
   @param transaction a bcs serialized transaction
   @param options max_gas_amount and gas_unit_limit
@@ -319,7 +319,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
     }
   }
 
-  /** 
+  /**
   Sign transaction (doesnt submit to chain).
   @param transaction
   @param options max_gas_amount and gas_unit_limit
@@ -350,7 +350,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
     }
   }
 
-  /** 
+  /**
   Sign message (doesnt submit to chain).
   @param message
   @return response from the wallet's signMessage function
@@ -371,7 +371,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
     }
   }
 
-  /** 
+  /**
   Event for when account has changed on the wallet
   @return the new account info
   @throws WalletAccountChangeError
@@ -391,7 +391,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
     }
   }
 
-  /** 
+  /**
   Event for when network has changed on the wallet
   @return the new network info
   @throws WalletNetworkChangeError
@@ -479,5 +479,112 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
         typeof error == "object" && "message" in error ? error.message : error;
       throw new WalletSignMessageAndVerifyError(errMsg).message;
     }
+  }
+
+  async prepareFeePayerTransaction<T extends Types.TransactionPayload>(
+      transaction: T,
+      feePayerAddress: string,
+      additionalSignerAddresses?: string[],
+      options?: TransactionOptions
+  ): Promise<TxnBuilderTypes.FeePayerRawTransaction | undefined> {
+    if (this._wallet && !("prepareFeePayerTransaction" in this._wallet)) {
+      throw new WalletNotSupportedMethod(
+          `Fee payer transactions are not supported by ${this.wallet?.name}`
+      ).message;
+    }
+
+    try {
+      this.doesWalletExist();
+      const response = await (this._wallet as any).prepareFeePayerTransaction(
+          transaction,
+          options
+      );
+      return response;
+    } catch (error: any) {
+      const errMsg =
+          typeof error == "object" && "message" in error ? error.message : error;
+      // TODO: Maybe change error type
+      throw new WalletSignTransactionError(errMsg).message;
+    }
+  }
+
+  async signAndSubmitFeePayerTransaction(
+      transaction: TxnBuilderTypes.FeePayerRawTransaction,
+      feePayerSignature: TxnBuilderTypes.AccountAuthenticator,
+      additionalSignatures?: TxnBuilderTypes.AccountAuthenticator[],
+      options?: TransactionOptions
+  ): Promise<any> {
+      if (this._wallet && !("signAndSubmitFeePayerTransaction" in this._wallet)) {
+          throw new WalletNotSupportedMethod(
+              `Fee payer transactions are not supported by ${this.wallet?.name}`
+          ).message;
+      }
+
+      try {
+          this.doesWalletExist();
+          const response = await (this._wallet as any).signAndSubmitFeePayerTransaction(
+              transaction,
+              options
+          );
+          return response;
+      } catch (error: any) {
+          const errMsg =
+              typeof error == "object" && "message" in error ? error.message : error;
+          // TODO: Maybe change error type
+          throw new WalletSignTransactionError(errMsg).message;
+      }
+  }
+
+  async prepareMultiAgentTransaction<T extends Types.TransactionPayload>(
+      transaction: T,
+      additionalSignerAddresses?: string[],
+      options?: TransactionOptions
+  ): Promise<TxnBuilderTypes.MultiAgentRawTransaction | undefined>{
+
+    if (this._wallet && !("prepareMultiAgentTransaction" in this._wallet)) {
+      throw new WalletNotSupportedMethod(
+          `Multi agent transactions are not supported by ${this.wallet?.name}`
+      ).message;
+    }
+
+    try {
+      this.doesWalletExist();
+      const response = await (this._wallet as any).prepareMultiAgentTransaction(
+          transaction,
+          options
+      );
+      return response;
+    } catch (error: any) {
+      const errMsg =
+          typeof error == "object" && "message" in error ? error.message : error;
+      // TODO: Maybe change error type
+      throw new WalletSignTransactionError(errMsg).message;
+    }
+  }
+
+  async signAndSubmitMultiAgentTransaction(
+      transaction: TxnBuilderTypes.FeePayerRawTransaction,
+      additionalSignatures?: TxnBuilderTypes.AccountAuthenticator[],
+      options?: TransactionOptions
+  ): Promise<any> {
+      if (this._wallet && !("signAndSubmitMultiAgentTransaction" in this._wallet)) {
+          throw new WalletNotSupportedMethod(
+              `Multi agent transactions are not supported by ${this.wallet?.name}`
+          ).message;
+      }
+
+      try {
+          this.doesWalletExist();
+          const response = await (this._wallet as any).signAndSubmitMultiAgentTransaction(
+              transaction,
+              options
+          );
+          return response;
+      } catch (error: any) {
+          const errMsg =
+              typeof error == "object" && "message" in error ? error.message : error;
+          // TODO: Maybe change error type
+          throw new WalletSignTransactionError(errMsg).message;
+      }
   }
 }

--- a/packages/wallet-adapter-core/src/types.ts
+++ b/packages/wallet-adapter-core/src/types.ts
@@ -1,4 +1,4 @@
-import { Types } from "aptos";
+import { TxnBuilderTypes, Types } from "aptos";
 import { NetworkName, WalletReadyState } from "./constants";
 
 export { TxnBuilderTypes, Types } from "aptos";
@@ -43,6 +43,9 @@ export interface PluginProvider {
     listener: (newAddress: AccountInfo) => Promise<void>
   ) => Promise<void>;
   onNetworkChange: OnNetworkChange;
+  signMultiAgentTransaction: (
+      rawTxn: TxnBuilderTypes.MultiAgentRawTransaction | TxnBuilderTypes.FeePayerRawTransaction
+  ) => Promise<string>;
 }
 
 export interface AdapterPluginEvents {

--- a/packages/wallet-adapter-react/src/WalletProvider.tsx
+++ b/packages/wallet-adapter-react/src/WalletProvider.tsx
@@ -134,6 +134,60 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
     }
   };
 
+  const prepareFeePayerTransaction = async (
+      transaction: Types.TransactionPayload,
+      feePayerAddress: string,
+      additionalSignerAddresses?: string[],
+      options?: TransactionOptions
+  ) => {
+    try {
+      return await walletCore.prepareFeePayerTransaction(transaction, feePayerAddress, additionalSignerAddresses, options);
+    } catch (error: any) {
+      if (onError) onError(error);
+      else throw error;
+    }
+  };
+
+  const signAndSubmitFeePayerTransaction = async (
+      transaction: TxnBuilderTypes.FeePayerRawTransaction,
+      feePayerSignature: TxnBuilderTypes.AccountAuthenticator,
+      additionalSignatures?: TxnBuilderTypes.AccountAuthenticator[],
+      options?: TransactionOptions
+  ) => {
+      try {
+          return await walletCore.signAndSubmitFeePayerTransaction(transaction, feePayerSignature, additionalSignatures, options);
+      } catch (error: any) {
+          if (onError) onError(error);
+          else throw error;
+      }
+  }
+
+  const prepareMultiAgentTransaction = async (
+      transaction: Types.TransactionPayload,
+      additionalSignerAddresses?: string[],
+      options?: TransactionOptions
+  ) => {
+      try {
+          return await walletCore.prepareMultiAgentTransaction(transaction, additionalSignerAddresses, options);
+      } catch (error: any) {
+          if (onError) onError(error);
+          else throw error;
+      }
+  };
+
+  const signAndSubmitMultiAgentTransaction = async (
+      transaction: TxnBuilderTypes.FeePayerRawTransaction,
+      additionalSignatures?: TxnBuilderTypes.AccountAuthenticator[],
+      options?: TransactionOptions
+  ) => {
+      try {
+          return await walletCore.signAndSubmitMultiAgentTransaction(transaction, additionalSignatures, options);
+      } catch (error: any) {
+          if (onError) onError(error);
+          else throw error;
+      }
+  }
+
   useEffect(() => {
     if (autoConnect) {
       if (localStorage.getItem("AptosWalletName")) {
@@ -240,6 +294,10 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
         signTransaction,
         signMessage,
         signMessageAndVerify,
+        prepareFeePayerTransaction,
+        prepareMultiAgentTransaction,
+        signAndSubmitFeePayerTransaction,
+        signAndSubmitMultiAgentTransaction,
         isLoading,
       }}
     >

--- a/packages/wallet-adapter-react/src/WalletProvider.tsx
+++ b/packages/wallet-adapter-react/src/WalletProvider.tsx
@@ -134,31 +134,17 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
     }
   };
 
-  const signAndSubmitFeePayerTransaction = async (
-      transaction: TxnBuilderTypes.FeePayerRawTransaction,
-      feePayerSignature: TxnBuilderTypes.AccountAuthenticator,
-      additionalSignatures?: TxnBuilderTypes.AccountAuthenticator[],
-      options?: TransactionOptions
-  ) => {
-      try {
-          return await walletCore.signAndSubmitFeePayerTransaction(transaction, feePayerSignature, additionalSignatures, options);
-      } catch (error: any) {
-          if (onError) onError(error);
-          else throw error;
-      }
-  }
 
-  const signAndSubmitMultiAgentTransaction = async (
-      transaction: TxnBuilderTypes.MultiAgentRawTransaction,
-      additionalSignatures?: TxnBuilderTypes.AccountAuthenticator[],
-      options?: TransactionOptions
+  const signMultiAgentTransaction = async (
+      transaction: TxnBuilderTypes.MultiAgentRawTransaction | TxnBuilderTypes.FeePayerRawTransaction,
   ) => {
-      try {
-          return await walletCore.signAndSubmitMultiAgentTransaction(transaction, additionalSignatures, options);
-      } catch (error: any) {
-          if (onError) onError(error);
-          else throw error;
-      }
+    try {
+      return await walletCore.signMultiAgentTransaction(transaction);
+    } catch (error: any) {
+      if (onError) onError(error);
+      else throw error;
+      return false;
+    }
   }
 
   useEffect(() => {
@@ -267,8 +253,7 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
         signTransaction,
         signMessage,
         signMessageAndVerify,
-        signAndSubmitFeePayerTransaction,
-        signAndSubmitMultiAgentTransaction,
+        signMultiAgentTransaction,
         isLoading,
       }}
     >

--- a/packages/wallet-adapter-react/src/WalletProvider.tsx
+++ b/packages/wallet-adapter-react/src/WalletProvider.tsx
@@ -134,22 +134,6 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
     }
   };
 
-  const prepareFeePayerTransaction = async (
-      transaction: Types.TransactionPayload,
-      feePayerAddress: string,
-      feePayerPublicKey: string,
-      additionalSignerAddresses?: string[],
-      additionalSignerPublicKeys?: string[],
-      options?: TransactionOptions
-  ) => {
-    try {
-      return await walletCore.prepareFeePayerTransaction(transaction, feePayerAddress, feePayerPublicKey, additionalSignerAddresses, additionalSignerPublicKeys, options);
-    } catch (error: any) {
-      if (onError) onError(error);
-      else throw error;
-    }
-  };
-
   const signAndSubmitFeePayerTransaction = async (
       transaction: TxnBuilderTypes.FeePayerRawTransaction,
       feePayerSignature: TxnBuilderTypes.AccountAuthenticator,
@@ -163,20 +147,6 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
           else throw error;
       }
   }
-
-  const prepareMultiAgentTransaction = async (
-      transaction: Types.TransactionPayload,
-      additionalSignerAddresses?: string[],
-      additionalSignerPublicKeys?: string[],
-      options?: TransactionOptions
-  ) => {
-      try {
-          return await walletCore.prepareMultiAgentTransaction(transaction, additionalSignerAddresses, additionalSignerPublicKeys, options);
-      } catch (error: any) {
-          if (onError) onError(error);
-          else throw error;
-      }
-  };
 
   const signAndSubmitMultiAgentTransaction = async (
       transaction: TxnBuilderTypes.MultiAgentRawTransaction,
@@ -297,8 +267,6 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
         signTransaction,
         signMessage,
         signMessageAndVerify,
-        prepareFeePayerTransaction,
-        prepareMultiAgentTransaction,
         signAndSubmitFeePayerTransaction,
         signAndSubmitMultiAgentTransaction,
         isLoading,

--- a/packages/wallet-adapter-react/src/WalletProvider.tsx
+++ b/packages/wallet-adapter-react/src/WalletProvider.tsx
@@ -137,11 +137,13 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
   const prepareFeePayerTransaction = async (
       transaction: Types.TransactionPayload,
       feePayerAddress: string,
+      feePayerPublicKey: string,
       additionalSignerAddresses?: string[],
+      additionalSignerPublicKeys?: string[],
       options?: TransactionOptions
   ) => {
     try {
-      return await walletCore.prepareFeePayerTransaction(transaction, feePayerAddress, additionalSignerAddresses, options);
+      return await walletCore.prepareFeePayerTransaction(transaction, feePayerAddress, feePayerPublicKey, additionalSignerAddresses, additionalSignerPublicKeys, options);
     } catch (error: any) {
       if (onError) onError(error);
       else throw error;
@@ -165,10 +167,11 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
   const prepareMultiAgentTransaction = async (
       transaction: Types.TransactionPayload,
       additionalSignerAddresses?: string[],
+      additionalSignerPublicKeys?: string[],
       options?: TransactionOptions
   ) => {
       try {
-          return await walletCore.prepareMultiAgentTransaction(transaction, additionalSignerAddresses, options);
+          return await walletCore.prepareMultiAgentTransaction(transaction, additionalSignerAddresses, additionalSignerPublicKeys, options);
       } catch (error: any) {
           if (onError) onError(error);
           else throw error;
@@ -176,7 +179,7 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
   };
 
   const signAndSubmitMultiAgentTransaction = async (
-      transaction: TxnBuilderTypes.FeePayerRawTransaction,
+      transaction: TxnBuilderTypes.MultiAgentRawTransaction,
       additionalSignatures?: TxnBuilderTypes.AccountAuthenticator[],
       options?: TransactionOptions
   ) => {

--- a/packages/wallet-adapter-react/src/useWallet.tsx
+++ b/packages/wallet-adapter-react/src/useWallet.tsx
@@ -53,7 +53,9 @@ export interface WalletContextState {
   prepareFeePayerTransaction<T extends Types.TransactionPayload>(
       transaction: T,
       feePayerAddress: string,
+      feePayerPublicKey: string,
       additionalSignerAddresses?: string[],
+      additionalSignerPublicKeys?: string[],
       options?: TransactionOptions
   ): Promise<TxnBuilderTypes.FeePayerRawTransaction | undefined>;
 
@@ -67,11 +69,12 @@ export interface WalletContextState {
   prepareMultiAgentTransaction<T extends Types.TransactionPayload>(
       transaction: T,
       additionalSignerAddresses?: string[],
+      additionalSignerPublicKeys?: string[],
       options?: TransactionOptions
   ): Promise<TxnBuilderTypes.MultiAgentRawTransaction | undefined>;
 
   signAndSubmitMultiAgentTransaction(
-      transaction: TxnBuilderTypes.FeePayerRawTransaction,
+      transaction: TxnBuilderTypes.MultiAgentRawTransaction,
       additionalSignatures?: TxnBuilderTypes.AccountAuthenticator[],
       options?: TransactionOptions
   ): Promise<any>;

--- a/packages/wallet-adapter-react/src/useWallet.tsx
+++ b/packages/wallet-adapter-react/src/useWallet.tsx
@@ -49,6 +49,32 @@ export interface WalletContextState {
   ): Promise<any>;
   signMessage(message: SignMessagePayload): Promise<SignMessageResponse | null>;
   signMessageAndVerify(message: SignMessagePayload): Promise<boolean>;
+
+  prepareFeePayerTransaction<T extends Types.TransactionPayload>(
+      transaction: T,
+      feePayerAddress: string,
+      additionalSignerAddresses?: string[],
+      options?: TransactionOptions
+  ): Promise<TxnBuilderTypes.FeePayerRawTransaction | undefined>;
+
+  signAndSubmitFeePayerTransaction(
+      transaction: TxnBuilderTypes.FeePayerRawTransaction,
+      feePayerSignature: TxnBuilderTypes.AccountAuthenticator,
+      additionalSignatures?: TxnBuilderTypes.AccountAuthenticator[],
+      options?: TransactionOptions
+  ): Promise<any>;
+
+  prepareMultiAgentTransaction<T extends Types.TransactionPayload>(
+      transaction: T,
+      additionalSignerAddresses?: string[],
+      options?: TransactionOptions
+  ): Promise<TxnBuilderTypes.MultiAgentRawTransaction | undefined>;
+
+  signAndSubmitMultiAgentTransaction(
+      transaction: TxnBuilderTypes.FeePayerRawTransaction,
+      additionalSignatures?: TxnBuilderTypes.AccountAuthenticator[],
+      options?: TransactionOptions
+  ): Promise<any>;
 }
 
 const DEFAULT_COUNTEXT = {

--- a/packages/wallet-adapter-react/src/useWallet.tsx
+++ b/packages/wallet-adapter-react/src/useWallet.tsx
@@ -50,17 +50,8 @@ export interface WalletContextState {
   signMessage(message: SignMessagePayload): Promise<SignMessageResponse | null>;
   signMessageAndVerify(message: SignMessagePayload): Promise<boolean>;
 
-  signAndSubmitFeePayerTransaction(
-      transaction: TxnBuilderTypes.FeePayerRawTransaction,
-      feePayerSignature: TxnBuilderTypes.AccountAuthenticator,
-      additionalSignatures?: TxnBuilderTypes.AccountAuthenticator[],
-      options?: TransactionOptions
-  ): Promise<any>;
-
-  signAndSubmitMultiAgentTransaction(
-      transaction: TxnBuilderTypes.MultiAgentRawTransaction,
-      additionalSignatures?: TxnBuilderTypes.AccountAuthenticator[],
-      options?: TransactionOptions
+  signMultiAgentTransaction(
+      transaction: TxnBuilderTypes.MultiAgentRawTransaction | TxnBuilderTypes.FeePayerRawTransaction,
   ): Promise<any>;
 }
 

--- a/packages/wallet-adapter-react/src/useWallet.tsx
+++ b/packages/wallet-adapter-react/src/useWallet.tsx
@@ -50,28 +50,12 @@ export interface WalletContextState {
   signMessage(message: SignMessagePayload): Promise<SignMessageResponse | null>;
   signMessageAndVerify(message: SignMessagePayload): Promise<boolean>;
 
-  prepareFeePayerTransaction<T extends Types.TransactionPayload>(
-      transaction: T,
-      feePayerAddress: string,
-      feePayerPublicKey: string,
-      additionalSignerAddresses?: string[],
-      additionalSignerPublicKeys?: string[],
-      options?: TransactionOptions
-  ): Promise<TxnBuilderTypes.FeePayerRawTransaction | undefined>;
-
   signAndSubmitFeePayerTransaction(
       transaction: TxnBuilderTypes.FeePayerRawTransaction,
       feePayerSignature: TxnBuilderTypes.AccountAuthenticator,
       additionalSignatures?: TxnBuilderTypes.AccountAuthenticator[],
       options?: TransactionOptions
   ): Promise<any>;
-
-  prepareMultiAgentTransaction<T extends Types.TransactionPayload>(
-      transaction: T,
-      additionalSignerAddresses?: string[],
-      additionalSignerPublicKeys?: string[],
-      options?: TransactionOptions
-  ): Promise<TxnBuilderTypes.MultiAgentRawTransaction | undefined>;
 
   signAndSubmitMultiAgentTransaction(
       transaction: TxnBuilderTypes.MultiAgentRawTransaction,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,7 +20,7 @@ importers:
         version: 2.25.2
       prettier:
         specifier: latest
-        version: 3.0.1
+        version: 3.0.2
       turbo:
         specifier: latest
         version: 1.10.12
@@ -47,7 +47,7 @@ importers:
         version: 0.1.0
       '@haechi-labs/face-aptos-adapter-plugin':
         specifier: ^0.0.4
-        version: 0.0.4(@aptos-labs/wallet-adapter-core@packages+wallet-adapter-core)(@haechi-labs/face-sdk@1.10.8)(@haechi-labs/face-types@1.10.8)(aptos@1.17.0)
+        version: 0.0.4(@aptos-labs/wallet-adapter-core@packages+wallet-adapter-core)(@haechi-labs/face-sdk@1.10.8)(@haechi-labs/face-types@1.10.8)(aptos@1.18.0)
       '@haechi-labs/face-sdk':
         specifier: ^1.10.8
         version: 1.10.8(@haechi-labs/face-types@1.10.8)(ethers@5.7.2)
@@ -82,8 +82,8 @@ importers:
         specifier: ^5.1.2
         version: 5.1.4(react-dom@18.2.0)(react@18.2.0)
       aptos:
-        specifier: ^1.17.0
-        version: 1.17.0
+        specifier: ^1.18.0
+        version: 1.18.0
       ethers:
         specifier: ^5.7.2
         version: 5.7.2
@@ -195,8 +195,8 @@ importers:
   packages/wallet-adapter-core:
     dependencies:
       aptos:
-        specifier: ^1.17.0
-        version: 1.17.0
+        specifier: ^1.18.0
+        version: 1.18.0
       buffer:
         specifier: ^6.0.3
         version: 6.0.3
@@ -387,7 +387,7 @@ packages:
   /@aptos-labs/wallet-adapter-core@0.1.7:
     resolution: {integrity: sha512-g3HvX31kuFT5HqEe9Vh0ZgV1u0Otsfx54yeAwL7RO8CioBVBjYELhMsOYz0BOjecmAKhQ14G60VU8MqDyzYkIA==}
     dependencies:
-      aptos: 1.17.0
+      aptos: 1.18.0
       eventemitter3: 4.0.7
     transitivePeerDependencies:
       - debug
@@ -396,7 +396,7 @@ packages:
   /@aptos-labs/wallet-adapter-core@0.2.3:
     resolution: {integrity: sha512-QjUVRYSL05pxdjYo2bScxEZ8wi6ww4sf5mBW5w89F5mDfnDz2XEmZQYfQtV3bxoyqnNWPEjagTds4tKMXDhF1w==}
     dependencies:
-      aptos: 1.17.0
+      aptos: 1.18.0
       buffer: 6.0.3
       eventemitter3: 4.0.7
       tweetnacl: 1.0.3
@@ -407,7 +407,7 @@ packages:
   /@aptos-labs/wallet-adapter-core@2.1.0:
     resolution: {integrity: sha512-ZSCCsFt2heEh9IDaObbzw8EwqfzJGCWGBoaGouBtOYn2DVkh5R0P9xRj6ryF9cuO+tkfP+8KZmZ9m4c+xsJN2g==}
     dependencies:
-      aptos: 1.17.0
+      aptos: 1.18.0
       buffer: 6.0.3
       eventemitter3: 4.0.7
       tweetnacl: 1.0.3
@@ -418,7 +418,7 @@ packages:
   /@aptos-labs/wallet-adapter-core@2.2.0:
     resolution: {integrity: sha512-JL0zTXXoSQba1EDGqY5yTJxZVKMKwgMKZNA1JyV54s5loWzE2tinwg002EB+ONodkVmMhKbWnajCFFOgvgk+NQ==}
     dependencies:
-      aptos: 1.17.0
+      aptos: 1.18.0
       buffer: 6.0.3
       eventemitter3: 4.0.7
       tweetnacl: 1.0.3
@@ -429,7 +429,7 @@ packages:
   /@aptos-labs/wallet-adapter-core@2.5.1:
     resolution: {integrity: sha512-ny6CD47ivpnVV22reyN6LouDMVY9eccY3F3HscqfhAK+IqFm4C1C4BTFCoMQwPe9/yht2E/B6VuZBRIsYf7NvQ==}
     dependencies:
-      aptos: 1.17.0
+      aptos: 1.18.0
       buffer: 6.0.3
       eventemitter3: 4.0.7
       tweetnacl: 1.0.3
@@ -775,8 +775,8 @@ packages:
     resolution: {integrity: sha512-IyS/DdGLsnzmwc94X4W58CANoGjKhVq6HCnbElsm2+S04Z+BEBr0rWrpEjC35au/wzqCZTISx2D/LV54vxiSNw==}
     dependencies:
       '@aptos-labs/wallet-adapter-core': 2.5.1
-      '@blocto/sdk': 0.5.4(aptos@1.17.0)
-      aptos: 1.17.0
+      '@blocto/sdk': 0.5.4(aptos@1.18.0)
+      aptos: 1.18.0
     transitivePeerDependencies:
       - '@solana/web3.js'
       - bufferutil
@@ -784,7 +784,7 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@blocto/sdk@0.5.4(aptos@1.17.0):
+  /@blocto/sdk@0.5.4(aptos@1.18.0):
     resolution: {integrity: sha512-VjzkT3tpz5YkjXNbx6Au4C0sphHeI+DRoTWMKX3N01U+XLl04/dn+Ao5Hsb4ZU7uS4Lw6mUjNfq+z3Fm5eZKaw==}
     peerDependencies:
       '@solana/web3.js': ^1.30.2
@@ -795,7 +795,7 @@ packages:
       aptos:
         optional: true
     dependencies:
-      aptos: 1.17.0
+      aptos: 1.18.0
       bs58: 5.0.0
       buffer: 6.0.3
       eip1193-provider: 1.0.1
@@ -1492,7 +1492,7 @@ packages:
     resolution: {integrity: sha512-t39g9V5zAiYZPGSahp4a0B4WM5IqxQJxr5ednv0f0l5amJZMPyOinFeZDgkLqTIzhe7yq6yIndKbqzPfdu1rng==}
     dependencies:
       '@mysten/sui.js': 0.13.0
-      aptos: 1.17.0
+      aptos: 1.18.0
       buffer: 6.0.3
     transitivePeerDependencies:
       - bufferutil
@@ -1505,12 +1505,12 @@ packages:
     resolution: {integrity: sha512-1rDa1jhEL8PUvTOu34s1HiVRhUV1wxRJe1SXrBEQGhSwY23WAlyHAiTTZszq61iK8mITPIw8f+W++AP6rBKLwg==}
     dependencies:
       '@aptos-labs/wallet-adapter-core': 2.2.0
-      aptos: 1.17.0
+      aptos: 1.18.0
     transitivePeerDependencies:
       - debug
     dev: false
 
-  /@haechi-labs/face-aptos-adapter-plugin@0.0.4(@aptos-labs/wallet-adapter-core@packages+wallet-adapter-core)(@haechi-labs/face-sdk@1.10.8)(@haechi-labs/face-types@1.10.8)(aptos@1.17.0):
+  /@haechi-labs/face-aptos-adapter-plugin@0.0.4(@aptos-labs/wallet-adapter-core@packages+wallet-adapter-core)(@haechi-labs/face-sdk@1.10.8)(@haechi-labs/face-types@1.10.8)(aptos@1.18.0):
     resolution: {integrity: sha512-5uI5Hg2rMiUUiHGuheK0/QDwJUruA0aruUReC8FO3NuBeZ5GyBisgdL6JrZC3kf7s/NZOrk33HMkVNPx6aEk8A==}
     peerDependencies:
       '@aptos-labs/wallet-adapter-core': ^2.2.0
@@ -1521,7 +1521,7 @@ packages:
       '@aptos-labs/wallet-adapter-core': link:packages/wallet-adapter-core
       '@haechi-labs/face-sdk': 1.10.8(@haechi-labs/face-types@1.10.8)(ethers@5.7.2)
       '@haechi-labs/face-types': 1.10.8(ethers@5.7.2)
-      aptos: 1.17.0
+      aptos: 1.18.0
     dev: false
 
   /@haechi-labs/face-sdk@1.10.8(@haechi-labs/face-types@1.10.8)(ethers@5.7.2):
@@ -1897,7 +1897,7 @@ packages:
     resolution: {integrity: sha512-B7z+Ff87L0cs4IMTF9+LCXGAWwQecihwN0QVI6NtJLWjV85A9MdlBC6oXiIC5J0ob3mtAMX2iOb2z2Xp37lxww==}
     dependencies:
       '@aptos-labs/wallet-adapter-core': 2.1.0
-      aptos: 1.17.0
+      aptos: 1.18.0
     transitivePeerDependencies:
       - debug
     dev: false
@@ -2275,7 +2275,7 @@ packages:
     resolution: {integrity: sha512-caDmoy3Az060YXHSmRibDDyUDd4YHGj87px+coJx2RSA7MSA5ufXXts4yNGH756WB32yP68FDaU4IZggJrlgAA==}
     dependencies:
       '@aptos-labs/wallet-adapter-core': 0.2.3
-      aptos: 1.17.0
+      aptos: 1.18.0
       bs58: 5.0.0
       js-sha3: 0.8.0
     transitivePeerDependencies:
@@ -2324,7 +2324,7 @@ packages:
     dependencies:
       '@aptos-labs/wallet-adapter-core': 0.2.3
       '@openblockhq/dappsdk': 5.0.7
-      aptos: 1.17.0
+      aptos: 1.18.0
       regenerator-runtime: 0.13.11
     transitivePeerDependencies:
       - bufferutil
@@ -2355,7 +2355,7 @@ packages:
     resolution: {integrity: sha512-w3to33CzjYvunWUbK86DNWmKK4YNbIpRuKZ8y47dq78k0v8NwwjcEatVknSS0k9TpbISCMSP06IMVPYk7GJ9iw==}
     dependencies:
       '@aptos-labs/wallet-adapter-core': 2.2.0
-      aptos: 1.17.0
+      aptos: 1.18.0
     transitivePeerDependencies:
       - debug
     dev: false
@@ -2422,7 +2422,7 @@ packages:
     resolution: {integrity: sha512-x32ocKBKQ6uBDhnRcChYzcSrjLxHfjLGuHn/A2vgks+qKl5sGAqMymmYNEtlV4y5z5mBdYMSDVBHnCHBmUolBQ==}
     dependencies:
       '@aptos-labs/wallet-adapter-core': 0.1.7
-      aptos: 1.17.0
+      aptos: 1.18.0
     transitivePeerDependencies:
       - debug
     dev: false
@@ -2524,7 +2524,7 @@ packages:
     resolution: {integrity: sha512-/ZFeAiR6PZ3t9UP3P3hjxzc433fi40dWnMX13oemzOITz2ISrW3hqYIVHHGyDuOFx4kQsVydBzArX+GXSCh8Rg==}
     dependencies:
       '@aptos-labs/wallet-adapter-core': 0.2.3
-      aptos: 1.17.0
+      aptos: 1.18.0
     transitivePeerDependencies:
       - debug
     dev: false
@@ -2537,7 +2537,7 @@ packages:
     resolution: {integrity: sha512-vlu5JuxqMpGMLanayNKQpTC87zn4NMRo3k96iVI+IdwEeyIgiJbbFq+XqUAezzQG/U88u4jv3vK2x7cbPnNFIw==}
     dependencies:
       '@aptos-labs/wallet-adapter-core': 0.1.7
-      aptos: 1.17.0
+      aptos: 1.18.0
     transitivePeerDependencies:
       - debug
     dev: false
@@ -2821,7 +2821,7 @@ packages:
     dependencies:
       '@aptos-labs/wallet-adapter-core': 2.2.0
       '@noble/hashes': 1.1.3
-      aptos: 1.17.0
+      aptos: 1.18.0
     transitivePeerDependencies:
       - debug
     dev: false
@@ -3009,8 +3009,8 @@ packages:
       picomatch: 2.3.1
     dev: true
 
-  /aptos@1.17.0:
-    resolution: {integrity: sha512-C+jNub8Sgg32F2t4TwYqMfHHWyuxLjNwoJGlRz5CTR52V4fTFjGvP6nlqE4MphwAWrIQnHKo93Thai7kNe3OvA==}
+  /aptos@1.18.0:
+    resolution: {integrity: sha512-T+mhfUEWWQtCG0zqoNETFgO11d/eauKucg1oEJC7GuCSY97FLADMrj0sQWzz94BlP+RiR8R+l0wE9BN75cLw2g==}
     engines: {node: '>=11.0.0'}
     dependencies:
       '@aptos-labs/aptos-client': 0.0.2
@@ -4760,7 +4760,7 @@ packages:
     dependencies:
       '@aptos-labs/wallet-adapter-core': 2.2.0
       '@fewcha/web3': 0.1.38
-      aptos: 1.17.0
+      aptos: 1.18.0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -6280,7 +6280,7 @@ packages:
     resolution: {integrity: sha512-N8xEClExInGpYoMO5IfMS34/MVz5BNCZAxwNh0nWamkuEJP48CI+D2BVIDbj0ESC7aINTq3zMSyCs7vxWrGa7Q==}
     dependencies:
       '@aptos-labs/wallet-adapter-core': 0.2.3
-      aptos: 1.17.0
+      aptos: 1.18.0
       msafe-wallet: 2.1.4
     transitivePeerDependencies:
       - debug
@@ -6614,7 +6614,7 @@ packages:
     resolution: {integrity: sha512-snhhP/qKXLg4foKsDVvy0Jus3H7o46L75aDCXiiSAonty2CnZe1+4cpB8azc7khaMgig+xj9gZbZXKmKtB+HqA==}
     dependencies:
       '@aptos-labs/wallet-adapter-core': 2.5.1
-      aptos: 1.17.0
+      aptos: 1.18.0
     transitivePeerDependencies:
       - debug
     dev: false
@@ -6757,8 +6757,8 @@ packages:
     hasBin: true
     dev: true
 
-  /prettier@3.0.1:
-    resolution: {integrity: sha512-fcOWSnnpCrovBsmFZIGIy9UqK2FaI7Hqax+DIO0A9UxeVoY4iweyaFjS5TavZN97Hfehph0nhsZnjlVKzEQSrQ==}
+  /prettier@3.0.2:
+    resolution: {integrity: sha512-o2YR9qtniXvwEZlOKbveKfDQVyqxbEIWn48Z8m3ZJjBjcCmUy3xZGIv+7AkaeuaTr6yPXJjwv07ZWlsWbEy1rQ==}
     engines: {node: '>=14'}
     hasBin: true
     dev: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,7 +47,7 @@ importers:
         version: 0.1.0
       '@haechi-labs/face-aptos-adapter-plugin':
         specifier: ^0.0.4
-        version: 0.0.4(@aptos-labs/wallet-adapter-core@packages+wallet-adapter-core)(@haechi-labs/face-sdk@1.10.8)(@haechi-labs/face-types@1.10.8)(aptos@1.18.0)
+        version: 0.0.4(@aptos-labs/wallet-adapter-core@packages+wallet-adapter-core)(@haechi-labs/face-sdk@1.10.8)(@haechi-labs/face-types@1.10.8)(aptos@1.19.0)
       '@haechi-labs/face-sdk':
         specifier: ^1.10.8
         version: 1.10.8(@haechi-labs/face-types@1.10.8)(ethers@5.7.2)
@@ -82,8 +82,8 @@ importers:
         specifier: ^5.1.2
         version: 5.1.4(react-dom@18.2.0)(react@18.2.0)
       aptos:
-        specifier: ^1.18.0
-        version: 1.18.0
+        specifier: ^1.19.0
+        version: 1.19.0
       ethers:
         specifier: ^5.7.2
         version: 5.7.2
@@ -195,8 +195,8 @@ importers:
   packages/wallet-adapter-core:
     dependencies:
       aptos:
-        specifier: ^1.18.0
-        version: 1.18.0
+        specifier: ^1.19.0
+        version: 1.19.0
       buffer:
         specifier: ^6.0.3
         version: 6.0.3
@@ -387,7 +387,7 @@ packages:
   /@aptos-labs/wallet-adapter-core@0.1.7:
     resolution: {integrity: sha512-g3HvX31kuFT5HqEe9Vh0ZgV1u0Otsfx54yeAwL7RO8CioBVBjYELhMsOYz0BOjecmAKhQ14G60VU8MqDyzYkIA==}
     dependencies:
-      aptos: 1.18.0
+      aptos: 1.19.0
       eventemitter3: 4.0.7
     transitivePeerDependencies:
       - debug
@@ -396,7 +396,7 @@ packages:
   /@aptos-labs/wallet-adapter-core@0.2.3:
     resolution: {integrity: sha512-QjUVRYSL05pxdjYo2bScxEZ8wi6ww4sf5mBW5w89F5mDfnDz2XEmZQYfQtV3bxoyqnNWPEjagTds4tKMXDhF1w==}
     dependencies:
-      aptos: 1.18.0
+      aptos: 1.19.0
       buffer: 6.0.3
       eventemitter3: 4.0.7
       tweetnacl: 1.0.3
@@ -407,7 +407,7 @@ packages:
   /@aptos-labs/wallet-adapter-core@2.1.0:
     resolution: {integrity: sha512-ZSCCsFt2heEh9IDaObbzw8EwqfzJGCWGBoaGouBtOYn2DVkh5R0P9xRj6ryF9cuO+tkfP+8KZmZ9m4c+xsJN2g==}
     dependencies:
-      aptos: 1.18.0
+      aptos: 1.19.0
       buffer: 6.0.3
       eventemitter3: 4.0.7
       tweetnacl: 1.0.3
@@ -418,7 +418,7 @@ packages:
   /@aptos-labs/wallet-adapter-core@2.2.0:
     resolution: {integrity: sha512-JL0zTXXoSQba1EDGqY5yTJxZVKMKwgMKZNA1JyV54s5loWzE2tinwg002EB+ONodkVmMhKbWnajCFFOgvgk+NQ==}
     dependencies:
-      aptos: 1.18.0
+      aptos: 1.19.0
       buffer: 6.0.3
       eventemitter3: 4.0.7
       tweetnacl: 1.0.3
@@ -429,7 +429,7 @@ packages:
   /@aptos-labs/wallet-adapter-core@2.5.1:
     resolution: {integrity: sha512-ny6CD47ivpnVV22reyN6LouDMVY9eccY3F3HscqfhAK+IqFm4C1C4BTFCoMQwPe9/yht2E/B6VuZBRIsYf7NvQ==}
     dependencies:
-      aptos: 1.18.0
+      aptos: 1.19.0
       buffer: 6.0.3
       eventemitter3: 4.0.7
       tweetnacl: 1.0.3
@@ -775,8 +775,8 @@ packages:
     resolution: {integrity: sha512-IyS/DdGLsnzmwc94X4W58CANoGjKhVq6HCnbElsm2+S04Z+BEBr0rWrpEjC35au/wzqCZTISx2D/LV54vxiSNw==}
     dependencies:
       '@aptos-labs/wallet-adapter-core': 2.5.1
-      '@blocto/sdk': 0.5.4(aptos@1.18.0)
-      aptos: 1.18.0
+      '@blocto/sdk': 0.5.4(aptos@1.19.0)
+      aptos: 1.19.0
     transitivePeerDependencies:
       - '@solana/web3.js'
       - bufferutil
@@ -784,7 +784,7 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@blocto/sdk@0.5.4(aptos@1.18.0):
+  /@blocto/sdk@0.5.4(aptos@1.19.0):
     resolution: {integrity: sha512-VjzkT3tpz5YkjXNbx6Au4C0sphHeI+DRoTWMKX3N01U+XLl04/dn+Ao5Hsb4ZU7uS4Lw6mUjNfq+z3Fm5eZKaw==}
     peerDependencies:
       '@solana/web3.js': ^1.30.2
@@ -795,7 +795,7 @@ packages:
       aptos:
         optional: true
     dependencies:
-      aptos: 1.18.0
+      aptos: 1.19.0
       bs58: 5.0.0
       buffer: 6.0.3
       eip1193-provider: 1.0.1
@@ -1492,7 +1492,7 @@ packages:
     resolution: {integrity: sha512-t39g9V5zAiYZPGSahp4a0B4WM5IqxQJxr5ednv0f0l5amJZMPyOinFeZDgkLqTIzhe7yq6yIndKbqzPfdu1rng==}
     dependencies:
       '@mysten/sui.js': 0.13.0
-      aptos: 1.18.0
+      aptos: 1.19.0
       buffer: 6.0.3
     transitivePeerDependencies:
       - bufferutil
@@ -1505,12 +1505,12 @@ packages:
     resolution: {integrity: sha512-1rDa1jhEL8PUvTOu34s1HiVRhUV1wxRJe1SXrBEQGhSwY23WAlyHAiTTZszq61iK8mITPIw8f+W++AP6rBKLwg==}
     dependencies:
       '@aptos-labs/wallet-adapter-core': 2.2.0
-      aptos: 1.18.0
+      aptos: 1.19.0
     transitivePeerDependencies:
       - debug
     dev: false
 
-  /@haechi-labs/face-aptos-adapter-plugin@0.0.4(@aptos-labs/wallet-adapter-core@packages+wallet-adapter-core)(@haechi-labs/face-sdk@1.10.8)(@haechi-labs/face-types@1.10.8)(aptos@1.18.0):
+  /@haechi-labs/face-aptos-adapter-plugin@0.0.4(@aptos-labs/wallet-adapter-core@packages+wallet-adapter-core)(@haechi-labs/face-sdk@1.10.8)(@haechi-labs/face-types@1.10.8)(aptos@1.19.0):
     resolution: {integrity: sha512-5uI5Hg2rMiUUiHGuheK0/QDwJUruA0aruUReC8FO3NuBeZ5GyBisgdL6JrZC3kf7s/NZOrk33HMkVNPx6aEk8A==}
     peerDependencies:
       '@aptos-labs/wallet-adapter-core': ^2.2.0
@@ -1521,7 +1521,7 @@ packages:
       '@aptos-labs/wallet-adapter-core': link:packages/wallet-adapter-core
       '@haechi-labs/face-sdk': 1.10.8(@haechi-labs/face-types@1.10.8)(ethers@5.7.2)
       '@haechi-labs/face-types': 1.10.8(ethers@5.7.2)
-      aptos: 1.18.0
+      aptos: 1.19.0
     dev: false
 
   /@haechi-labs/face-sdk@1.10.8(@haechi-labs/face-types@1.10.8)(ethers@5.7.2):
@@ -1897,7 +1897,7 @@ packages:
     resolution: {integrity: sha512-B7z+Ff87L0cs4IMTF9+LCXGAWwQecihwN0QVI6NtJLWjV85A9MdlBC6oXiIC5J0ob3mtAMX2iOb2z2Xp37lxww==}
     dependencies:
       '@aptos-labs/wallet-adapter-core': 2.1.0
-      aptos: 1.18.0
+      aptos: 1.19.0
     transitivePeerDependencies:
       - debug
     dev: false
@@ -2275,7 +2275,7 @@ packages:
     resolution: {integrity: sha512-caDmoy3Az060YXHSmRibDDyUDd4YHGj87px+coJx2RSA7MSA5ufXXts4yNGH756WB32yP68FDaU4IZggJrlgAA==}
     dependencies:
       '@aptos-labs/wallet-adapter-core': 0.2.3
-      aptos: 1.18.0
+      aptos: 1.19.0
       bs58: 5.0.0
       js-sha3: 0.8.0
     transitivePeerDependencies:
@@ -2324,7 +2324,7 @@ packages:
     dependencies:
       '@aptos-labs/wallet-adapter-core': 0.2.3
       '@openblockhq/dappsdk': 5.0.7
-      aptos: 1.18.0
+      aptos: 1.19.0
       regenerator-runtime: 0.13.11
     transitivePeerDependencies:
       - bufferutil
@@ -2355,7 +2355,7 @@ packages:
     resolution: {integrity: sha512-w3to33CzjYvunWUbK86DNWmKK4YNbIpRuKZ8y47dq78k0v8NwwjcEatVknSS0k9TpbISCMSP06IMVPYk7GJ9iw==}
     dependencies:
       '@aptos-labs/wallet-adapter-core': 2.2.0
-      aptos: 1.18.0
+      aptos: 1.19.0
     transitivePeerDependencies:
       - debug
     dev: false
@@ -2422,7 +2422,7 @@ packages:
     resolution: {integrity: sha512-x32ocKBKQ6uBDhnRcChYzcSrjLxHfjLGuHn/A2vgks+qKl5sGAqMymmYNEtlV4y5z5mBdYMSDVBHnCHBmUolBQ==}
     dependencies:
       '@aptos-labs/wallet-adapter-core': 0.1.7
-      aptos: 1.18.0
+      aptos: 1.19.0
     transitivePeerDependencies:
       - debug
     dev: false
@@ -2524,7 +2524,7 @@ packages:
     resolution: {integrity: sha512-/ZFeAiR6PZ3t9UP3P3hjxzc433fi40dWnMX13oemzOITz2ISrW3hqYIVHHGyDuOFx4kQsVydBzArX+GXSCh8Rg==}
     dependencies:
       '@aptos-labs/wallet-adapter-core': 0.2.3
-      aptos: 1.18.0
+      aptos: 1.19.0
     transitivePeerDependencies:
       - debug
     dev: false
@@ -2537,7 +2537,7 @@ packages:
     resolution: {integrity: sha512-vlu5JuxqMpGMLanayNKQpTC87zn4NMRo3k96iVI+IdwEeyIgiJbbFq+XqUAezzQG/U88u4jv3vK2x7cbPnNFIw==}
     dependencies:
       '@aptos-labs/wallet-adapter-core': 0.1.7
-      aptos: 1.18.0
+      aptos: 1.19.0
     transitivePeerDependencies:
       - debug
     dev: false
@@ -2821,7 +2821,7 @@ packages:
     dependencies:
       '@aptos-labs/wallet-adapter-core': 2.2.0
       '@noble/hashes': 1.1.3
-      aptos: 1.18.0
+      aptos: 1.19.0
     transitivePeerDependencies:
       - debug
     dev: false
@@ -3009,8 +3009,8 @@ packages:
       picomatch: 2.3.1
     dev: true
 
-  /aptos@1.18.0:
-    resolution: {integrity: sha512-T+mhfUEWWQtCG0zqoNETFgO11d/eauKucg1oEJC7GuCSY97FLADMrj0sQWzz94BlP+RiR8R+l0wE9BN75cLw2g==}
+  /aptos@1.19.0:
+    resolution: {integrity: sha512-IEvEfBFndhDce1HCMdow24Dh52sFFuRcgDpjTbH3Fi4TQpCD9s7zX+C5eCzTNiWQmEH/dfL2uDw5dbREGQxsbQ==}
     engines: {node: '>=11.0.0'}
     dependencies:
       '@aptos-labs/aptos-client': 0.0.2
@@ -4760,7 +4760,7 @@ packages:
     dependencies:
       '@aptos-labs/wallet-adapter-core': 2.2.0
       '@fewcha/web3': 0.1.38
-      aptos: 1.18.0
+      aptos: 1.19.0
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -6280,7 +6280,7 @@ packages:
     resolution: {integrity: sha512-N8xEClExInGpYoMO5IfMS34/MVz5BNCZAxwNh0nWamkuEJP48CI+D2BVIDbj0ESC7aINTq3zMSyCs7vxWrGa7Q==}
     dependencies:
       '@aptos-labs/wallet-adapter-core': 0.2.3
-      aptos: 1.18.0
+      aptos: 1.19.0
       msafe-wallet: 2.1.4
     transitivePeerDependencies:
       - debug
@@ -6614,7 +6614,7 @@ packages:
     resolution: {integrity: sha512-snhhP/qKXLg4foKsDVvy0Jus3H7o46L75aDCXiiSAonty2CnZe1+4cpB8azc7khaMgig+xj9gZbZXKmKtB+HqA==}
     dependencies:
       '@aptos-labs/wallet-adapter-core': 2.5.1
-      aptos: 1.18.0
+      aptos: 1.19.0
     transitivePeerDependencies:
       - debug
     dev: false


### PR DESCRIPTION
This is a first attempt at fee payer and multi agent transactions, though the model is not ideal.

1. Application creates a transaction (and has to set the expiration time etc. probably longer).
2. Calls `provider.signMultiTransaction()` to sign with a local key (or send to a backend to do similar)
3. Calls `signMultiAgentTransaction` to get the user's signature.
4. Converts the User's signature into an Authenticator (tbd, how should we handle this)
5. Application handles submitting the transaction.

This leaves a few issues:
1. User has no control over where the transaction is sent, though the app does
2. Application must properly handle submission and retrieval, which they basically didn't have to do any of before with the wallet adapter
3. Application has to do a lot more processing around the transaction, vs the simple "signAndSubmitTransaction" with a payload previously in the wallet adapter.
4. Simulation of results is usually not handled as easily as before where the transaction would be simulated and submitted by the wallet
5. Wallets now need to handle these multiple paths

Support via Petra wallet adapter added here:
https://github.com/aptos-labs/petra-plugin-wallet-adapter/pull/10

https://github.com/aptos-labs/aptos-core/issues/9896