### PR TITLE
Wallet adapter v2

### DIFF
--- a/.changeset/forty-avocados-hide.md
+++ b/.changeset/forty-avocados-hide.md
@@ -16,4 +16,4 @@ but with a full SDK V2 support for the dapp.
 - Convert wallet `SignedTransaction` response from `signTransaction()` to TS SDK V2 `AccountAuthenticator`
 - Demo app to demonstrate different trnsaction flows - single signer, sponsor and multi agent transactions
 - Reject promise on core and/or provider errors instead of just returning `false`
-- Use `@aptos-labs/ts-sdk@experimental` version `0.0.6`
+- Use `@aptos-labs/ts-sdk@experimental` version `0.0.7`

--- a/.changeset/forty-avocados-hide.md
+++ b/.changeset/forty-avocados-hide.md
@@ -1,0 +1,19 @@
+---
+"@aptos-labs/wallet-adapter-ant-design": major
+"@aptos-labs/wallet-adapter-mui-design": major
+"@aptos-labs/wallet-adapter-react": major
+"@aptos-labs/wallet-adapter-core": major
+"@aptos-labs/wallet-adapter-nextjs-example": major
+---
+
+Support TypeScript SDK V2. Fully compatible with existing SDK V1 and Wallet Adapter V1
+but with a full SDK V2 support for the dapp.
+
+- Add support for SDK V2 input types
+- `signAndSubmitTransaction()` accept only SDK V2 transaction input type
+- Implement a `submitTransaction()` function for multi signers transactions
+- `signTransaction()` to support both SDK V1 and V2 versions
+- Convert wallet `SignedTransaction` response from `signTransaction()` to TS SDK V2 `AccountAuthenticator`
+- Demo app to demonstrate different trnsaction flows - single signer, sponsor and multi agent transactions
+- Reject promise on core and/or provider errors instead of just returning `false`
+- Use `@aptos-labs/ts-sdk@experimental` version `0.0.6`

--- a/apps/nextjs-example/components/AppContext.tsx
+++ b/apps/nextjs-example/components/AppContext.tsx
@@ -20,14 +20,17 @@ import { AutoConnectProvider, useAutoConnect } from "./AutoConnectProvider";
 import { FC, ReactNode } from "react";
 import face from "../lib/faceInitialization";
 import { AlertProvider, useAlert } from "./AlertProvider";
