### PR TITLE
Update to latest sdk version `1.3.0`

### DIFF
--- a/.changeset/dirty-guests-bathe.md
+++ b/.changeset/dirty-guests-bathe.md
@@ -1,0 +1,6 @@
+---
+"@aptos-labs/wallet-adapter-core": minor
+"@aptos-labs/wallet-adapter-nextjs-example": minor
+---
+
+Update @aptos-labs/ts-sdk package version to 1.3.0

--- a/apps/nextjs-example/package.json
+++ b/apps/nextjs-example/package.json
@@ -11,7 +11,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@aptos-labs/ts-sdk": "1.2.0",
+    "@aptos-labs/ts-sdk": "1.3.0",
     "@aptos-labs/wallet-adapter-ant-design": "workspace:*",
     "@aptos-labs/wallet-adapter-core": "workspace:*",
     "@aptos-labs/wallet-adapter-mui-design": "workspace:*",

--- a/packages/wallet-adapter-core/package.json
+++ b/packages/wallet-adapter-core/package.json
@@ -51,6 +51,6 @@
   },
   "peerDependencies": {
     "aptos": "^1.21.0",
-    "@aptos-labs/ts-sdk": "^1.2.0"
+    "@aptos-labs/ts-sdk": "^1.3.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,8 +28,8 @@ importers:
   apps/nextjs-example:
     dependencies:
       '@aptos-labs/ts-sdk':
-        specifier: 1.2.0
-        version: 1.2.0
+        specifier: 1.3.0
+        version: 1.3.0
       '@aptos-labs/wallet-adapter-ant-design':
         specifier: workspace:*
         version: link:../../packages/wallet-adapter-ant-design
@@ -201,8 +201,8 @@ importers:
   packages/wallet-adapter-core:
     dependencies:
       '@aptos-labs/ts-sdk':
-        specifier: ^1.2.0
-        version: 1.2.0
+        specifier: ^1.3.0
+        version: 1.3.0
       aptos:
         specifier: ^1.21.0
         version: 1.21.0
@@ -413,12 +413,12 @@ packages:
       - debug
     dev: false
 
-  /@aptos-labs/ts-sdk@1.2.0:
-    resolution: {integrity: sha512-pe7MhSmyZ6ez4tPud8Q3KOsthdJOR8SNUT/c0gPUIET2yVOf/cmx9TT/dIBm8kwX7hVWZGX4aBWDvZJbeY6dRg==}
+  /@aptos-labs/ts-sdk@1.3.0:
+    resolution: {integrity: sha512-cg9S9ZGEYrb2SfIh8q5Evo/joz+rIM/SmrJI7Wa7S0CG3fBd8v8NBePG+obBm+LU4pPbJRw7KGrX6rsdqvQwWw==}
     engines: {node: '>=11.0.0'}
     dependencies:
       '@aptos-labs/aptos-client': 0.1.0
-      '@noble/curves': 1.2.0
+      '@noble/curves': 1.3.0
       '@noble/hashes': 1.3.3
       '@scure/bip32': 1.3.3
       '@scure/bip39': 1.2.1
@@ -2821,7 +2821,7 @@ packages:
     resolution: {integrity: sha512-osvveYtyzdEVbt3OfwwXFr4P2iVBL5u1Q3q4ONBfDY/UpOuXmOlbgwc1xECEboY8wIays8Yt6onaWMUdUbfl0A==}
     dependencies:
       '@noble/curves': 1.1.0
-      '@noble/hashes': 1.3.2
+      '@noble/hashes': 1.3.3
       '@scure/base': 1.1.3
     dev: false
 


### PR DESCRIPTION
This PR updates ts sdk to the latest version where we use `number` types for transaction options parameters. https://github.com/aptos-labs/aptos-ts-sdk/pull/248

With this change the legacy code still converts transaction option parameters to `BigInt` for wallet backward compatibility, but for any usage with the new sdk we use the `number` type.