### PR TITLE
Make sender optional when sign and submit single signer transaction

### DIFF
--- a/.changeset/slimy-dingos-listen.md
+++ b/.changeset/slimy-dingos-listen.md
@@ -1,0 +1,7 @@
+---
+"@aptos-labs/wallet-adapter-react": minor
+"@aptos-labs/wallet-adapter-core": minor
+"@aptos-labs/wallet-adapter-nextjs-example": minor
+---
+
+Make sender optional when sign and submit single signer transaction

--- a/apps/nextjs-example/components/transactionFlow/SingleSigner.tsx
+++ b/apps/nextjs-example/components/transactionFlow/SingleSigner.tsx
@@ -52,14 +52,12 @@ export default function SingleSignerTransaction({
 
     try {
       const response = await signAndSubmitTransaction({
-        sender: account.address,
         data: {
           function: "0x1::coin::transfer",
           typeArguments: [APTOS_COIN],
           functionArguments: [account.address, 1], // 1 is in Octas
         },
       });
-      console.log("response", response);
       await aptosClient(network?.name.toLowerCase()).waitForTransaction({
         transactionHash: response.hash,
       });
@@ -74,7 +72,6 @@ export default function SingleSignerTransaction({
 
     try {
       const response = await signAndSubmitTransaction({
-        sender: account.address,
         data: {
           function: "0x1::coin::transfer",
           typeArguments: [parseTypeTag(APTOS_COIN)],
@@ -90,6 +87,7 @@ export default function SingleSignerTransaction({
     }
   };
 
+  // Legacy typescript sdk support
   const onSignTransaction = async () => {
     try {
       const payload = {

--- a/packages/wallet-adapter-core/src/WalletCore.ts
+++ b/packages/wallet-adapter-core/src/WalletCore.ts
@@ -1,6 +1,5 @@
 import { HexString, TxnBuilderTypes, Types, BCS } from "aptos";
 import {
-  InputGenerateTransactionData,
   AnyRawTransaction,
   AccountAuthenticator,
   AccountAuthenticatorEd25519,
@@ -42,6 +41,7 @@ import {
   WalletInfo,
   WalletCoreEvents,
   SignMessageResponse,
+  InputTransactionData,
 } from "./types";
 import {
   removeLocalStorage,
@@ -285,12 +285,12 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
   /**
    * Signs and submits a transaction to chain
    *
-   * @param transactionInput InputGenerateTransactionData
+   * @param transactionInput InputTransactionData
    * @param options optional. A configuration object to generate a transaction by
    * @returns The pending transaction hash (V1 output) | PendingTransactionResponse (V2 output)
    */
   async signAndSubmitTransaction(
-    transactionInput: InputGenerateTransactionData,
+    transactionInput: InputTransactionData,
     options?: InputGenerateTransactionOptions
   ): Promise<
     { hash: Types.HexEncodedBytes; output?: any } | PendingTransactionResponse
@@ -301,7 +301,10 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
       // wallet supports sdk v2
       if (this._wallet?.version === "v2") {
         const response = await this._wallet.signAndSubmitTransaction(
-          transactionInput,
+          {
+            ...transactionInput,
+            sender: transactionInput.sender ?? this._account!.address,
+          },
           options
         );
         // response should be PendingTransactionResponse

--- a/packages/wallet-adapter-core/src/types.ts
+++ b/packages/wallet-adapter-core/src/types.ts
@@ -5,6 +5,7 @@ import {
   InputGenerateTransactionOptions,
   InputSubmitTransactionData,
   PendingTransactionResponse,
+  AccountAddressInput,
 } from "@aptos-labs/ts-sdk";
 import { WalletReadyState } from "./constants";
 
@@ -126,3 +127,9 @@ export interface TransactionOptions {
   max_gas_amount?: bigint;
   gas_unit_price?: bigint;
 }
+
+// Omit the ts-sdk InputGenerateTransactionData type to make "sender" optional
+export type InputTransactionData = Omit<
+  InputGenerateTransactionData,
+  "sender"
+> & { sender?: AccountAddressInput };

--- a/packages/wallet-adapter-react/src/WalletProvider.tsx
+++ b/packages/wallet-adapter-react/src/WalletProvider.tsx
@@ -15,13 +15,13 @@ import type {
   WalletInfo,
   InputGenerateTransactionOptions,
   AnyRawTransaction,
-  InputGenerateTransactionData,
   InputSubmitTransactionData,
   AccountAuthenticator,
   PendingTransactionResponse,
   SignMessageResponse,
   WalletName,
   Types,
+  InputTransactionData,
 } from "@aptos-labs/wallet-adapter-core";
 import { WalletCore } from "@aptos-labs/wallet-adapter-core";
 
@@ -131,7 +131,7 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
   };
 
   const signAndSubmitTransaction = async (
-    transaction: InputGenerateTransactionData,
+    transaction: InputTransactionData,
     options?: InputGenerateTransactionOptions
   ) => {
     try {

--- a/packages/wallet-adapter-react/src/useWallet.tsx
+++ b/packages/wallet-adapter-react/src/useWallet.tsx
@@ -11,8 +11,8 @@ import {
   isRedirectable,
   isMobile,
   InputGenerateTransactionOptions,
-  InputGenerateTransactionData,
   AnyRawTransaction,
+  InputTransactionData,
   InputSubmitTransactionData,
   PendingTransactionResponse,
   AccountAuthenticator,
@@ -40,7 +40,7 @@ export interface WalletContextState {
   wallet: WalletInfo | null;
   wallets: ReadonlyArray<Wallet>;
   signAndSubmitTransaction(
-    transaction: InputGenerateTransactionData,
+    transaction: InputTransactionData,
     options?: InputGenerateTransactionOptions
   ): Promise<any>;
   signTransaction(


### PR DESCRIPTION
`sender` prop should not be required by the dapp to provide when sign and submit a single signer transaction, this PR makes it an optional prop and if not provided the adapter would take care for it