-import {IdentityConnectWallet} from "@identity-connect/wallet-adapter-plugin";
+import { IdentityConnectWallet } from "@identity-connect/wallet-adapter-plugin";
 
 const WalletContextProvider: FC<{ children: ReactNode }> = ({ children }) => {
   const { autoConnect } = useAutoConnect();
   const { setErrorAlertMessage } = useAlert();
 
   const wallets = [
-    new IdentityConnectWallet("57fa42a9-29c6-4f1e-939c-4eefa36d9ff5", {networkName: NetworkName.Testnet}),
+    // TODO IdentityConnectWallet and BloctoWallet to use Network enum from @aptos-labs/ts-sdk
+    new IdentityConnectWallet("57fa42a9-29c6-4f1e-939c-4eefa36d9ff5", {
+      networkName: NetworkName.Testnet,
+    }),
     // Blocto supports Testnet/Mainnet for now.
     new BloctoWallet({
       network: NetworkName.Testnet,

--- a/apps/nextjs-example/components/Button.tsx
+++ b/apps/nextjs-example/components/Button.tsx
@@ -1,0 +1,19 @@
+export default function Button(props: {
+  color: string | undefined;
+  onClick: () => void;
+  disabled: boolean;
+  message: string;
+}) {
+  const { color, onClick, disabled, message } = props;
+  return (
+    <button
+      className={`bg-${color}-500 text-white font-bold py-2 px-4 rounded mr-4 ${
+        disabled ? "opacity-50 cursor-not-allowed" : `hover:bg-${color}-700`
+      }`}
+      onClick={onClick}
+      disabled={disabled}
+    >
+      {message}
+    </button>
+  );
+}

--- a/apps/nextjs-example/components/Col.tsx
+++ b/apps/nextjs-example/components/Col.tsx
@@ -1,0 +1,15 @@
+export default function Col(props: {
+  title?: boolean;
+  border?: boolean;
+  children?: React.ReactNode;
+}) {
+  return (
+    <td
+      className={`px-8 py-4 ${props.border ? "border-t" : ""} w-${
+        props.title ? "1/4" : "3/4"
+      }`}
+    >
+      {props.children}
+    </td>
+  );
+}

--- a/apps/nextjs-example/components/Row.tsx
+++ b/apps/nextjs-example/components/Row.tsx
@@ -1,0 +1,3 @@
+export default function Row(props: { children?: React.ReactNode }) {
+  return <tr>{props.children}</tr>;
+}

--- a/apps/nextjs-example/components/transactionFlow/MultiAgent.tsx
+++ b/apps/nextjs-example/components/transactionFlow/MultiAgent.tsx
@@ -46,7 +46,7 @@ export default function MultiAgentTransaction({
     const generate = async (): Promise<AnyRawTransaction> => {
       const transactionToSign = await aptosClient(
         network?.name.toLowerCase()
-      ).generateTransaction({
+      ).build.multiAgentTransaction({
         sender: account.address,
         secondarySignerAddresses: [secondarySigner.accountAddress],
         data: {

--- a/apps/nextjs-example/components/transactionFlow/MultiAgent.tsx
+++ b/apps/nextjs-example/components/transactionFlow/MultiAgent.tsx
@@ -1,0 +1,179 @@
+import {
+  Account,
+  AccountAuthenticator,
+  AnyRawTransaction,
+} from "@aptos-labs/ts-sdk";
+import { useWallet } from "@aptos-labs/wallet-adapter-react";
+
+import { useState, useEffect } from "react";
+import { aptosClient } from "../../utils";
+import { useAlert } from "../AlertProvider";
+import Button from "../Button";
+import Col from "../Col";
+import Row from "../Row";
+export const APTOS_COIN = "0x1::aptos_coin::AptosCoin";
+type MultiAgentTransactionProps = {
+  isSendableNetwork: (connected: boolean, network?: string) => boolean;
+};
+
+export default function MultiAgentTransaction({
+  isSendableNetwork,
+}: MultiAgentTransactionProps) {
+  const { connected, account, network, signTransaction, submitTransaction } =
+    useWallet();
+
+  const [secondarySignerAccount, setSecondarySignerAccount] =
+    useState<Account>();
+  const [transactionToSubmit, setTransactionToSubmit] =
+    useState<AnyRawTransaction | null>(null);
+  const { setSuccessAlertHash } = useAlert();
+
+  const [senderAuthenticator, setSenderAuthenticator] =
+    useState<AccountAuthenticator>();
+  const [secondarySignerAuthenticator, setSecondarySignerAuthenticator] =
+    useState<AccountAuthenticator>();
+
+  let sendable = isSendableNetwork(connected, network?.name);
+
+  useEffect(() => {
+    if (!sendable) return;
+    if (!account) return;
+    if (!network) return;
+
+    const secondarySigner = Account.generate();
+
+    // Generate a raw transaction using the SDK
+    const generate = async (): Promise<AnyRawTransaction> => {
+      const transactionToSign = await aptosClient(
+        network?.name.toLowerCase()
+      ).generateTransaction({
+        sender: account.address,
+        secondarySignerAddresses: [secondarySigner.accountAddress],
+        data: {
+          function: "0x1::coin::transfer",
+          typeArguments: [APTOS_COIN],
+          functionArguments: [account.address, 1], // 1 is in Octas
+        },
+      });
+      return transactionToSign;
+    };
+
+    // Fund secondary signer account to create it on chain
+    const fundSecondarySigner = async () => {
+      await aptosClient(network.name.toLowerCase()).fundAccount({
+        accountAddress: secondarySigner.accountAddress.toString(),
+        amount: 100_000_000,
+      });
+    };
+
+    // Fund current connected account to create it on chain
+    const fundCurrentAccount = async () => {
+      await aptosClient(network.name.toLowerCase()).fundAccount({
+        accountAddress: account.address,
+        amount: 100_000_000,
+      });
+    };
+
+    // We fund the secondary signer account to create it on chain
+    // We fund the current connected account to create it on chain
+    // Then we generate the transaction with the current connected account
+    // as the sender and the secondary signer account
+    fundSecondarySigner().then(() => {
+      setSecondarySignerAccount(secondarySigner);
+      fundCurrentAccount().then(() => {
+        generate().then((transactionToSign) =>
+          setTransactionToSubmit(transactionToSign)
+        );
+      });
+    });
+  }, [network, account, sendable]);
+
+  const onSenderSignTransaction = async () => {
+    if (!transactionToSubmit) {
+      throw new Error("No Transaction to sign");
+    }
+    try {
+      const authenticator = await signTransaction(transactionToSubmit);
+      setSenderAuthenticator(authenticator);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const onSecondarySignerSignTransaction = async () => {
+    if (!transactionToSubmit) {
+      throw new Error("No Transaction to sign");
+    }
+    try {
+      const authenticator = await signTransaction(transactionToSubmit);
+      setSecondarySignerAuthenticator(authenticator);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const onSubmitTransaction = async () => {
+    if (!transactionToSubmit) {
+      throw new Error("No Transaction to sign");
+    }
+    if (!senderAuthenticator) {
+      throw new Error("No senderAuthenticator");
+    }
+    if (!secondarySignerAuthenticator) {
+      throw new Error("No secondarySignerAuthenticator");
+    }
+    try {
+      const response = await submitTransaction({
+        transaction: transactionToSubmit,
+        senderAuthenticator: senderAuthenticator,
+        additionalSignersAuthenticators: [secondarySignerAuthenticator],
+      });
+      setSuccessAlertHash(response.hash, network?.name);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  return (
+    <>
+      <Row>
+        <Col title={true} border={true}>
+          <h3>Multi Agent Transaction Flow</h3>
+        </Col>
+        <Col border={true}>
+          <Button
+            color={"blue"}
+            onClick={onSenderSignTransaction}
+            disabled={!sendable || !transactionToSubmit}
+            message={"Sign as sender"}
+          />
+
+          <Button
+            color={"blue"}
+            onClick={onSecondarySignerSignTransaction}
+            disabled={!sendable || !senderAuthenticator}
+            message={"Sign as secondary signer"}
+          />
+          <Button
+            color={"blue"}
+            onClick={onSubmitTransaction}
+            disabled={!sendable || !secondarySignerAuthenticator}
+            message={"Submit transaction"}
+          />
+        </Col>
+      </Row>
+      {secondarySignerAccount && secondarySignerAuthenticator && (
+        <Row>
+          <Col title={true}>
+            <h3>Secondary Signer details</h3>
+          </Col>
+          <Col>
+            <p>Private Key: {secondarySignerAccount.privateKey.toString()}</p>
+            <p>Public Key: {secondarySignerAccount.publicKey.toString()}</p>
+            <p>Address: {secondarySignerAccount.accountAddress.toString()}</p>
+          </Col>
+        </Row>
+      )}
+    </>
+  );
+}

--- a/apps/nextjs-example/components/transactionFlow/SingleSigner.tsx
+++ b/apps/nextjs-example/components/transactionFlow/SingleSigner.tsx
@@ -113,7 +113,7 @@ export default function SingleSignerTransaction({
     try {
       const transactionToSign = await aptosClient(
         network?.name.toLowerCase()
-      ).generateTransaction({
+      ).build.transaction({
         sender: account.address,
         data: {
           function: "0x1::coin::transfer",

--- a/apps/nextjs-example/components/transactionFlow/SingleSigner.tsx
+++ b/apps/nextjs-example/components/transactionFlow/SingleSigner.tsx
@@ -1,0 +1,177 @@
+import { parseTypeTag, AccountAddress, U64 } from "@aptos-labs/ts-sdk";
+import { useWallet } from "@aptos-labs/wallet-adapter-react";
+
+import { aptosClient } from "../../utils";
+import { useAlert } from "../AlertProvider";
+import Button from "../Button";
+import Col from "../Col";
+import Row from "../Row";
+export const APTOS_COIN = "0x1::aptos_coin::AptosCoin";
+type SingleSignerTransactionProps = {
+  isSendableNetwork: (connected: boolean, network?: string) => boolean;
+};
+
+export default function SingleSignerTransaction({
+  isSendableNetwork,
+}: SingleSignerTransactionProps) {
+  const { setSuccessAlertMessage, setSuccessAlertHash } = useAlert();
+
+  const {
+    connected,
+    account,
+    network,
+    signAndSubmitTransaction,
+    signMessageAndVerify,
+    signMessage,
+    signTransaction,
+  } = useWallet();
+  let sendable = isSendableNetwork(connected, network?.name);
+
+  const onSignMessageAndVerify = async () => {
+    const payload = {
+      message: "Hello from Aptos Wallet Adapter",
+      nonce: Math.random().toString(16),
+    };
+    const response = await signMessageAndVerify(payload);
+    setSuccessAlertMessage(
+      JSON.stringify({ onSignMessageAndVerify: response })
+    );
+  };
+
+  const onSignMessage = async () => {
+    const payload = {
+      message: "Hello from Aptos Wallet Adapter",
+      nonce: Math.random().toString(16),
+    };
+    const response = await signMessage(payload);
+    setSuccessAlertMessage(
+      JSON.stringify({ onSignMessageAndVerify: response })
+    );
+  };
+
+  const onSignAndSubmitTransaction = async () => {
+    if (!account) return;
+
+    try {
+      const response = await signAndSubmitTransaction({
+        sender: account.address,
+        data: {
+          function: "0x1::coin::transfer",
+          typeArguments: [APTOS_COIN],
+          functionArguments: [account.address, 1], // 1 is in Octas
+        },
+      });
+      console.log("response", response);
+      await aptosClient(network?.name.toLowerCase()).waitForTransaction({
+        transactionHash: response.hash,
+      });
+      setSuccessAlertHash(response.hash, network?.name);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const onSignAndSubmitBCSTransaction = async () => {
+    if (!account) return;
+
+    try {
+      const response = await signAndSubmitTransaction({
+        sender: account.address,
+        data: {
+          function: "0x1::coin::transfer",
+          typeArguments: [parseTypeTag(APTOS_COIN)],
+          functionArguments: [AccountAddress.from(account.address), new U64(1)], // 1 is in Octas
+        },
+      });
+      await aptosClient(network?.name.toLowerCase()).waitForTransaction({
+        transactionHash: response.hash,
+      });
+      setSuccessAlertHash(response.hash, network?.name);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const onSignTransaction = async () => {
+    try {
+      const payload = {
+        type: "entry_function_payload",
+        function: "0x1::coin::transfer",
+        type_arguments: ["0x1::aptos_coin::AptosCoin"],
+        arguments: [account?.address, 1], // 1 is in Octas
+      };
+      const response = await signTransaction(payload);
+      setSuccessAlertMessage(JSON.stringify(response));
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const onSignTransactionV2 = async () => {
+    if (!account) return;
+
+    try {
+      const transactionToSign = await aptosClient(
+        network?.name.toLowerCase()
+      ).generateTransaction({
+        sender: account.address,
+        data: {
+          function: "0x1::coin::transfer",
+          typeArguments: [APTOS_COIN],
+          functionArguments: [account.address, 1], // 1 is in Octas
+        },
+      });
+      const response = await signTransaction(transactionToSign);
+      setSuccessAlertMessage(JSON.stringify(response));
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  return (
+    <Row>
+      <Col title={true} border={true}>
+        <h3>Single Signer Flow</h3>
+      </Col>
+      <Col border={true}>
+        <Button
+          color={"blue"}
+          onClick={onSignAndSubmitTransaction}
+          disabled={!sendable}
+          message={"Sign and submit transaction"}
+        />
+        <Button
+          color={"blue"}
+          onClick={onSignAndSubmitBCSTransaction}
+          disabled={!sendable}
+          message={"Sign and submit BCS transaction"}
+        />
+        <Button
+          color={"blue"}
+          onClick={onSignTransaction}
+          disabled={!sendable}
+          message={"Sign transaction"}
+        />
+        <Button
+          color={"blue"}
+          onClick={onSignTransactionV2}
+          disabled={!sendable}
+          message={"Sign transaction V2"}
+        />
+
+        <Button
+          color={"blue"}
+          onClick={onSignMessage}
+          disabled={!sendable}
+          message={"Sign message"}
+        />
+        <Button
+          color={"blue"}
+          onClick={onSignMessageAndVerify}
+          disabled={!sendable}
+          message={"Sign message and verify"}
+        />
+      </Col>
+    </Row>
+  );
+}

--- a/apps/nextjs-example/components/transactionFlow/Sponsor.tsx
+++ b/apps/nextjs-example/components/transactionFlow/Sponsor.tsx
@@ -1,0 +1,134 @@
+import { AccountAuthenticator, AnyRawTransaction } from "@aptos-labs/ts-sdk";
+import { useWallet } from "@aptos-labs/wallet-adapter-react";
+import { useState, useEffect } from "react";
+import { aptosClient } from "../../utils";
+import { useAlert } from "../AlertProvider";
+import Button from "../Button";
+import Col from "../Col";
+import Row from "../Row";
+export const APTOS_COIN = "0x1::aptos_coin::AptosCoin";
+type SponsorTransactionProps = {
+  isSendableNetwork: (connected: boolean, network?: string) => boolean;
+};
+
+export default function SponsorTransaction({
+  isSendableNetwork,
+}: SponsorTransactionProps) {
+  const { connected, account, network, signTransaction, submitTransaction } =
+    useWallet();
+  const [transactionToSubmit, setTransactionToSubmit] =
+    useState<AnyRawTransaction | null>(null);
+  const { setSuccessAlertHash } = useAlert();
+
+  const [senderAuthenticator, setSenderAuthenticator] =
+    useState<AccountAuthenticator>();
+  const [feepayerAuthenticator, setFeepayerAuthenticator] =
+    useState<AccountAuthenticator>();
+
+  let sendable = isSendableNetwork(connected, network?.name);
+
+  useEffect(() => {
+    if (!sendable) return;
+    if (!account) return;
+    if (!network) return;
+
+    // Generate a raw transaction using the SDK
+    const generate = async (): Promise<AnyRawTransaction> => {
+      const transactionToSign = await aptosClient(
+        network?.name.toLowerCase()
+      ).generateTransaction({
+        sender: account.address,
+        hasFeePayer: true,
+        data: {
+          function: "0x1::coin::transfer",
+          typeArguments: [APTOS_COIN],
+          functionArguments: [account.address, 1], // 1 is in Octas
+        },
+      });
+      return transactionToSign;
+    };
+
+    // Fund current connected account to create it on chain
+    const fundCurrentAccount = async () => {
+      await aptosClient(network.name.toLowerCase()).fundAccount({
+        accountAddress: account.address,
+        amount: 100_000_000,
+      });
+    };
+
+    // We fund the current connected account to create it on chain
+    // Then we generate the transaction with the current connected account
+    // as the sender
+    fundCurrentAccount().then(() => {
+      generate().then((transactionToSign) =>
+        setTransactionToSubmit(transactionToSign)
+      );
+    });
+  }, [network, account, sendable]);
+
+  const onSignTransaction = async (asSponsor?: boolean) => {
+    if (!transactionToSubmit) {
+      throw new Error("No Transaction to sign");
+    }
+    try {
+      const authenticator = await signTransaction(transactionToSubmit);
+      if (asSponsor) {
+        setFeepayerAuthenticator(authenticator);
+      } else {
+        setSenderAuthenticator(authenticator);
+      }
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const onSubmitTransaction = async () => {
+    if (!transactionToSubmit) {
+      throw new Error("No Transaction to sign");
+    }
+    if (!senderAuthenticator) {
+      throw new Error("No senderAuthenticator");
+    }
+    if (!feepayerAuthenticator) {
+      throw new Error("No feepayerAuthenticator");
+    }
+    try {
+      const response = await submitTransaction({
+        transaction: transactionToSubmit,
+        senderAuthenticator: senderAuthenticator,
+        feePayerAuthenticator: feepayerAuthenticator,
+      });
+      setSuccessAlertHash(response.hash, network?.name);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  return (
+    <Row>
+      <Col title={true} border={true}>
+        <h3>Sponsor Transaction Flow</h3>
+      </Col>
+      <Col border={true}>
+        <Button
+          color={"blue"}
+          onClick={() => onSignTransaction(false)}
+          disabled={!sendable || !transactionToSubmit}
+          message={"Sign as Sender"}
+        />
+        <Button
+          color={"blue"}
+          onClick={() => onSignTransaction(true)}
+          disabled={!sendable || !senderAuthenticator}
+          message={"Sign as Sponsor"}
+        />
+        <Button
+          color={"blue"}
+          onClick={onSubmitTransaction}
+          disabled={!sendable || !feepayerAuthenticator}
+          message={"Submit transaction"}
+        />
+      </Col>
+    </Row>
+  );
+}

--- a/apps/nextjs-example/components/transactionFlow/Sponsor.tsx
+++ b/apps/nextjs-example/components/transactionFlow/Sponsor.tsx
@@ -71,7 +71,10 @@ export default function SponsorTransaction({
       throw new Error("No Transaction to sign");
     }
     try {
-      const authenticator = await signTransaction(transactionToSubmit);
+      const authenticator = await signTransaction(
+        transactionToSubmit,
+        asSponsor
+      );
       if (asSponsor) {
         setFeepayerAuthenticator(authenticator);
       } else {

--- a/apps/nextjs-example/components/transactionFlow/Sponsor.tsx
+++ b/apps/nextjs-example/components/transactionFlow/Sponsor.tsx
@@ -36,9 +36,9 @@ export default function SponsorTransaction({
     const generate = async (): Promise<AnyRawTransaction> => {
       const transactionToSign = await aptosClient(
         network?.name.toLowerCase()
-      ).generateTransaction({
+      ).build.transaction({
         sender: account.address,
-        hasFeePayer: true,
+        withFeePayer: true,
         data: {
           function: "0x1::coin::transfer",
           typeArguments: [APTOS_COIN],

--- a/apps/nextjs-example/package.json
+++ b/apps/nextjs-example/package.json
@@ -11,7 +11,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@aptos-labs/ts-sdk": "^0.0.6",
+    "@aptos-labs/ts-sdk": "^0.0.7",
     "@aptos-labs/wallet-adapter-ant-design": "workspace:*",
     "@aptos-labs/wallet-adapter-core": "workspace:*",
     "@aptos-labs/wallet-adapter-mui-design": "workspace:*",

--- a/apps/nextjs-example/package.json
+++ b/apps/nextjs-example/package.json
@@ -11,7 +11,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@aptos-labs/ts-sdk": "^0.0.5",
+    "@aptos-labs/ts-sdk": "^0.0.6",
     "@aptos-labs/wallet-adapter-ant-design": "workspace:*",
     "@aptos-labs/wallet-adapter-core": "workspace:*",
     "@aptos-labs/wallet-adapter-mui-design": "workspace:*",

--- a/apps/nextjs-example/package.json
+++ b/apps/nextjs-example/package.json
@@ -11,6 +11,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@aptos-labs/ts-sdk": "^0.0.5",
     "@aptos-labs/wallet-adapter-ant-design": "workspace:*",
     "@aptos-labs/wallet-adapter-core": "workspace:*",
     "@aptos-labs/wallet-adapter-mui-design": "workspace:*",
@@ -31,8 +32,6 @@
     "@trustwallet/aptos-wallet-adapter": "^0.1.6",
     "@welldone-studio/aptos-wallet-adapter": "^0.1.4",
     "antd": "^5.1.2",
-    "aptos": "^1.19.0",
-    "@aptos-labs/ts-sdk": "^0.0.3",
     "ethers": "^5.7.2",
     "fewcha-plugin-wallet-adapter": "^0.1.3",
     "next": "13.0.0",

--- a/apps/nextjs-example/pages/index.tsx
+++ b/apps/nextjs-example/pages/index.tsx
@@ -1,534 +1,286 @@
-import {
-    APTOS_COIN,
-    AptosAccount,
-    AptosClient,
-    BCS,
-    CoinClient,
-    FaucetClient, HexString,
-    Network,
-    Provider,
-    TxnBuilderTypes,
-    Types
-} from "aptos";
-import { AccountAddress, U64, parseTypeTag } from "@aptos-labs/ts-sdk";
-import {NetworkName, useWallet} from "@aptos-labs/wallet-adapter-react";
-import {WalletConnector} from "@aptos-labs/wallet-adapter-mui-design";
+import { useWallet } from "@aptos-labs/wallet-adapter-react";
+import { WalletConnector } from "@aptos-labs/wallet-adapter-mui-design";
 import dynamic from "next/dynamic";
 import Image from "next/image";
-import {useAutoConnect} from "../components/AutoConnectProvider";
-import {useAlert} from "../components/AlertProvider";
-import {AccountInfo, NetworkInfo, WalletInfo} from "@aptos-labs/wallet-adapter-core";
-import {useState} from "react";
-
-const FEE_PAYER_ACCOUNT_KEY = "feePayerAccountPrivateKey";
-const DO_NOTHING_SCRIPT = "a11ceb0b0600000001050001000000000102";
+import { useAutoConnect } from "../components/AutoConnectProvider";
+import {
+  AccountInfo,
+  NetworkInfo,
+  WalletInfo,
+} from "@aptos-labs/wallet-adapter-core";
+import SingleSignerTransaction from "../components/transactionFlow/SingleSigner";
+import SponsorTransaction from "../components/transactionFlow/Sponsor";
+import MultiAgentTransaction from "../components/transactionFlow/MultiAgent";
+import Row from "../components/Row";
+import Col from "../components/Col";
+import { Network } from "@aptos-labs/ts-sdk";
 
 const WalletButtons = dynamic(() => import("../components/WalletButtons"), {
-    suspense: false,
-    ssr: false,
+  suspense: false,
+  ssr: false,
 });
 
 const WalletSelectorAntDesign = dynamic(
-    () => import("../components/WalletSelectorAntDesign"),
-    {
-        suspense: false,
-        ssr: false,
-    }
+  () => import("../components/WalletSelectorAntDesign"),
+  {
+    suspense: false,
+    ssr: false,
+  }
 );
 
-const aptosClient = (network?: string) => {
-    if (network === NetworkName.Devnet.toLowerCase()) {
-        return DEVNET_CLIENT;
-    } else if (network === NetworkName.Testnet.toLowerCase()) {
-        return TESTNET_CLIENT;
-    } else if (network === NetworkName.Mainnet.toLowerCase()) {
-        throw new Error("Please use devnet or testnet for testing");
-    } else {
-        throw new Error(`Unknown network: ${network}`);
-    }
-}
-
-const faucet = (network?: string) => {
-    if (network === NetworkName.Devnet.toLowerCase()) {
-        return DEVNET_FAUCET;
-    } else if (network === NetworkName.Testnet.toLowerCase()) {
-        return TESTNET_FAUCET;
-    } else if (network === NetworkName.Mainnet.toLowerCase()) {
-        throw new Error("Please use devnet or testnet for testing");
-    } else {
-        throw new Error(`Unknown network: ${network}`);
-    }
-}
-
-const DEVNET_CLIENT = new Provider(Network.DEVNET);
-const TESTNET_CLIENT = new Provider(Network.TESTNET);
-const DEVNET_FAUCET = new FaucetClient("https://fullnode.devnet.aptoslabs.com", "https://faucet.devnet.aptoslabs.com");
-const TESTNET_FAUCET = new FaucetClient("https://fullnode.testnet.aptoslabs.com", "https://faucet.testnet.aptoslabs.com");
-
 const isSendableNetwork = (connected: boolean, network?: string): boolean => {
-    return connected && (network?.toLowerCase() === NetworkName.Devnet.toLowerCase()
-        || network?.toLowerCase() === NetworkName.Testnet.toLowerCase())
-}
+  return (
+    connected &&
+    (network?.toLowerCase() === Network.DEVNET.toLowerCase() ||
+      network?.toLowerCase() === Network.TESTNET.toLowerCase())
+  );
+};
 
 export default function App() {
-    const {
-        account,
-        connected,
-        network,
-        wallet,
-    } = useWallet();
+  const { account, connected, network, wallet } = useWallet();
 
-    return (
-        <div>
-            <h1 className="flex justify-center mt-2 mb-4 text-4xl font-extrabold tracking-tight leading-none text-black">
-                Aptos Wallet Adapter Tester ({network?.name ?? ""})
-            </h1>
-            <table className="table-auto w-full border-separate border-spacing-y-8 shadow-lg bg-white border-separate">
-                <tbody>
-                <WalletSelect/>
-                <AutoConnect/>
-                {connected && <Row><Col title={true} border={true}>
-                    <h3><b>Wallet Information</b></h3>
-                </Col>
-                    <Col border={true}/>
-                </Row>}
-                {connected && <WalletProps wallet={wallet} network={network} account={account}/>}
-                {connected && <RequiredFunctionality/>}
-                {connected && <OptionalFunctionality/>}
-                </tbody>
-            </table>
-        </div>
-    );
+  return (
+    <div>
+      <h1 className="flex justify-center mt-2 mb-4 text-4xl font-extrabold tracking-tight leading-none text-black">
+        Aptos Wallet Adapter Tester ({network?.name ?? ""})
+      </h1>
+      <table className="table-auto w-full border-separate border-spacing-y-8 shadow-lg bg-white border-separate">
+        <tbody>
+          <WalletSelect />
+          <AutoConnect />
+          {connected && (
+            <Row>
+              <Col title={true} border={true}>
+                <h3>
+                  <b>Wallet Information</b>
+                </h3>
+              </Col>
+              <Col border={true} />
+            </Row>
+          )}
+          {connected && (
+            <WalletProps wallet={wallet} network={network} account={account} />
+          )}
+          {connected && !isSendableNetwork(connected, network?.name) && (
+            <tr>
+              <Col title={true}></Col>
+              <Col>
+                <p style={{ color: "red" }}>
+                  Transactions only work with Devnet or Testnet networks
+                </p>
+              </Col>
+            </tr>
+          )}
+          {connected && (
+            <SingleSignerTransaction isSendableNetwork={isSendableNetwork} />
+          )}
+          {connected && (
+            <SponsorTransaction isSendableNetwork={isSendableNetwork} />
+          )}
+          {connected && (
+            <MultiAgentTransaction isSendableNetwork={isSendableNetwork} />
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
 }
 
 function WalletSelect() {
-    return <>
-        <Row>
-            <Col title={true} border={true}>
-                <h2><b>Wallet Select</b></h2>
-            </Col>
-            <Col border={true}/>
-        </Row>
-        <Row>
-            <Col title={true}>
-                <h3>Connect a Wallet</h3>
-            </Col>
-            <Col>
-                <WalletButtons/>
-            </Col>
-        </Row>
-        <Row>
-            <Col title={true}>
-                <h3>Ant Design</h3>
-            </Col>
-            <Col>
-                <WalletSelectorAntDesign/>
-            </Col>
-        </Row>
-        <Row>
-            <Col title={true}>
-                <h3>MUI Design</h3>
-            </Col>
-            <Col>
-                <WalletConnector/>
-            </Col>
-        </Row>
-    </>;
+  return (
+    <>
+      <Row>
+        <Col title={true} border={true}>
+          <h2>
+            <b>Wallet Select</b>
+          </h2>
+        </Col>
+        <Col border={true} />
+      </Row>
+      <Row>
+        <Col title={true}>
+          <h3>Connect a Wallet</h3>
+        </Col>
+        <Col>
+          <WalletButtons />
+        </Col>
+      </Row>
+      <Row>
+        <Col title={true}>
+          <h3>Ant Design</h3>
+        </Col>
+        <Col>
+          <WalletSelectorAntDesign />
+        </Col>
+      </Row>
+      <Row>
+        <Col title={true}>
+          <h3>MUI Design</h3>
+        </Col>
+        <Col>
+          <WalletConnector />
+        </Col>
+      </Row>
+    </>
+  );
 }
 
 // TODO: Verify public key matches account
-function WalletProps(props: { account: AccountInfo | null, network: NetworkInfo | null, wallet: WalletInfo | null }) {
-    const {account, network, wallet} = props;
-    const isValidNetworkName = () => {
-        // TODO: Do we allow non lowercase
-        return Object.values<string | undefined>(NetworkName).includes(props.network?.name);
-    }
+function WalletProps(props: {
+  account: AccountInfo | null;
+  network: NetworkInfo | null;
+  wallet: WalletInfo | null;
+}) {
+  const { account, network, wallet } = props;
+  const isValidNetworkName = () => {
+    // TODO: Do we allow non lowercase
+    return Object.values<string | undefined>(Network).includes(
+      props.network?.name
+    );
+  };
 
-    return <>
-        <tr>
-            <Col title={true}>
-                <h3>Wallet Name</h3>
-            </Col>
-            <Col>
-                <b>Icon: </b>
-                {props.wallet && (
-                    <Image
-                        src={wallet?.icon ?? ""}
-                        alt={wallet?.name ?? ""}
-                        width={25}
-                        height={25}
-                    />
-                )}
-                <b> Name: </b>
-                {wallet?.name}
-                <b> URL: </b>
-                <a
-                    target="_blank"
-                    className="text-sky-600"
-                    rel="noreferrer"
-                    href={wallet?.url}
-                >
-                    {wallet?.url}
-                </a>
-            </Col>
-        </tr>
-        <Row>
-            <Col title={true}>
-                <h3>Account Info</h3>
-            </Col>
-            <Col>
-                <DisplayRequiredValue name={"Address"} isCorrect={!!account?.address}
-                                      value={account?.address}/>
-                <DisplayRequiredValue name={"Public key"} isCorrect={!!account?.publicKey}
-                                      value={account?.publicKey?.toString()}/>
-                <DisplayOptionalValue name={"ANS Name (only if attached)"} value={account?.ansName}/>
-                <DisplayOptionalValue name={"Min keys required (only for multisig)"}
-                                      value={account?.minKeysRequired?.toString()}/>
-            </Col>
-        </Row>
-        <Row>
-            <Col title={true}>
-                <h3>Network Info</h3>
-            </Col>
-            <Col>
-                <DisplayRequiredValue name={"Network Name"} isCorrect={isValidNetworkName()} value={network?.name}
-                                      expected={"one of: " + Object.values<string>(NetworkName).join(", ")}/>
-                <DisplayOptionalValue name={"URL"} value={network?.url}/>
-                <DisplayOptionalValue name={"ChainId"} value={network?.chainId}/>
-            </Col>
-        </Row>
-    </>;
+  return (
+    <>
+      <tr>
+        <Col title={true}>
+          <h3>Wallet Name</h3>
+        </Col>
+        <Col>
+          <b>Icon: </b>
+          {props.wallet && (
+            <Image
+              src={wallet?.icon ?? ""}
+              alt={wallet?.name ?? ""}
+              width={25}
+              height={25}
+            />
+          )}
+          <b> Name: </b>
+          {wallet?.name}
+          <b> URL: </b>
+          <a
+            target="_blank"
+            className="text-sky-600"
+            rel="noreferrer"
+            href={wallet?.url}
+          >
+            {wallet?.url}
+          </a>
+        </Col>
+      </tr>
+      <Row>
+        <Col title={true}>
+          <h3>Account Info</h3>
+        </Col>
+        <Col>
+          <DisplayRequiredValue
+            name={"Address"}
+            isCorrect={!!account?.address}
+            value={account?.address}
+          />
+          <DisplayRequiredValue
+            name={"Public key"}
+            isCorrect={!!account?.publicKey}
+            value={account?.publicKey?.toString()}
+          />
+          <DisplayOptionalValue
+            name={"ANS Name (only if attached)"}
+            value={account?.ansName}
+          />
+          <DisplayOptionalValue
+            name={"Min keys required (only for multisig)"}
+            value={account?.minKeysRequired?.toString()}
+          />
+        </Col>
+      </Row>
+      <Row>
+        <Col title={true}>
+          <h3>Network Info</h3>
+        </Col>
+        <Col>
+          <DisplayRequiredValue
+            name={"Network Name"}
+            isCorrect={isValidNetworkName()}
+            value={network?.name}
+            expected={"one of: " + Object.values<string>(Network).join(", ")}
+          />
+          <DisplayOptionalValue name={"URL"} value={network?.url} />
+          <DisplayOptionalValue name={"ChainId"} value={network?.chainId} />
+        </Col>
+      </Row>
+    </>
+  );
 }
 
-function DisplayRequiredValue(props: { name: string, isCorrect: boolean, value?: string, expected?: string }) {
-    const {name, isCorrect, value, expected} = props;
+function DisplayRequiredValue(props: {
+  name: string;
+  isCorrect: boolean;
+  value?: string;
+  expected?: string;
+}) {
+  const { name, isCorrect, value, expected } = props;
 
-    const successStyling = () => {
-        if (isCorrect) {
-            return {color: 'green'}
-        } else {
-            return {color: 'black', border: '2px solid red'}
-        }
+  const successStyling = () => {
+    if (isCorrect) {
+      return { color: "green" };
+    } else {
+      return { color: "black", border: "2px solid red" };
     }
+  };
 
-    return <div style={successStyling()}><p>
-        <b>{name}:</b> {value ?? "Not present"} {!isCorrect && expected && <>
-        <b>Expected:</b> {expected}</>}</p></div>
+  return (
+    <div style={successStyling()}>
+      <p>
+        <b>{name}:</b> {value ?? "Not present"}{" "}
+        {!isCorrect && expected && (
+          <>
+            <b>Expected:</b> {expected}
+          </>
+        )}
+      </p>
+    </div>
+  );
 }
 
-function DisplayOptionalValue(props: { name: string, value?: string | null }) {
-    return <div><p><b>{props.name}:</b> {props.value ?? "Not present"}</p></div>
+function DisplayOptionalValue(props: { name: string; value?: string | null }) {
+  return (
+    <div>
+      <p>
+        <b>{props.name}:</b> {props.value ?? "Not present"}
+      </p>
+    </div>
+  );
 }
 
 function AutoConnect() {
-    const {autoConnect, setAutoConnect} = useAutoConnect();
-    return <>
-        <Row>
-            <Col title={true} border={true}>
-                <h3>Auto reconnect on page open</h3>
-            </Col>
-            <Col border={true}>
-                <div className="relative flex flex-col overflow-hidden">
-                    <div className="flex">
-                        <label className="inline-flex relative items-center mr-5 cursor-pointer">
-                            <input
-                                type="checkbox"
-                                className="sr-only peer"
-                                checked={autoConnect}
-                                readOnly
-                            />
-                            <div
-                                onClick={() => {
-                                    setAutoConnect(!autoConnect);
-                                }}
-                                className="w-11 h-6 bg-gray-200 rounded-full peer  peer-focus:ring-green-300  peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-green-600"
-                            ></div>
-                        </label>
-                    </div>
-                </div>
-            </Col>
-        </Row>
-    </>;
-}
-
-function RequiredFunctionality() {
-    const {setSuccessAlertMessage, setSuccessAlertHash} = useAlert();
-
-    // TODO: pass as props
-    const {
-        connected,
-        disconnect,
-        account,
-        network,
-        signAndSubmitTransaction,
-        signMessage,
-    } = useWallet();
-    let sendable = isSendableNetwork(connected, network?.name)
-
-    const onSignMessage = async () => {
-        const payload = {
-            message: "Hello from Aptos Wallet Adapter",
-            nonce: Math.random().toString(16),
-            address: true,
-            application: true,
-            chain_id: true,
-        };
-        const response = await signMessage(payload);
-        setSuccessAlertMessage(JSON.stringify(response));
-    };
-
-    const onSignAndSubmitTransaction = async () => {
-        const payload: Types.TransactionPayload = {
-            type: "entry_function_payload",
-            function: "0x1::coin::transfer",
-            type_arguments: ["0x1::aptos_coin::AptosCoin"],
-            arguments: [account?.address, 1], // 1 is in Octas
-        };
-        const response = await signAndSubmitTransaction(payload);
-        try {
-            await aptosClient(network?.name.toLowerCase()).waitForTransaction(response.hash);
-            setSuccessAlertHash(response.hash, network?.name);
-        } catch (error) {
-            console.error(error);
-        }
-    };
-
-    return <Row>
+  const { autoConnect, setAutoConnect } = useAutoConnect();
+  return (
+    <>
+      <Row>
         <Col title={true} border={true}>
-            <h3>Standard Functions</h3>
+          <h3>Auto reconnect on page open</h3>
         </Col>
         <Col border={true}>
-            <Button color={"blue"} onClick={disconnect} disabled={!connected} message={"Disconnect"}/>
-            <Button color={"blue"} onClick={onSignAndSubmitTransaction} disabled={!sendable}
-                    message={"Sign and submit transaction"}/>
-            <Button color={"blue"} onClick={onSignMessage} disabled={!sendable} message={"Sign message"}/>
+          <div className="relative flex flex-col overflow-hidden">
+            <div className="flex">
+              <label className="inline-flex relative items-center mr-5 cursor-pointer">
+                <input
+                  type="checkbox"
+                  className="sr-only peer"
+                  checked={autoConnect}
+                  readOnly
+                />
+                <div
+                  onClick={() => {
+                    setAutoConnect(!autoConnect);
+                  }}
+                  className="w-11 h-6 bg-gray-200 rounded-full peer  peer-focus:ring-green-300  peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-green-600"
+                ></div>
+              </label>
+            </div>
+          </div>
         </Col>
-    </Row>;
-}
-
-function OptionalFunctionality() {
-    const [initializedFeePayer, setInitializedFeePayer] = useState<boolean>(false);
-    const {setSuccessAlertMessage, setSuccessAlertHash} = useAlert();
-    // TODO: pass as props
-    const {
-        connected,
-        account,
-        network,
-        signAndSubmitTransaction,
-        signAndSubmitBCSTransaction,
-        signTransaction,
-        signMessageAndVerify,
-        signMultiAgentTransaction,
-        submitTransaction,
-    } = useWallet();
-    let sendable = isSendableNetwork(connected, network?.name)
-
-    const onSignAndSubmitBCSTransaction = async () => {
-        const token = new TxnBuilderTypes.TypeTagStruct(
-            TxnBuilderTypes.StructTag.fromString("0x1::aptos_coin::AptosCoin")
-        );
-        const entryFunctionBCSPayload =
-            new TxnBuilderTypes.TransactionPayloadEntryFunction(
-                TxnBuilderTypes.EntryFunction.natural(
-                    "0x1::coin",
-                    "transfer",
-                    [token],
-                    [
-                        BCS.bcsToBytes(
-                            TxnBuilderTypes.AccountAddress.fromHex(account!.address)
-                        ),
-                        BCS.bcsSerializeUint64(2),
-                    ]
-                )
-            );
-
-        const response = await signAndSubmitBCSTransaction(entryFunctionBCSPayload);
-        try {
-            await aptosClient(network?.name.toLowerCase()).waitForTransaction(response.hash);
-            setSuccessAlertHash(response.hash, network?.name);
-        } catch (error) {
-            console.error(error);
-        }
-    };
-
-    const onSignTransaction = async () => {
-        const payload: Types.TransactionPayload = {
-            type: "entry_function_payload",
-            function: "0x1::coin::transfer",
-            type_arguments: ["0x1::aptos_coin::AptosCoin"],
-            arguments: [account?.address, 1], // 1 is in Octas
-        };
-        const response = await signTransaction(payload);
-        setSuccessAlertMessage(JSON.stringify(response));
-    };
-
-    const onSignMessageAndVerify = async () => {
-        const payload = {
-            message: "Hello from Aptos Wallet Adapter",
-            nonce: Math.random().toString(16),
-        };
-        const response = await signMessageAndVerify(payload);
-        setSuccessAlertMessage(
-            JSON.stringify({onSignMessageAndVerify: response})
-        );
-    };
-
-    const loadFeePayerAccount = (): AptosAccount => {
-        // Check if it exists in local storage
-        let maybeFeePayer = window.localStorage.getItem(FEE_PAYER_ACCOUNT_KEY);
-        if (!maybeFeePayer) {
-            let feePayerAccount = new AptosAccount();
-            window.localStorage.setItem(FEE_PAYER_ACCOUNT_KEY, feePayerAccount.toPrivateKeyObject().privateKeyHex)
-            return feePayerAccount;
-        } else {
-            let key = HexString.ensure(maybeFeePayer).toUint8Array();
-            return new AptosAccount(key);
-        }
-    }
-
-    // TODO: Let's put this into a cookie or local storage so it only happens once
-    const fundAndSetFeePayer = async (client: AptosClient): Promise<AptosAccount> => {
-        // Check if it exists in local storage
-        let feePayerAccount = loadFeePayerAccount();
-        let feePayerAddress = feePayerAccount.address();
-
-        if (initializedFeePayer) {
-            return feePayerAccount;
-        }
-
-        try {
-            let coinClient = new CoinClient(client);
-            let balance = await coinClient.checkBalance(feePayerAddress);
-            if (Number(balance) >= 100000000) {
-                setInitializedFeePayer(true);
-                return feePayerAccount;
-            }
-        } catch (error: any) {
-            // Swallow errors, likely due to account not existing
-        }
-        await (faucet(network?.name.toLowerCase()).fundAccount(feePayerAddress, 100000000));
-
-        setInitializedFeePayer(true);
-        return feePayerAccount;
-    }
-
-    const onSubmitFeePayer = async () => {
-        if (!account) {
-            throw new Error("Not connected");
-        }
-
-        // TODO: MultiSig isn't supported here properly
-        // This is not supporting multi sig, if 0 or undefined
-        if (account.minKeysRequired) {
-            throw new Error("MultiSig not supported");
-        }
-
-        let provider = aptosClient(network?.name.toLowerCase());
-        // Generate an account and fund it
-        let feePayerAccount = await fundAndSetFeePayer(provider);
-
-        const payload: Types.TransactionPayload = {
-            type: "entry_function_payload",
-            function: "0x1::aptos_account::transfer",
-            type_arguments: [],
-            arguments: [account.address, 1], // 1 is in Octas
-        };
-
-        // This would normally be provided by the service or a server
-        // We need to increase the default timeout
-        let expiration_timestamp_secs = Math.floor(Date.now() / 1000) + 60000;
-
-        const rawTxn = await provider.generateFeePayerTransaction(account.address, payload, feePayerAccount.address().hex(), [], {expiration_timestamp_secs: expiration_timestamp_secs.toString()})
-
-        // Sign with fee payer
-        const feePayerAuthenticator = await provider.signMultiTransaction(feePayerAccount, rawTxn);
-
-        // Sign with user
-        const userSignature  = await signMultiAgentTransaction(rawTxn);
-        // TODO: Why do we need to check this when the error should fail?
-        if (!userSignature) {
-            return;
-        }
-
-        // TODO: This extra code here needs to be put into the wallet adapter
-        let userAuthenticator = new TxnBuilderTypes.AccountAuthenticatorEd25519(
-            new TxnBuilderTypes.Ed25519PublicKey(HexString.ensure(account.publicKey as string).toUint8Array()),
-            new TxnBuilderTypes.Ed25519Signature(HexString.ensure(userSignature as string).toUint8Array())
-        );
-
-        // Submit it TODO: the wallet possibly should send it instead?
-        let response: undefined | Types.PendingTransaction = undefined;
-            response = await provider.submitFeePayerTransaction(rawTxn, userAuthenticator, feePayerAuthenticator);
-            if (response?.hash === undefined) {
-                throw new Error(`No response given ${response}`)
-            }
-            await aptosClient(network?.name.toLowerCase()).waitForTransaction(response.hash);
-            setSuccessAlertHash(response.hash, network?.name);
-
-        setSuccessAlertMessage(
-            JSON.stringify({signAndSubmitTransaction: response ?? "No response"})
-        );
-    };
-
-    const onSubmitTransaction = async () => {
-        if(!account){
-            throw new Error("Account not connected");
-        }
-        const response = await submitTransaction({
-            sender: account.address,
-            data: {
-                function: "0x1::coin::transfer",
-                typeArguments: [parseTypeTag(APTOS_COIN)],
-                functionArguments: [AccountAddress.fromHexInputRelaxed(account.address), new U64(1)], // 1 is in Octas
-            }
-        });
-        try {
-            await aptosClient(network?.name.toLowerCase()).waitForTransaction(response.hash);
-            setSuccessAlertHash(response.hash, network?.name);
-        } catch (error) {
-            console.error(error);
-        }
-    };
-
-    return <Row>
-        <Col title={true} border={true}>
-            <h3>Optional Feature Functions</h3>
-        </Col>
-        <Col border={true}>
-            <Button color={"blue"} onClick={onSignMessageAndVerify} disabled={!sendable}
-                    message={"Sign message and verify"}/>
-            <Button color={"blue"} onClick={onSignTransaction} disabled={!sendable} message={"Sign transaction"}/>
-            <Button color={"blue"} onClick={onSignAndSubmitBCSTransaction} disabled={!sendable}
-                    message={"Sign and submit BCS transaction"}/>
-            <Button color={"blue"} onClick={onSubmitFeePayer} disabled={!sendable}
-                    message={"Sign and submit fee payer"}/>
-            <Button color={"blue"} onClick={onSubmitTransaction} disabled={!sendable}
-                    message={"Sign and submit with the @aptos-labs/ts-sdk"}/>
-        </Col>
-    </Row>;
-}
-
-function Row(props: { children?: React.ReactNode }) {
-    return <tr>
-        {props.children}
-    </tr>
-}
-
-function Col(props: { title?: boolean, border?: boolean, children?: React.ReactNode }) {
-    return <td className={`px-8 py-4 ${props.border ? "border-t" : ""} w-${props.title ? "1/4" : "3/4"}`}>
-        {props.children}
-    </td>
-}
-
-function Button(props: { color: string | undefined, onClick: () => void, disabled: boolean, message: string }) {
-    const {color, onClick, disabled, message} = props;
-    return <button
-        className={`bg-${color}-500 text-white font-bold py-2 px-4 rounded mr-4 ${
-            disabled
-                ? "opacity-50 cursor-not-allowed"
-                : `hover:bg-${color}-700`
-        }`}
-        onClick={onClick}
-        disabled={disabled}
-    >{message}</button>
+      </Row>
+    </>
+  );
 }

--- a/apps/nextjs-example/utils/index.ts
+++ b/apps/nextjs-example/utils/index.ts
@@ -1,0 +1,19 @@
+import { Aptos, AptosConfig, Network } from "@aptos-labs/ts-sdk";
+
+export const aptosClient = (network?: string) => {
+  if (network === Network.DEVNET.toLowerCase()) {
+    return DEVNET_CLIENT;
+  } else if (network === Network.TESTNET.toLowerCase()) {
+    return TESTNET_CLIENT;
+  } else if (network === Network.MAINNET.toLowerCase()) {
+    throw new Error("Please use devnet or testnet for testing");
+  } else {
+    throw new Error(`Unknown network: ${network}`);
+  }
+};
+export const DEVNET_CONFIG = new AptosConfig({
+  network: Network.DEVNET,
+});
+export const DEVNET_CLIENT = new Aptos(DEVNET_CONFIG);
+export const TESTNET_CONFIG = new AptosConfig({ network: Network.TESTNET });
+export const TESTNET_CLIENT = new Aptos(TESTNET_CONFIG);

--- a/packages/wallet-adapter-ant-design/src/WalletSelector.tsx
+++ b/packages/wallet-adapter-ant-design/src/WalletSelector.tsx
@@ -4,8 +4,8 @@ import {
   isRedirectable,
   useWallet,
   Wallet,
-  WalletName,
   WalletReadyState,
+  WalletName,
 } from "@aptos-labs/wallet-adapter-react";
 import "./styles.css";
 import { truncateAddress } from "./utils";

--- a/packages/wallet-adapter-core/package.json
+++ b/packages/wallet-adapter-core/package.json
@@ -45,12 +45,12 @@
     "typescript": "^4.5.3"
   },
   "dependencies": {
-    "@aptos-labs/ts-sdk": "^0.0.3",
     "buffer": "^6.0.3",
     "eventemitter3": "^4.0.7",
     "tweetnacl": "^1.0.3"
   },
   "peerDependencies": {
-    "aptos": "^1.19.0"
+    "aptos": "^1.19.0",
+    "@aptos-labs/ts-sdk": "^0.0.5"
   }
 }

--- a/packages/wallet-adapter-core/package.json
+++ b/packages/wallet-adapter-core/package.json
@@ -51,6 +51,6 @@
   },
   "peerDependencies": {
     "aptos": "^1.19.0",
-    "@aptos-labs/ts-sdk": "^0.0.5"
+    "@aptos-labs/ts-sdk": "^0.0.6"
   }
 }

--- a/packages/wallet-adapter-core/package.json
+++ b/packages/wallet-adapter-core/package.json
@@ -51,6 +51,6 @@
   },
   "peerDependencies": {
     "aptos": "^1.19.0",
-    "@aptos-labs/ts-sdk": "^0.0.6"
+    "@aptos-labs/ts-sdk": "^0.0.7"
   }
 }

--- a/packages/wallet-adapter-core/src/WalletCore.ts
+++ b/packages/wallet-adapter-core/src/WalletCore.ts
@@ -11,6 +11,7 @@ import {
   generateTransactionPayload,
   InputSubmitTransactionData,
   PendingTransactionResponse,
+  InputEntryFunctionDataWithRemoteABI,
 } from "@aptos-labs/ts-sdk";
 import EventEmitter from "eventemitter3";
 import nacl from "tweetnacl";
@@ -317,7 +318,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
           network: convertNetwork(this._network),
         });
         const newPayload = await generateTransactionPayload({
-          ...(payloadData as any),
+          ...(payloadData as InputEntryFunctionDataWithRemoteABI),
           aptosConfig: aptosConfig,
         });
         const oldTransactionPayload =

--- a/packages/wallet-adapter-core/src/WalletCore.ts
+++ b/packages/wallet-adapter-core/src/WalletCore.ts
@@ -47,6 +47,7 @@ import {
   setLocalStorage,
   scopePollingDetectionStrategy,
   isRedirectable,
+  generalizedErrorMessage,
 } from "./utils";
 import { getNameByAddress } from "./ans";
 import {
@@ -254,8 +255,8 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
       this.emit("connect", account);
     } catch (error: any) {
       this.clearData();
-      const errMsg =
-        typeof error == "object" && "message" in error ? error.message : error;
+
+      const errMsg = generalizedErrorMessage(error);
       throw new WalletConnectionError(errMsg).message;
     } finally {
       this._connecting = false;
@@ -275,8 +276,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
       this.clearData();
       this.emit("disconnect");
     } catch (error: any) {
-      const errMsg =
-        typeof error == "object" && "message" in error ? error.message : error;
+      const errMsg = generalizedErrorMessage(error);
       throw new WalletDisconnectionError(errMsg).message;
     }
   }
@@ -324,7 +324,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
           convertV2TransactionPayloadToV1BCSPayload(newPayload);
         const response = await this.waletCoreV1.signAndSubmitBCSTransaction(
           oldTransactionPayload,
-          this._wallet,
+          this._wallet!,
           {
             max_gas_amount: options?.maxGasAmount
               ? BigInt(options?.maxGasAmount)
@@ -344,7 +344,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
         convertV2PayloadToV1JSONPayload(payloadData);
       const response = await this.waletCoreV1.signAndSubmitTransaction(
         oldTransactionPayload,
-        this._wallet,
+        this._wallet!,
         {
           max_gas_amount: options?.maxGasAmount
             ? BigInt(options?.maxGasAmount)
@@ -357,8 +357,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
       const { hash, ...output } = response;
       return { hash, output };
     } catch (error: any) {
-      const errMsg =
-        typeof error == "object" && "message" in error ? error.message : error;
+      const errMsg = generalizedErrorMessage(error);
       throw new WalletSignAndSubmitMessageError(errMsg).message;
     }
   }
@@ -375,6 +374,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
    */
   async signTransaction(
     transactionOrPayload: AnyRawTransaction | Types.TransactionPayload,
+    asFeePayer?: boolean,
     options?: InputGenerateTransactionOptions
   ): Promise<AccountAuthenticator> {
     try {
@@ -387,7 +387,8 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
           ).message;
         }
         const accountAuthenticator = (this._wallet as any).signTransaction(
-          transactionOrPayload
+          transactionOrPayload,
+          asFeePayer
         );
 
         return accountAuthenticator;
@@ -402,7 +403,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
 
       const response = await this.waletCoreV1.signTransaction(
         transactionOrPayload as Types.TransactionPayload,
-        this._wallet,
+        this._wallet!,
         {
           max_gas_amount: options?.maxGasAmount
             ? BigInt(options?.maxGasAmount)
@@ -432,8 +433,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
       );
       return accountAuthenticator;
     } catch (error: any) {
-      const errMsg =
-        typeof error == "object" && "message" in error ? error.message : error;
+      const errMsg = generalizedErrorMessage(error);
       throw new WalletSignTransactionError(errMsg).message;
     }
   }
@@ -450,8 +450,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
       const response = await this._wallet!.signMessage(message);
       return response;
     } catch (error: any) {
-      const errMsg =
-        typeof error == "object" && "message" in error ? error.message : error;
+      const errMsg = generalizedErrorMessage(error);
       throw new WalletSignMessageError(errMsg).message;
     }
   }
@@ -472,8 +471,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
 
       return pendingTransaction;
     } catch (error: any) {
-      const errMsg =
-        typeof error == "object" && "message" in error ? error.message : error;
+      const errMsg = generalizedErrorMessage(error);
       throw new WalletSignTransactionError(errMsg).message;
     }
   }
@@ -492,8 +490,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
         this.emit("accountChange", this._account);
       });
     } catch (error: any) {
-      const errMsg =
-        typeof error == "object" && "message" in error ? error.message : error;
+      const errMsg = generalizedErrorMessage(error);
       throw new WalletAccountChangeError(errMsg).message;
     }
   }
@@ -512,8 +509,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
         this.emit("networkChange", this._network);
       });
     } catch (error: any) {
-      const errMsg =
-        typeof error == "object" && "message" in error ? error.message : error;
+      const errMsg = generalizedErrorMessage(error);
       throw new WalletNetworkChangeError(errMsg).message;
     }
   }
@@ -587,8 +583,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
       }
       return verified;
     } catch (error: any) {
-      const errMsg =
-        typeof error == "object" && "message" in error ? error.message : error;
+      const errMsg = generalizedErrorMessage(error);
       throw new WalletSignMessageAndVerifyError(errMsg).message;
     }
   }

--- a/packages/wallet-adapter-core/src/WalletCore.ts
+++ b/packages/wallet-adapter-core/src/WalletCore.ts
@@ -1,5 +1,17 @@
-import { HexString, TxnBuilderTypes, Types } from "aptos";
-import { AptosConfig, InputGenerateTransactionData, generateTransactionPayload } from "@aptos-labs/ts-sdk";
+import { HexString, TxnBuilderTypes, Types, BCS } from "aptos";
+import {
+  InputGenerateTransactionData,
+  AnyRawTransaction,
+  AccountAuthenticator,
+  AccountAuthenticatorEd25519,
+  Ed25519PublicKey,
+  InputGenerateTransactionOptions,
+  Ed25519Signature,
+  AptosConfig,
+  generateTransactionPayload,
+  InputSubmitTransactionData,
+  PendingTransactionResponse,
+} from "@aptos-labs/ts-sdk";
 import EventEmitter from "eventemitter3";
 import nacl from "tweetnacl";
 import { Buffer } from "buffer";
@@ -24,13 +36,11 @@ import {
 import {
   AccountInfo,
   NetworkInfo,
-  WalletName,
   SignMessagePayload,
-  SignMessageResponse,
   Wallet,
   WalletInfo,
   WalletCoreEvents,
-  TransactionOptions,
+  SignMessageResponse,
 } from "./types";
 import {
   removeLocalStorage,
@@ -39,14 +49,19 @@ import {
   isRedirectable,
 } from "./utils";
 import { getNameByAddress } from "./ans";
-import { AccountAuthenticator } from "@aptos-labs/ts-sdk";
-import { convertNetwork, convertToBCSPayload } from "./conversion";
+import {
+  convertNetwork,
+  convertV2TransactionPayloadToV1BCSPayload,
+  convertV2PayloadToV1JSONPayload,
+} from "./conversion";
+import { WalletCoreV1 } from "./WalletCoreV1";
 
 export class WalletCore extends EventEmitter<WalletCoreEvents> {
   private _wallets: ReadonlyArray<Wallet> = [];
   private _wallet: Wallet | null = null;
   private _account: AccountInfo | null = null;
   private _network: NetworkInfo | null = null;
+  private readonly waletCoreV1: WalletCoreV1 = new WalletCoreV1();
 
   private _connecting: boolean = false;
   private _connected: boolean = false;
@@ -180,7 +195,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
    * If all good, we connect the wallet by calling `this.connectWallet`
    * @param walletName. The wallet name we want to connect.
    */
-  async connect(walletName: WalletName): Promise<void | string> {
+  async connect(walletName: string): Promise<void | string> {
     const selectedWallet = this._wallets?.find(
       (wallet: Wallet) => wallet.name === walletName
     );
@@ -267,54 +282,80 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
   }
 
   /**
-  Sign and submit an entry (not bcs serialized) transaction type to chain.
-  @param transaction a non-bcs serialized transaction
-  @param options max_gas_amount and gas_unit_limit
-  @return response from the wallet's signAndSubmitTransaction function
-  @throws WalletSignAndSubmitMessageError
-  */
-  async signAndSubmitTransaction(
-    transaction: Types.TransactionPayload,
-    options?: TransactionOptions
-  ): Promise<any> {
-    try {
-      this.doesWalletExist();
-      const response = await this._wallet?.signAndSubmitTransaction(
-        transaction,
-        options
-      );
-      return response;
-    } catch (error: any) {
-      const errMsg =
-        typeof error == "object" && "message" in error ? error.message : error;
-      throw new WalletSignAndSubmitMessageError(errMsg).message;
-    }
-  }
-
-  /**
-   Sign and submit a bsc serialized transaction type to chain.
-   @param transaction a bcs serialized transaction
-   @param options max_gas_amount and gas_unit_limit
-   @return response from the wallet's signAndSubmitBCSTransaction function
-   @throws WalletSignAndSubmitMessageError
+   * Signs and submits a transaction to chain
+   *
+   * @param transactionInput InputGenerateTransactionData
+   * @param options optional. A configuration object to generate a transaction by
+   * @returns The pending transaction hash (V1 output) | PendingTransactionResponse (V2 output)
    */
-  async signAndSubmitBCSTransaction(
-    transaction: TxnBuilderTypes.TransactionPayload,
-    options?: TransactionOptions
-  ): Promise<any> {
-    if (this._wallet && !("signAndSubmitBCSTransaction" in this._wallet)) {
-      throw new WalletNotSupportedMethod(
-        `Submit a BCS Transaction is not supported by ${this.wallet?.name}`
-      ).message;
-    }
-
+  async signAndSubmitTransaction(
+    transactionInput: InputGenerateTransactionData,
+    options?: InputGenerateTransactionOptions
+  ): Promise<
+    { hash: Types.HexEncodedBytes; output?: any } | PendingTransactionResponse
+  > {
     try {
       this.doesWalletExist();
-      const response = await (this._wallet as any).signAndSubmitBCSTransaction(
-        transaction,
-        options
+
+      // wallet supports sdk v2
+      if (this._wallet?.version === "v2") {
+        const response = await this._wallet.signAndSubmitTransaction(
+          transactionInput,
+          options
+        );
+        // response should be PendingTransactionResponse
+        return response;
+      }
+
+      // get the payload piece from the input
+      const payloadData = transactionInput.data;
+
+      // if first function arguments is an object (i.e a bcs serialized argument)
+      // we assume the transaction should be a bcs serialized transaction
+      if (typeof payloadData.functionArguments[0] === "object") {
+        const aptosConfig = new AptosConfig({
+          network: convertNetwork(this._network),
+        });
+        const newPayload = await generateTransactionPayload({
+          ...(payloadData as any),
+          aptosConfig: aptosConfig,
+        });
+        const oldTransactionPayload =
+          convertV2TransactionPayloadToV1BCSPayload(newPayload);
+        const response = await this.waletCoreV1.signAndSubmitBCSTransaction(
+          oldTransactionPayload,
+          this._wallet,
+          {
+            max_gas_amount: options?.maxGasAmount
+              ? BigInt(options?.maxGasAmount)
+              : undefined,
+            gas_unit_price: options?.gasUnitPrice
+              ? BigInt(options?.gasUnitPrice)
+              : undefined,
+          }
+        );
+        const { hash, ...output } = response;
+        return { hash, output };
+      }
+
+      // if it is not a bcs serialized arguments transaction, convert to the old
+      // json format
+      const oldTransactionPayload =
+        convertV2PayloadToV1JSONPayload(payloadData);
+      const response = await this.waletCoreV1.signAndSubmitTransaction(
+        oldTransactionPayload,
+        this._wallet,
+        {
+          max_gas_amount: options?.maxGasAmount
+            ? BigInt(options?.maxGasAmount)
+            : undefined,
+          gas_unit_price: options?.gasUnitPrice
+            ? BigInt(options?.gasUnitPrice)
+            : undefined,
+        }
       );
-      return response;
+      const { hash, ...output } = response;
+      return { hash, output };
     } catch (error: any) {
       const errMsg =
         typeof error == "object" && "message" in error ? error.message : error;
@@ -323,29 +364,73 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
   }
 
   /**
-   Sign transaction (doesnt submit to chain).
-   @param transaction
-   @param options max_gas_amount and gas_unit_limit
-   @return response from the wallet's signTransaction function
-   @throws WalletSignTransactionError
+   * Signs a transaction
+   *
+   * To support both existing wallet adapter V1 and V2, we support 2 input types
+   *
+   * @param transactionOrPayload AnyRawTransaction - V2 input | Types.TransactionPayload - V1 input
+   * @param options optional. V1 input
+   *
+   * @returns AccountAuthenticator
    */
   async signTransaction(
-    transaction: Types.TransactionPayload,
-    options?: TransactionOptions
-  ): Promise<Uint8Array | null> {
-    if (this._wallet && !("signTransaction" in this._wallet)) {
-      throw new WalletNotSupportedMethod(
-        `Sign Transaction is not supported by ${this.wallet?.name}`
-      ).message;
-    }
-
+    transactionOrPayload: AnyRawTransaction | Types.TransactionPayload,
+    options?: InputGenerateTransactionOptions
+  ): Promise<AccountAuthenticator> {
     try {
       this.doesWalletExist();
-      const response = await (this._wallet as any).signTransaction(
-        transaction,
-        options
+      // if input is AnyRawTransaction, i.e V2
+      if ("rawTransaction" in transactionOrPayload) {
+        if (this._wallet?.version !== "v2") {
+          throw new WalletNotSupportedMethod(
+            `Sign Transaction V2 is not supported by ${this.wallet?.name}`
+          ).message;
+        }
+        const accountAuthenticator = (this._wallet as any).signTransaction(
+          transactionOrPayload
+        );
+
+        return accountAuthenticator;
+      }
+
+      // check current signTransaction function exists
+      if (this._wallet && !("signTransaction" in this._wallet)) {
+        throw new WalletNotSupportedMethod(
+          `Sign Transaction is not supported by ${this.wallet?.name}`
+        ).message;
+      }
+
+      const response = await this.waletCoreV1.signTransaction(
+        transactionOrPayload as Types.TransactionPayload,
+        this._wallet,
+        {
+          max_gas_amount: options?.maxGasAmount
+            ? BigInt(options?.maxGasAmount)
+            : undefined,
+          gas_unit_price: options?.gasUnitPrice
+            ? BigInt(options?.gasUnitPrice)
+            : undefined,
+        }
       );
-      return response;
+      if (!response) {
+        throw new Error("error");
+      }
+
+      // Convert retuned bcs serialized SignedTransaction into V2 AccountAuthenticator
+      const deserializer1 = new BCS.Deserializer(response);
+      const deserializedSignature =
+        TxnBuilderTypes.SignedTransaction.deserialize(deserializer1);
+      const transactionAuthenticator =
+        deserializedSignature.authenticator as TxnBuilderTypes.TransactionAuthenticatorEd25519;
+
+      const publicKey = transactionAuthenticator.public_key.value;
+      const signature = transactionAuthenticator.signature.value;
+
+      const accountAuthenticator = new AccountAuthenticatorEd25519(
+        new Ed25519PublicKey(publicKey),
+        new Ed25519Signature(signature)
+      );
+      return accountAuthenticator;
     } catch (error: any) {
       const errMsg =
         typeof error == "object" && "message" in error ? error.message : error;
@@ -359,13 +444,10 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
    @return response from the wallet's signMessage function
    @throws WalletSignMessageError
    */
-  async signMessage(
-    message: SignMessagePayload
-  ): Promise<SignMessageResponse | null> {
+  async signMessage(message: SignMessagePayload): Promise<SignMessageResponse> {
     try {
       this.doesWalletExist();
-      if (!this._wallet) return null;
-      const response = await this._wallet?.signMessage(message);
+      const response = await this._wallet!.signMessage(message);
       return response;
     } catch (error: any) {
       const errMsg =
@@ -374,43 +456,21 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
     }
   }
 
-  /**
-   * This function is for signing and submitting a transaction using the `@aptos-labs/ts-sdk` (aka the v2 SDK)
-   * input types. It's internally converting the input types to the old SDK input types and then calling
-   * the v1 SDK's `signAndSubmitBCSTransaction` with it.
-   * 
-   * @param transactionInput the transaction input
-   * @param options max_gas_amount and gas_unit_limit
-   * @returns the response from the wallet's signAndSubmitBCSTransaction function
-   */
   async submitTransaction(
-    transactionInput: InputGenerateTransactionData,
-    options?: TransactionOptions,
-  ): Promise<{ hash: string, output?: any }> {
-    const payloadData = transactionInput.data;
-    const aptosConfig = new AptosConfig({network: convertNetwork(this._network)});
-    // TODO: Refactor this any, and remove the need for it by fixing the if ("bytecode" in data) stuff in `generateTransaction` in the v2 SDK
-    const newPayload = await generateTransactionPayload({ ...payloadData as any, aptosConfig: aptosConfig });
-    const oldTransactionPayload = convertToBCSPayload(newPayload);
-    const response = await this.signAndSubmitBCSTransaction(oldTransactionPayload, options);
-    const { hash, ...output } = response;
-    return { hash, output };
-  }
-
-  async signMultiAgentTransaction(
-    transaction: TxnBuilderTypes.MultiAgentRawTransaction | TxnBuilderTypes.FeePayerRawTransaction
-  ): Promise<string | null> {
-    if (this._wallet && !("signMultiAgentTransaction" in this._wallet)) {
+    transaction: InputSubmitTransactionData
+  ): Promise<PendingTransactionResponse> {
+    if (this._wallet && !("submitTransaction" in this._wallet)) {
       throw new WalletNotSupportedMethod(
-        `Multi-agent & sponsored transactions are not supported by ${this.wallet?.name}`
+        `Submit Transaction is not supported by ${this.wallet?.name}`
       ).message;
     }
     try {
       this.doesWalletExist();
-      const response = await (this._wallet as any).signMultiAgentTransaction(
+      const pendingTransaction = (this._wallet as any).submitTransaction(
         transaction
       );
-      return response;
+
+      return pendingTransaction;
     } catch (error: any) {
       const errMsg =
         typeof error == "object" && "message" in error ? error.message : error;
@@ -458,6 +518,11 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
     }
   }
 
+  /**
+   * Signs a message and verifies the signer
+   * @param message SignMessagePayload
+   * @returns boolean
+   */
   async signMessageAndVerify(message: SignMessagePayload): Promise<boolean> {
     try {
       this.doesWalletExist();

--- a/packages/wallet-adapter-core/src/WalletCoreV1.ts
+++ b/packages/wallet-adapter-core/src/WalletCoreV1.ts
@@ -1,0 +1,86 @@
+import { TxnBuilderTypes, Types } from "aptos";
+import EventEmitter from "eventemitter3";
+
+import {
+  WalletSignAndSubmitMessageError,
+  WalletSignTransactionError,
+} from "./error";
+import { Wallet, WalletCoreEvents, TransactionOptions } from "./types";
+
+export class WalletCoreV1 extends EventEmitter<WalletCoreEvents> {
+  /**
+  Sign and submit an entry (not bcs serialized) transaction type to chain.
+  @param transaction a non-bcs serialized transaction
+  @param options max_gas_amount and gas_unit_limit
+  @return response from the wallet's signAndSubmitTransaction function
+  @throws WalletSignAndSubmitMessageError
+  */
+  async signAndSubmitTransaction(
+    transaction: Types.TransactionPayload,
+    wallet: Wallet | null,
+    options?: TransactionOptions
+  ): Promise<any> {
+    try {
+      const response = await (wallet as any).signAndSubmitTransaction(
+        transaction,
+        options
+      );
+      return response;
+    } catch (error: any) {
+      const errMsg =
+        typeof error == "object" && "message" in error ? error.message : error;
+      throw new WalletSignAndSubmitMessageError(errMsg).message;
+    }
+  }
+
+  /**
+   Sign and submit a bsc serialized transaction type to chain.
+   @param transaction a bcs serialized transaction
+   @param options max_gas_amount and gas_unit_limit
+   @return response from the wallet's signAndSubmitBCSTransaction function
+   @throws WalletSignAndSubmitMessageError
+   */
+  async signAndSubmitBCSTransaction(
+    transaction: TxnBuilderTypes.TransactionPayload,
+    wallet: Wallet | null,
+    options?: TransactionOptions
+  ): Promise<any> {
+    try {
+      const response = await (wallet as any).signAndSubmitBCSTransaction(
+        transaction,
+        options
+      );
+      return response;
+    } catch (error: any) {
+      const errMsg =
+        typeof error == "object" && "message" in error ? error.message : error;
+      throw new WalletSignAndSubmitMessageError(errMsg).message;
+    }
+  }
+
+  /**
+   Sign transaction (doesnt submit to chain).
+   @param transaction
+   @param options max_gas_amount and gas_unit_limit
+   @return response from the wallet's signTransaction function
+   @throws WalletSignTransactionError
+   */
+  async signTransaction(
+    transaction: Types.TransactionPayload,
+    wallet: Wallet | null,
+    options?: TransactionOptions
+  ): Promise<Uint8Array | null> {
+    try {
+      const response = await (wallet as any).signTransaction(
+        transaction,
+        options
+      );
+      console.log("response v1", response);
+      return response;
+    } catch (error: any) {
+      const errMsg =
+        typeof error == "object" && "message" in error ? error.message : error;
+      throw new WalletSignTransactionError(errMsg).message;
+    }
+  }
+}

--- a/packages/wallet-adapter-core/src/WalletCoreV1.ts
+++ b/packages/wallet-adapter-core/src/WalletCoreV1.ts
@@ -17,7 +17,7 @@ export class WalletCoreV1 extends EventEmitter<WalletCoreEvents> {
   */
   async signAndSubmitTransaction(
     transaction: Types.TransactionPayload,
-    wallet: Wallet | null,
+    wallet: Wallet,
     options?: TransactionOptions
   ): Promise<any> {
     try {
@@ -42,7 +42,7 @@ export class WalletCoreV1 extends EventEmitter<WalletCoreEvents> {
    */
   async signAndSubmitBCSTransaction(
     transaction: TxnBuilderTypes.TransactionPayload,
-    wallet: Wallet | null,
+    wallet: Wallet,
     options?: TransactionOptions
   ): Promise<any> {
     try {
@@ -67,7 +67,7 @@ export class WalletCoreV1 extends EventEmitter<WalletCoreEvents> {
    */
   async signTransaction(
     transaction: Types.TransactionPayload,
-    wallet: Wallet | null,
+    wallet: Wallet,
     options?: TransactionOptions
   ): Promise<Uint8Array | null> {
     try {
@@ -75,7 +75,6 @@ export class WalletCoreV1 extends EventEmitter<WalletCoreEvents> {
         transaction,
         options
       );
-      console.log("response v1", response);
       return response;
     } catch (error: any) {
       const errMsg =

--- a/packages/wallet-adapter-core/src/conversion.ts
+++ b/packages/wallet-adapter-core/src/conversion.ts
@@ -1,24 +1,57 @@
-import { Network, AnyTransactionPayloadInstance } from "@aptos-labs/ts-sdk"
-import { BCS, TxnBuilderTypes } from "aptos"
+import {
+  Network,
+  TransactionPayload,
+  InputGenerateTransactionPayloadData,
+  TypeTag,
+} from "@aptos-labs/ts-sdk";
+import { BCS, TxnBuilderTypes, Types } from "aptos";
 import { NetworkInfo } from "./types";
-import { NetworkName } from "./constants";
 
 // old => new
 export function convertNetwork(networkInfo: NetworkInfo | null): Network {
-    switch(networkInfo?.name.toLowerCase()) {
-        case "mainnet" as NetworkName:
-            return Network.MAINNET;
-        case "testnet" as NetworkName:
-            return Network.TESTNET;
-        case "devnet" as NetworkName:
-            return Network.DEVNET;
-        default:
-            throw new Error("Invalid network name")
-    }
+  switch (networkInfo?.name.toLowerCase()) {
+    case "mainnet" as Network:
+      return Network.MAINNET;
+    case "testnet" as Network:
+      return Network.TESTNET;
+    case "devnet" as Network:
+      return Network.DEVNET;
+    default:
+      throw new Error("Invalid network name");
+  }
 }
 
 // new => old
-export function convertToBCSPayload(payload: AnyTransactionPayloadInstance): TxnBuilderTypes.TransactionPayload {
-    const deserializer = new BCS.Deserializer(payload.bcsToBytes());
-    return TxnBuilderTypes.TransactionPayload.deserialize(deserializer);
+export function convertV2TransactionPayloadToV1BCSPayload(
+  payload: TransactionPayload
+): TxnBuilderTypes.TransactionPayload {
+  const deserializer = new BCS.Deserializer(payload.bcsToBytes());
+  return TxnBuilderTypes.TransactionPayload.deserialize(deserializer);
+}
+
+export function convertV2PayloadToV1JSONPayload(
+  payload: InputGenerateTransactionPayloadData
+): Types.TransactionPayload {
+  if ("bytecode" in payload) {
+    // is a script payload
+    throw new Error("script payload not supported");
+  } else {
+    // is entry function payload
+    const stringTypeTags: string[] | undefined = payload.typeArguments?.map(
+      (typeTag) => {
+        if (typeTag instanceof TypeTag) {
+          return typeTag.toString();
+        }
+        return typeTag;
+      }
+    );
+    const newPayload: Types.TransactionPayload = {
+      type: "entry_function_payload",
+      function: payload.function,
+      type_arguments: stringTypeTags || [],
+      arguments: payload.functionArguments,
+    };
+
+    return newPayload;
+  }
 }

--- a/packages/wallet-adapter-core/src/types.ts
+++ b/packages/wallet-adapter-core/src/types.ts
@@ -1,16 +1,38 @@
-import { TxnBuilderTypes, Types } from "aptos";
-import { NetworkName, WalletReadyState } from "./constants";
+import { Types } from "aptos";
+import {
+  Network,
+  InputGenerateTransactionData,
+  InputGenerateTransactionOptions,
+  InputSubmitTransactionData,
+  PendingTransactionResponse,
+} from "@aptos-labs/ts-sdk";
+import { WalletReadyState } from "./constants";
 
 export { TxnBuilderTypes, Types } from "aptos";
-export type { InputGenerateTransactionData } from "@aptos-labs/ts-sdk";
+export type {
+  InputGenerateTransactionData,
+  InputGenerateTransactionOptions,
+  AnyRawTransaction,
+  InputSubmitTransactionData,
+  PendingTransactionResponse,
+  AccountAuthenticator,
+} from "@aptos-labs/ts-sdk";
+
 // WalletName is a nominal type that wallet adapters should use, e.g. `'MyCryptoWallet' as WalletName<'MyCryptoWallet'>`
 export type WalletName<T extends string = string> = T & {
   __brand__: "WalletName";
 };
+
 export type NetworkInfo = {
-  name: NetworkName;
+  name: Network;
   chainId?: string;
   url?: string;
+};
+
+export type WalletInfo = {
+  name: WalletName;
+  icon: string;
+  url: string;
 };
 
 export type AccountInfo = {
@@ -25,66 +47,6 @@ export interface AptosWalletErrorResult {
   name: string;
   message: string;
 }
-
-export type OnNetworkChange = (
-  callBack: (networkInfo: NetworkInfo) => Promise<void>
-) => Promise<void>;
-
-export interface PluginProvider {
-  connect: () => Promise<AccountInfo>;
-  account: () => Promise<AccountInfo>;
-  disconnect: () => Promise<void>;
-  signAndSubmitTransaction: (
-    transaction: any,
-    options?: any
-  ) => Promise<{ hash: Types.HexEncodedBytes } | AptosWalletErrorResult>;
-  signMessage: (message: SignMessagePayload) => Promise<SignMessageResponse>;
-  network: () => Promise<NetworkName>;
-  onAccountChange: (
-    listener: (newAddress: AccountInfo) => Promise<void>
-  ) => Promise<void>;
-  onNetworkChange: OnNetworkChange;
-  signMultiAgentTransaction: (
-      rawTxn: TxnBuilderTypes.MultiAgentRawTransaction | TxnBuilderTypes.FeePayerRawTransaction
-  ) => Promise<string>;
-}
-
-export interface AdapterPluginEvents {
-  onNetworkChange: OnNetworkChange;
-  onAccountChange(callback: any): Promise<any>;
-}
-
-export interface AdapterPluginProps<Name extends string = string> {
-  name: WalletName<Name>;
-  url: string;
-  icon: `data:image/${"svg+xml" | "webp" | "png" | "gif"};base64,${string}`;
-  providerName?: string;
-  provider: any;
-  deeplinkProvider?: (data: { url: string }) => string;
-  connect(): Promise<any>;
-  disconnect: () => Promise<any>;
-  network: () => Promise<any>;
-  signAndSubmitTransaction<T extends Types.TransactionPayload, V>(
-    transaction: T,
-    options?: V
-  ): Promise<{ hash: Types.HexEncodedBytes }>;
-  signMessage<T extends SignMessagePayload>(
-    message: T
-  ): Promise<SignMessageResponse>;
-}
-
-export type AdapterPlugin<Name extends string = string> =
-  AdapterPluginProps<Name> & AdapterPluginEvents;
-
-export type Wallet<Name extends string = string> = AdapterPlugin<Name> & {
-  readyState?: WalletReadyState;
-};
-
-export type WalletInfo = {
-  name: WalletName;
-  icon: string;
-  url: string;
-};
 
 export declare interface WalletCoreEvents {
   connect(account: AccountInfo | null): void;
@@ -113,6 +75,52 @@ export interface SignMessageResponse {
   signature: string | string[]; // The signed full message
   bitmap?: Uint8Array; // a 4-byte (32 bits) bit-vector of length N
 }
+
+export type OnNetworkChange = (
+  callBack: (networkInfo: NetworkInfo) => Promise<void>
+) => Promise<void>;
+
+export type OnAccountChange = (
+  callBack: (accountInfo: AccountInfo) => Promise<any>
+) => Promise<void>;
+
+export interface AdapterPluginEvents {
+  onNetworkChange: OnNetworkChange;
+  onAccountChange: OnAccountChange;
+}
+
+// TODO add signTransaction()
+export interface AdapterPluginProps<Name extends string = string> {
+  name: WalletName<Name>;
+  url: string;
+  icon: `data:image/${"svg+xml" | "webp" | "png" | "gif"};base64,${string}`;
+  version?: "v1" | "v2";
+  providerName?: string;
+  provider: any;
+  deeplinkProvider?: (data: { url: string }) => string;
+  connect(): Promise<any>;
+  disconnect: () => Promise<any>;
+  network: () => Promise<any>;
+  signAndSubmitTransaction<V>(
+    transaction: Types.TransactionPayload | InputGenerateTransactionData,
+    options?: InputGenerateTransactionOptions
+  ): Promise<
+    { hash: Types.HexEncodedBytes; output?: any } | PendingTransactionResponse
+  >;
+  submitTransaction?(
+    transaction: InputSubmitTransactionData
+  ): Promise<PendingTransactionResponse>;
+  signMessage<T extends SignMessagePayload>(
+    message: T
+  ): Promise<SignMessageResponse>;
+}
+
+export type AdapterPlugin<Name extends string = string> =
+  AdapterPluginProps<Name> & AdapterPluginEvents;
+
+export type Wallet<Name extends string = string> = AdapterPlugin<Name> & {
+  readyState?: WalletReadyState;
+};
 
 export interface TransactionOptions {
   max_gas_amount?: bigint;

--- a/packages/wallet-adapter-core/src/utils/helpers.ts
+++ b/packages/wallet-adapter-core/src/utils/helpers.ts
@@ -18,9 +18,15 @@ export function isInAppBrowser(): boolean {
 
 export function isRedirectable(): boolean {
   // SSR: return false
-  if (typeof navigator === 'undefined' || !navigator) return false;
+  if (typeof navigator === "undefined" || !navigator) return false;
 
   // if we are on mobile and NOT in a in-app browser we will redirect to a wallet app
 
   return isMobile() && !isInAppBrowser();
+}
+
+export function generalizedErrorMessage(error: any): string {
+  return typeof error === "object" && "message" in error
+    ? error.message
+    : error;
 }

--- a/packages/wallet-adapter-core/tsconfig.json
+++ b/packages/wallet-adapter-core/tsconfig.json
@@ -4,6 +4,6 @@
   "exclude": ["dist", "build", "node_modules"],
   "compilerOptions": {
     "target": "es5",
-    "lib": ["ES2015", "dom", "es2017", "ES2019.Array"]
+    "lib": ["es2020", "dom"]
   }
 }

--- a/packages/wallet-adapter-mui-design/src/WalletModel.tsx
+++ b/packages/wallet-adapter-mui-design/src/WalletModel.tsx
@@ -16,8 +16,8 @@ import {
   isRedirectable,
   useWallet,
   Wallet,
-  WalletName,
   WalletReadyState,
+  WalletName,
 } from "@aptos-labs/wallet-adapter-react";
 import { grey } from "./aptosColorPalette";
 // reported bug with loading mui icons with esm, therefore need to import like this https://github.com/mui/material-ui/issues/35233
@@ -42,7 +42,8 @@ const ConnectWalletRow: React.FC<{
           borderRadius: `${theme.shape.borderRadius}px`,
           display: "flex",
           gap: "1rem",
-        }}>
+        }}
+      >
         <ListItemAvatar
           sx={{
             display: "flex",
@@ -51,7 +52,8 @@ const ConnectWalletRow: React.FC<{
             height: "2rem",
             minWidth: "0",
             color: `${theme.palette.text.primary}`,
-          }}>
+          }}
+        >
           <Box
             component="img"
             src={wallet.icon}
@@ -67,7 +69,8 @@ const ConnectWalletRow: React.FC<{
         <Button
           variant="contained"
           size="small"
-          className="wallet-connect-button">
+          className="wallet-connect-button"
+        >
           Connect
         </Button>
       </ListItemButton>
@@ -86,7 +89,8 @@ const InstallWalletRow: React.FC<{ wallet: Wallet }> = ({ wallet }) => {
         background: theme.palette.mode === "dark" ? grey[700] : grey[200],
         padding: "1rem 1rem",
         gap: "1rem",
-      }}>
+      }}
+    >
       <ListItemAvatar
         sx={{
           display: "flex",
@@ -95,7 +99,8 @@ const InstallWalletRow: React.FC<{ wallet: Wallet }> = ({ wallet }) => {
           height: "2rem",
           minWidth: "0",
           opacity: "0.25",
-        }}>
+        }}
+      >
         <Box
           component="img"
           src={wallet.icon}
@@ -116,7 +121,8 @@ const InstallWalletRow: React.FC<{ wallet: Wallet }> = ({ wallet }) => {
         href={wallet.url}
         target="_blank"
         size="small"
-        className="wallet-connect-install">
+        className="wallet-connect-install"
+      >
         Install
       </Button>
     </ListItem>
@@ -200,7 +206,8 @@ export default function WalletsModal({
       aria-describedby="select a wallet to connect"
       sx={{ borderRadius: `${theme.shape.borderRadius}px` }}
       maxWidth="xs"
-      fullWidth>
+      fullWidth
+    >
       <Stack
         sx={{
           display: "flex",
@@ -210,7 +217,8 @@ export default function WalletsModal({
           bgcolor: "background.paper",
           boxShadow: 24,
           p: 3,
-        }}>
+        }}
+      >
         <IconButton
           onClick={handleClose}
           sx={{
@@ -218,7 +226,8 @@ export default function WalletsModal({
             right: 12,
             top: 12,
             color: grey[450],
-          }}>
+          }}
+        >
           <CloseIcon />
         </IconButton>
         <Typography align="center" variant="h5" pt={2}>
@@ -231,7 +240,8 @@ export default function WalletsModal({
             alignItems: "center",
             justifyContent: "center",
             mb: 4,
-          }}>
+          }}
+        >
           {networkSupport && (
             <>
               <LanOutlinedIcon
@@ -246,7 +256,8 @@ export default function WalletsModal({
                   fontSize: "0.9rem",
                   color: grey[400],
                 }}
-                align="center">
+                align="center"
+              >
                 {networkSupport} only
               </Typography>
             </>

--- a/packages/wallet-adapter-react/src/WalletProvider.tsx
+++ b/packages/wallet-adapter-react/src/WalletProvider.tsx
@@ -86,10 +86,11 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
 
   const signTransaction = async (
     transaction: AnyRawTransaction | Types.TransactionPayload,
+    asFeePayer?: boolean,
     options?: InputGenerateTransactionOptions
   ): Promise<AccountAuthenticator> => {
     try {
-      return await walletCore.signTransaction(transaction, options);
+      return await walletCore.signTransaction(transaction, asFeePayer, options);
     } catch (error: any) {
       if (onError) onError(error);
       return Promise.reject(error);

--- a/packages/wallet-adapter-react/src/WalletProvider.tsx
+++ b/packages/wallet-adapter-react/src/WalletProvider.tsx
@@ -13,11 +13,15 @@ import type {
   SignMessagePayload,
   Wallet,
   WalletInfo,
-  WalletName,
-  TransactionOptions,
-  TxnBuilderTypes,
-  Types,
+  InputGenerateTransactionOptions,
+  AnyRawTransaction,
   InputGenerateTransactionData,
+  InputSubmitTransactionData,
+  AccountAuthenticator,
+  PendingTransactionResponse,
+  SignMessageResponse,
+  WalletName,
+  Types,
 } from "@aptos-labs/wallet-adapter-core";
 import { WalletCore } from "@aptos-labs/wallet-adapter-core";
 
@@ -65,7 +69,7 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
     } catch (error: any) {
       console.log("connect error", error);
       if (onError) onError(error);
-      else throw error;
+      return Promise.reject(error);
     } finally {
       setIsLoading(false);
     }
@@ -74,90 +78,68 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
   const disconnect = async () => {
     try {
       await walletCore.disconnect();
-    } catch (e) {
-      console.log("disconnect error", e);
-      if (onError) onError(e);
+    } catch (error) {
+      if (onError) onError(error);
+      return Promise.reject(error);
+    }
+  };
+
+  const signTransaction = async (
+    transaction: AnyRawTransaction | Types.TransactionPayload,
+    options?: InputGenerateTransactionOptions
+  ): Promise<AccountAuthenticator> => {
+    try {
+      return await walletCore.signTransaction(transaction, options);
+    } catch (error: any) {
+      if (onError) onError(error);
+      return Promise.reject(error);
+    }
+  };
+
+  const signMessage = async (
+    message: SignMessagePayload
+  ): Promise<SignMessageResponse> => {
+    try {
+      return await walletCore.signMessage(message);
+    } catch (error: any) {
+      if (onError) onError(error);
+      return Promise.reject(error);
+    }
+  };
+
+  const signMessageAndVerify = async (
+    message: SignMessagePayload
+  ): Promise<boolean> => {
+    try {
+      return await walletCore.signMessageAndVerify(message);
+    } catch (error: any) {
+      if (onError) onError(error);
+      return Promise.reject(error);
+    }
+  };
+
+  const submitTransaction = async (
+    transaction: InputSubmitTransactionData
+  ): Promise<PendingTransactionResponse> => {
+    try {
+      return await walletCore.submitTransaction(transaction);
+    } catch (error: any) {
+      if (onError) onError(error);
+      return Promise.reject(error);
     }
   };
 
   const signAndSubmitTransaction = async (
-    transaction: Types.TransactionPayload,
-    options?: TransactionOptions
+    transaction: InputGenerateTransactionData,
+    options?: InputGenerateTransactionOptions
   ) => {
     try {
       return await walletCore.signAndSubmitTransaction(transaction, options);
     } catch (error: any) {
       if (onError) onError(error);
-      else throw error;
+      return Promise.reject(error);
     }
   };
-
-  const signAndSubmitBCSTransaction = async (
-    transaction: TxnBuilderTypes.TransactionPayload,
-    options?: TransactionOptions
-  ) => {
-    try {
-      return await walletCore.signAndSubmitBCSTransaction(transaction, options);
-    } catch (error: any) {
-      throw error;
-    }
-  };
-
-  const signTransaction = async (
-    transaction: Types.TransactionPayload,
-    options?: TransactionOptions
-  ) => {
-    try {
-      return await walletCore.signTransaction(transaction, options);
-    } catch (error: any) {
-      if (onError) onError(error);
-      else throw error;
-    }
-  };
-
-  const signMessage = async (message: SignMessagePayload) => {
-    try {
-      return await walletCore.signMessage(message);
-    } catch (error: any) {
-      if (onError) onError(error);
-      else throw error;
-      return null;
-    }
-  };
-
-  const signMessageAndVerify = async (message: SignMessagePayload) => {
-    try {
-      return await walletCore.signMessageAndVerify(message);
-    } catch (error: any) {
-      if (onError) onError(error);
-      else throw error;
-      return false;
-    }
-  };
-
-  const signMultiAgentTransaction = async (
-      transaction: TxnBuilderTypes.MultiAgentRawTransaction | TxnBuilderTypes.FeePayerRawTransaction,
-  ) => {
-    try {
-      return await walletCore.signMultiAgentTransaction(transaction);
-    } catch (error: any) {
-      if (onError) onError(error);
-      else throw error;
-      return false;
-    }
-  }
-
-  const submitTransaction = async (
-      transaction: InputGenerateTransactionData,
-  ) => {
-    try {
-      return await walletCore.submitTransaction(transaction);
-    } catch (error: any) {
-      if (onError) onError(error);
-      else throw error;
-      return false;
-    }
-  }
 
   useEffect(() => {
     if (autoConnect) {
@@ -261,13 +243,11 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
         wallet,
         wallets,
         signAndSubmitTransaction,
-        signAndSubmitBCSTransaction,
         signTransaction,
         signMessage,
         signMessageAndVerify,
-        signMultiAgentTransaction,
-        submitTransaction,
         isLoading,
+        submitTransaction,
       }}
     >
       {children}

--- a/packages/wallet-adapter-react/src/index.tsx
+++ b/packages/wallet-adapter-react/src/index.tsx
@@ -7,5 +7,5 @@ export {
   isMobile,
   isRedirectable,
 } from "./useWallet";
-export type { WalletName, Wallet } from "./useWallet";
+export type { Wallet, WalletName } from "./useWallet";
 export * from "./WalletProvider";

--- a/packages/wallet-adapter-react/src/useWallet.tsx
+++ b/packages/wallet-adapter-react/src/useWallet.tsx
@@ -45,6 +45,7 @@ export interface WalletContextState {
   ): Promise<any>;
   signTransaction(
     transactionOrPayload: AnyRawTransaction | Types.TransactionPayload,
+    asFeePayer?: boolean,
     options?: InputGenerateTransactionOptions
   ): Promise<AccountAuthenticator>;
   submitTransaction(

--- a/packages/wallet-adapter-react/src/useWallet.tsx
+++ b/packages/wallet-adapter-react/src/useWallet.tsx
@@ -2,7 +2,6 @@ import {
   AccountInfo,
   NetworkInfo,
   WalletInfo,
-  WalletName,
   SignMessagePayload,
   SignMessageResponse,
   Wallet,
@@ -11,20 +10,24 @@ import {
   isInAppBrowser,
   isRedirectable,
   isMobile,
-  TransactionOptions,
-  TxnBuilderTypes,
-  Types,
+  InputGenerateTransactionOptions,
   InputGenerateTransactionData,
+  AnyRawTransaction,
+  InputSubmitTransactionData,
+  PendingTransactionResponse,
+  AccountAuthenticator,
+  Types,
+  WalletName,
 } from "@aptos-labs/wallet-adapter-core";
 import { createContext, useContext } from "react";
 
-export type { WalletName, Wallet };
+export type { Wallet, WalletName };
 export {
   WalletReadyState,
-  NetworkName,
   isInAppBrowser,
   isRedirectable,
   isMobile,
+  NetworkName,
 };
 
 export interface WalletContextState {
@@ -36,32 +39,27 @@ export interface WalletContextState {
   disconnect(): void;
   wallet: WalletInfo | null;
   wallets: ReadonlyArray<Wallet>;
-  signAndSubmitTransaction<T extends Types.TransactionPayload>(
-    transaction: T,
-    options?: TransactionOptions
+  signAndSubmitTransaction(
+    transaction: InputGenerateTransactionData,
+    options?: InputGenerateTransactionOptions
   ): Promise<any>;
-  signAndSubmitBCSTransaction<T extends TxnBuilderTypes.TransactionPayload>(
-    transaction: T,
-    options?: TransactionOptions
-  ): Promise<any>;
-  signTransaction<T extends Types.TransactionPayload>(
-    transaction: T,
-    options?: TransactionOptions
-  ): Promise<any>;
-  signMessage(message: SignMessagePayload): Promise<SignMessageResponse | null>;
+  signTransaction(
+    transactionOrPayload: AnyRawTransaction | Types.TransactionPayload,
+    options?: InputGenerateTransactionOptions
+  ): Promise<AccountAuthenticator>;
+  submitTransaction(
+    transaction: InputSubmitTransactionData
+  ): Promise<PendingTransactionResponse>;
+  signMessage(message: SignMessagePayload): Promise<SignMessageResponse>;
   signMessageAndVerify(message: SignMessagePayload): Promise<boolean>;
-  submitTransaction(transaction: InputGenerateTransactionData): Promise<any>;
-  signMultiAgentTransaction(
-      transaction: TxnBuilderTypes.MultiAgentRawTransaction | TxnBuilderTypes.FeePayerRawTransaction,
-  ): Promise<any>;
 }
 
-const DEFAULT_COUNTEXT = {
+const DEFAULT_CONTEXT = {
   connected: false,
 };
 
 export const WalletContext = createContext<WalletContextState>(
-  DEFAULT_COUNTEXT as WalletContextState
+  DEFAULT_CONTEXT as WalletContextState
 );
 
 export function useWallet(): WalletContextState {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,8 +28,8 @@ importers:
   apps/nextjs-example:
     dependencies:
       '@aptos-labs/ts-sdk':
-        specifier: ^0.0.5
-        version: 0.0.5
+        specifier: ^0.0.6
+        version: 0.0.6
       '@aptos-labs/wallet-adapter-ant-design':
         specifier: workspace:*
         version: link:../../packages/wallet-adapter-ant-design
@@ -198,8 +198,8 @@ importers:
   packages/wallet-adapter-core:
     dependencies:
       '@aptos-labs/ts-sdk':
-        specifier: ^0.0.5
-        version: 0.0.5
+        specifier: ^0.0.6
+        version: 0.0.6
       aptos:
         specifier: ^1.19.0
         version: 1.20.0
@@ -403,15 +403,15 @@ packages:
       - debug
     dev: false
 
-  /@aptos-labs/ts-sdk@0.0.5:
-    resolution: {integrity: sha512-fLvyISjPuOP8Rzt3yeuCsfBztSMId19Z0xpMY8ZRM03sqc4zZGk8ID2PLMhy/F0etLGMSPWh1qqycsnjHbeoWw==}
+  /@aptos-labs/ts-sdk@0.0.6:
+    resolution: {integrity: sha512-rsfMbUBbQLVudtxTuisEH/AIDysiTBsd/493vGwozEK6rD2yjkU9h31hmyGylwj5gPCb6Pu2HJdAKNx5LZH5AQ==}
     engines: {node: '>=11.0.0'}
     dependencies:
       '@aptos-labs/aptos-client': 0.0.2
       '@noble/curves': 1.2.0
-      '@noble/hashes': 1.1.3
+      '@noble/hashes': 1.3.2
       '@scure/bip32': 1.3.2
-      '@scure/bip39': 1.1.0
+      '@scure/bip39': 1.2.1
       form-data: 4.0.0
       tweetnacl: 1.0.3
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,8 +28,8 @@ importers:
   apps/nextjs-example:
     dependencies:
       '@aptos-labs/ts-sdk':
-        specifier: ^0.0.3
-        version: 0.0.3
+        specifier: ^0.0.5
+        version: 0.0.5
       '@aptos-labs/wallet-adapter-ant-design':
         specifier: workspace:*
         version: link:../../packages/wallet-adapter-ant-design
@@ -90,9 +90,6 @@ importers:
       antd:
         specifier: ^5.1.2
         version: 5.10.2(react-dom@18.2.0)(react@18.2.0)
-      aptos:
-        specifier: ^1.19.0
-        version: 1.20.0
       ethers:
         specifier: ^5.7.2
         version: 5.7.2
@@ -201,8 +198,8 @@ importers:
   packages/wallet-adapter-core:
     dependencies:
       '@aptos-labs/ts-sdk':
-        specifier: ^0.0.3
-        version: 0.0.3
+        specifier: ^0.0.5
+        version: 0.0.5
       aptos:
         specifier: ^1.19.0
         version: 1.20.0
@@ -406,13 +403,14 @@ packages:
       - debug
     dev: false
 
-  /@aptos-labs/ts-sdk@0.0.3:
-    resolution: {integrity: sha512-1qVcKAMToLI+EOrw0kQvL9/yyXZ7iU4/NIpvFokIWK6DNe3ExSu+SebwFc0jAqyy/kvMWht8FBF2hnmW2G1pyA==}
+  /@aptos-labs/ts-sdk@0.0.5:
+    resolution: {integrity: sha512-fLvyISjPuOP8Rzt3yeuCsfBztSMId19Z0xpMY8ZRM03sqc4zZGk8ID2PLMhy/F0etLGMSPWh1qqycsnjHbeoWw==}
     engines: {node: '>=11.0.0'}
     dependencies:
       '@aptos-labs/aptos-client': 0.0.2
       '@noble/curves': 1.2.0
       '@noble/hashes': 1.1.3
+      '@scure/bip32': 1.3.2
       '@scure/bip39': 1.1.0
       form-data: 4.0.0
       tweetnacl: 1.0.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,8 +28,8 @@ importers:
   apps/nextjs-example:
     dependencies:
       '@aptos-labs/ts-sdk':
-        specifier: ^0.0.6
-        version: 0.0.6
+        specifier: ^0.0.7
+        version: 0.0.7
       '@aptos-labs/wallet-adapter-ant-design':
         specifier: workspace:*
         version: link:../../packages/wallet-adapter-ant-design
@@ -198,8 +198,8 @@ importers:
   packages/wallet-adapter-core:
     dependencies:
       '@aptos-labs/ts-sdk':
-        specifier: ^0.0.6
-        version: 0.0.6
+        specifier: ^0.0.7
+        version: 0.0.7
       aptos:
         specifier: ^1.19.0
         version: 1.20.0
@@ -403,8 +403,8 @@ packages:
       - debug
     dev: false
 
-  /@aptos-labs/ts-sdk@0.0.6:
-    resolution: {integrity: sha512-rsfMbUBbQLVudtxTuisEH/AIDysiTBsd/493vGwozEK6rD2yjkU9h31hmyGylwj5gPCb6Pu2HJdAKNx5LZH5AQ==}
+  /@aptos-labs/ts-sdk@0.0.7:
+    resolution: {integrity: sha512-6YRVRrrKFIo2wiYVmrgcl6oj87B2LW+AhgrAQGIvwHPzr+ihQl2woFpC/UmygG9dv+n8Ow9XOhuFGlg60Xwngw==}
     engines: {node: '>=11.0.0'}
     dependencies:
       '@aptos-labs/aptos-client': 0.0.2


### PR DESCRIPTION
Wallet Adapter V2

- Dapp to support SDK V2 and use only @aptos-labs/ts-sdk package. 
- Add 3 different transaction flows - Single signer, Fee payer, Multi Agent. See attached video. 
   - Single signer has the same functionality with the option to `signAndSubmitTransction`, `signMessage`, `signMessageAndVerify`. For `signTransaction` we had to keep both V1 and V2 "ways" as we can't really change the function signature without introducing wallet plugin breaking changes. We can technically just use a new function with a different name only for V2 but rather to use the same function to support both v1 and v2 to easy ecosystem adoption 
   - Fee payer flow supports `sign as sender`, then need to switch wallet to `sign as sponsor`, and then submit transaction (everything implemented in the V2 way)
   - Multi agent flow supports `sign as sender`, then you would get a private key you can import to the wallet to `sign as secondary signer`, and then submit transaction (everything implemented in the V2 way)

Note: I chose this way so users can experience the use of signing with a wallet and can experience the e2e flow with a wallet.

 - Wallet core conversion layer from `signAndSubmitTransaction` with V2 inputs -> V1 `signAndSubmitTransaction` or V2 `signAndSubmitBCSTransaction`
 - Wallet core conversion layer to return V2 `AccountAuthenticator` from `signTransaction`
 - `submitTransaction` to only support V2 expected flow


https://github.com/aptos-labs/aptos-wallet-adapter/assets/29798064/580d2ad4-a514-479c-8de5-2c12a66d2e11

