### PR TITLE
Fix is bcs argument types check

### DIFF
--- a/.changeset/rare-elephants-breathe.md
+++ b/.changeset/rare-elephants-breathe.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/wallet-adapter-core": patch
+---
+
+Fix is bcs argument types check

--- a/packages/wallet-adapter-core/src/WalletCore.ts
+++ b/packages/wallet-adapter-core/src/WalletCore.ts
@@ -49,6 +49,7 @@ import {
   scopePollingDetectionStrategy,
   isRedirectable,
   generalizedErrorMessage,
+  areBCSArguments,
 } from "./utils";
 import { getNameByAddress } from "./ans";
 import {
@@ -310,9 +311,8 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
       // get the payload piece from the input
       const payloadData = transactionInput.data;
 
-      // if first function arguments is an object (i.e a bcs serialized argument)
-      // we assume the transaction should be a bcs serialized transaction
-      if (typeof payloadData.functionArguments[0] === "object") {
+      // first check if each argument is a BCS serialized argument
+      if (areBCSArguments(payloadData.functionArguments)) {
         const aptosConfig = new AptosConfig({
           network: convertNetwork(this._network),
         });
@@ -337,7 +337,6 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
         const { hash, ...output } = response;
         return { hash, output };
       }
-
       // if it is not a bcs serialized arguments transaction, convert to the old
       // json format
       const oldTransactionPayload =

--- a/packages/wallet-adapter-core/src/utils/helpers.ts
+++ b/packages/wallet-adapter-core/src/utils/helpers.ts
@@ -1,3 +1,5 @@
+import { Serializable } from "@aptos-labs/ts-sdk";
+
 export function isMobile(): boolean {
   return /Mobile|iP(hone|od|ad)|Android|BlackBerry|IEMobile|Kindle|NetFront|Silk-Accelerated|(hpw|web)OS|Fennec|Minimo|Opera M(obi|ini)|Blazer|Dolfin|Dolphin|Skyfire|Zune/i.test(
     navigator.userAgent
@@ -30,3 +32,11 @@ export function generalizedErrorMessage(error: any): string {
     ? error.message
     : error;
 }
+
+// Helper function to check if input arguments are BCS serialized arguments.
+// In @aptos-labs/ts-sdk each move representative class extends
+// Serializable, so if each argument is of an instance of a class
+// the extends Serializable - we know these are BCS arguments
+export const areBCSArguments = (args: any): boolean => {
+  return args.every((arg: any) => arg instanceof Serializable);
+};


### PR DESCRIPTION
fixes https://github.com/aptos-labs/aptos-wallet-adapter/issues/219

We first differentiate bcs transaction and simple json transaction by checking if the first argument is of type `object`.
Since `Array`, `Uint8Array` and more all resolves to  the `object` type, the code is buggy.

We fix it by checking if each argument extends Serializable class. 
In @aptos-labs/ts-sdk each move representative class extends Serializable, so if each argument is of an instance of a class
the extends Serializable - we know these are BCS arguments