### PR TITLE
Return false from `areBCSArguments` function if array is empty

### DIFF
--- a/.changeset/many-numbers-punch.md
+++ b/.changeset/many-numbers-punch.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/wallet-adapter-core": patch
+---
+
+Return false from areBCSArguments function if array is empty

--- a/packages/wallet-adapter-core/src/utils/helpers.ts
+++ b/packages/wallet-adapter-core/src/utils/helpers.ts
@@ -38,5 +38,8 @@ export function generalizedErrorMessage(error: any): string {
 // Serializable, so if each argument is of an instance of a class
 // the extends Serializable - we know these are BCS arguments
 export const areBCSArguments = (args: any): boolean => {
+  // `every` returns true if the array is empty, so
+  // first check the array length
+  if (args.length === 0) return false;
   return args.every((arg: any) => arg instanceof Serializable);
 };

--- a/packages/wallet-adapter-core/src/utils/helpers.ts
+++ b/packages/wallet-adapter-core/src/utils/helpers.ts
@@ -1,4 +1,8 @@
-import { Serializable } from "@aptos-labs/ts-sdk";
+import {
+  EntryFunctionArgumentTypes,
+  Serializable,
+  SimpleEntryFunctionArgumentTypes,
+} from "@aptos-labs/ts-sdk";
 
 export function isMobile(): boolean {
   return /Mobile|iP(hone|od|ad)|Android|BlackBerry|IEMobile|Kindle|NetFront|Silk-Accelerated|(hpw|web)OS|Fennec|Minimo|Opera M(obi|ini)|Blazer|Dolfin|Dolphin|Skyfire|Zune/i.test(
@@ -37,9 +41,14 @@ export function generalizedErrorMessage(error: any): string {
 // In @aptos-labs/ts-sdk each move representative class extends
 // Serializable, so if each argument is of an instance of a class
 // the extends Serializable - we know these are BCS arguments
-export const areBCSArguments = (args: any): boolean => {
+export const areBCSArguments = (
+  args: Array<EntryFunctionArgumentTypes | SimpleEntryFunctionArgumentTypes>
+): boolean => {
   // `every` returns true if the array is empty, so
   // first check the array length
   if (args.length === 0) return false;
-  return args.every((arg: any) => arg instanceof Serializable);
+  return args.every(
+    (arg: EntryFunctionArgumentTypes | SimpleEntryFunctionArgumentTypes) =>
+      arg instanceof Serializable
+  );
 };


### PR DESCRIPTION
`areBCSArguments` function will return `true` if `args` is empty (`every` returns true for an empty array). That causes the adapter to use `signAndSubmitBCSTransaction` when `functionArguments` is empty. We want to avoid it, and use `signAndSubmitTransaction` since all wallets support this function and not the former one.