### PR TITLE
[bug fix] use current connected wallet to compare to the selected walle…

### DIFF
--- a/.changeset/happy-kiwis-pull.md
+++ b/.changeset/happy-kiwis-pull.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/wallet-adapter-core": minor
+---
+
+['Bug fix'] Use current connected wallet to compare to the selected wallet before connecting to a wallet

--- a/packages/wallet-adapter-core/src/WalletCore.ts
+++ b/packages/wallet-adapter-core/src/WalletCore.ts
@@ -207,7 +207,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
 
     if (this._connected) {
       // if the selected wallet is already connected, we don't need to connect again
-      if (selectedWallet.name === walletName)
+      if (this._wallet?.name === walletName)
         throw new WalletConnectionError(
           `${walletName} wallet is already connected`
         ).message;


### PR DESCRIPTION
…t before connecting to a wallet

A partner reported that when trying to connect to a new wallet when another wallet is already connected, the adapter throws  "X wallet is already connected"

Note: after this PR lands and a new core package version published, we need to put up another PR to bump the react package to use the new core version