### PR TITLE
Consolidate `options` argument on `signAndSubmitTransaction`

### DIFF
--- a/.changeset/grumpy-forks-change.md
+++ b/.changeset/grumpy-forks-change.md
@@ -1,0 +1,6 @@
+---
+"@aptos-labs/wallet-adapter-react": patch
+"@aptos-labs/wallet-adapter-core": patch
+---
+
+Consolidate options argument on signAndSubmitTransaction

--- a/packages/wallet-adapter-core/src/WalletCore.ts
+++ b/packages/wallet-adapter-core/src/WalletCore.ts
@@ -290,8 +290,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
    * @returns The pending transaction hash (V1 output) | PendingTransactionResponse (V2 output)
    */
   async signAndSubmitTransaction(
-    transactionInput: InputTransactionData,
-    options?: InputGenerateTransactionOptions
+    transactionInput: InputTransactionData
   ): Promise<
     { hash: Types.HexEncodedBytes; output?: any } | PendingTransactionResponse
   > {
@@ -300,13 +299,10 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
 
       // wallet supports sdk v2
       if (this._wallet?.version === "v2") {
-        const response = await this._wallet.signAndSubmitTransaction(
-          {
-            ...transactionInput,
-            sender: transactionInput.sender ?? this._account!.address,
-          },
-          options
-        );
+        const response = await this._wallet.signAndSubmitTransaction({
+          ...transactionInput,
+          sender: transactionInput.sender ?? this._account!.address,
+        });
         // response should be PendingTransactionResponse
         return response;
       }
@@ -330,11 +326,11 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
           oldTransactionPayload,
           this._wallet!,
           {
-            max_gas_amount: options?.maxGasAmount
-              ? BigInt(options?.maxGasAmount)
+            max_gas_amount: transactionInput.options?.maxGasAmount
+              ? BigInt(transactionInput.options?.maxGasAmount)
               : undefined,
-            gas_unit_price: options?.gasUnitPrice
-              ? BigInt(options?.gasUnitPrice)
+            gas_unit_price: transactionInput.options?.gasUnitPrice
+              ? BigInt(transactionInput.options?.gasUnitPrice)
               : undefined,
           }
         );
@@ -350,11 +346,11 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
         oldTransactionPayload,
         this._wallet!,
         {
-          max_gas_amount: options?.maxGasAmount
-            ? BigInt(options?.maxGasAmount)
+          max_gas_amount: transactionInput.options?.maxGasAmount
+            ? BigInt(transactionInput.options?.maxGasAmount)
             : undefined,
-          gas_unit_price: options?.gasUnitPrice
-            ? BigInt(options?.gasUnitPrice)
+          gas_unit_price: transactionInput.options?.gasUnitPrice
+            ? BigInt(transactionInput.options?.gasUnitPrice)
             : undefined,
         }
       );

--- a/packages/wallet-adapter-core/src/types.ts
+++ b/packages/wallet-adapter-core/src/types.ts
@@ -6,6 +6,7 @@ import {
   InputSubmitTransactionData,
   PendingTransactionResponse,
   AccountAddressInput,
+  InputGenerateTransactionPayloadData,
 } from "@aptos-labs/ts-sdk";
 import { WalletReadyState } from "./constants";
 
@@ -128,8 +129,8 @@ export interface TransactionOptions {
   gas_unit_price?: bigint;
 }
 
-// Omit the ts-sdk InputGenerateTransactionData type to make "sender" optional
-export type InputTransactionData = Omit<
-  InputGenerateTransactionData,
-  "sender"
-> & { sender?: AccountAddressInput };
+export type InputTransactionData = {
+  sender?: AccountAddressInput;
+  data: InputGenerateTransactionPayloadData;
+  options?: InputGenerateTransactionOptions;
+};

--- a/packages/wallet-adapter-react/src/WalletProvider.tsx
+++ b/packages/wallet-adapter-react/src/WalletProvider.tsx
@@ -131,11 +131,10 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
   };
 
   const signAndSubmitTransaction = async (
-    transaction: InputTransactionData,
-    options?: InputGenerateTransactionOptions
+    transaction: InputTransactionData
   ) => {
     try {
-      return await walletCore.signAndSubmitTransaction(transaction, options);
+      return await walletCore.signAndSubmitTransaction(transaction);
     } catch (error: any) {
       if (onError) onError(error);
       return Promise.reject(error);

--- a/packages/wallet-adapter-react/src/useWallet.tsx
+++ b/packages/wallet-adapter-react/src/useWallet.tsx
@@ -39,10 +39,7 @@ export interface WalletContextState {
   disconnect(): void;
   wallet: WalletInfo | null;
   wallets: ReadonlyArray<Wallet>;
-  signAndSubmitTransaction(
-    transaction: InputTransactionData,
-    options?: InputGenerateTransactionOptions
-  ): Promise<any>;
+  signAndSubmitTransaction(transaction: InputTransactionData): Promise<any>;
   signTransaction(
     transactionOrPayload: AnyRawTransaction | Types.TransactionPayload,
     asFeePayer?: boolean,


### PR DESCRIPTION
`signAndSubmitTransaction` function arguments accepts the `options` argument in multiple ways
1. As part of the `transaction` argument object
2. As a second argument

This PR consolidates the argument an is now part of the `transaction` argument object
Should fix https://github.com/aptos-labs/aptos-wallet-adapter/issues/209