### PR TITLE
Export `PluginProvider` type

### DIFF
--- a/.changeset/dull-lobsters-approve.md
+++ b/.changeset/dull-lobsters-approve.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/wallet-adapter-core": minor
+---
+
+Export PluginProvider type

--- a/apps/nextjs-example/components/AppContext.tsx
+++ b/apps/nextjs-example/components/AppContext.tsx
@@ -12,8 +12,8 @@ import { TokenPocketWallet } from "@tp-lab/aptos-wallet-adapter";
 import { TrustWallet } from "@trustwallet/aptos-wallet-adapter";
 import { MSafeWalletAdapter } from "@msafe/aptos-wallet-adapter";
 import { WelldoneWallet } from "@welldone-studio/aptos-wallet-adapter";
-import { OKXWallet } from '@okwallet/aptos-wallet-adapter';
-import { OnekeyWallet } from '@onekeyfe/aptos-wallet-adapter';
+import { OKXWallet } from "@okwallet/aptos-wallet-adapter";
+import { OnekeyWallet } from "@onekeyfe/aptos-wallet-adapter";
 import {
   AptosWalletAdapterProvider,
   NetworkName,

--- a/packages/wallet-adapter-core/src/WalletCoreV1.ts
+++ b/packages/wallet-adapter-core/src/WalletCoreV1.ts
@@ -2,6 +2,7 @@ import { TxnBuilderTypes, Types } from "aptos";
 import EventEmitter from "eventemitter3";
 
 import {
+  WalletNotSupportedMethod,
   WalletSignAndSubmitMessageError,
   WalletSignTransactionError,
 } from "./error";
@@ -45,6 +46,11 @@ export class WalletCoreV1 extends EventEmitter<WalletCoreEvents> {
     wallet: Wallet,
     options?: TransactionOptions
   ): Promise<any> {
+    if (!("signAndSubmitBCSTransaction" in wallet)) {
+      throw new WalletNotSupportedMethod(
+        `Submit a BCS Transaction is not supported by ${wallet.name}`
+      ).message;
+    }
     try {
       const response = await (wallet as any).signAndSubmitBCSTransaction(
         transaction,

--- a/packages/wallet-adapter-core/src/types.ts
+++ b/packages/wallet-adapter-core/src/types.ts
@@ -103,7 +103,7 @@ export interface AdapterPluginProps<Name extends string = string> {
   connect(): Promise<any>;
   disconnect: () => Promise<any>;
   network: () => Promise<any>;
-  signAndSubmitTransaction<V>(
+  signAndSubmitTransaction(
     transaction: Types.TransactionPayload | InputGenerateTransactionData,
     options?: InputGenerateTransactionOptions
   ): Promise<
@@ -134,3 +134,20 @@ export type InputTransactionData = {
   data: InputGenerateTransactionPayloadData;
   options?: InputGenerateTransactionOptions;
 };
+
+// To be used by a wallet plugin
+export interface PluginProvider {
+  connect: () => Promise<AccountInfo>;
+  account: () => Promise<AccountInfo>;
+  disconnect: () => Promise<void>;
+  signAndSubmitTransaction: (
+    transaction: any,
+    options?: any
+  ) => Promise<{ hash: Types.HexEncodedBytes } | AptosWalletErrorResult>;
+  signMessage: (message: SignMessagePayload) => Promise<SignMessageResponse>;
+  network: () => Promise<NetworkInfo>;
+  onAccountChange: (
+    listener: (newAddress: AccountInfo) => Promise<void>
+  ) => Promise<void>;
+  onNetworkChange: OnNetworkChange;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7245,7 +7245,7 @@ packages:
     resolution: {integrity: sha512-snhhP/qKXLg4foKsDVvy0Jus3H7o46L75aDCXiiSAonty2CnZe1+4cpB8azc7khaMgig+xj9gZbZXKmKtB+HqA==}
     dependencies:
       '@aptos-labs/wallet-adapter-core': 2.5.1
-      aptos: 1.20.0
+      aptos: 1.21.0
     transitivePeerDependencies:
       - debug
     dev: false


### PR DESCRIPTION
It was accidentally removed in a pervious PR https://github.com/aptos-labs/aptos-wallet-adapter/pull/197/files#diff-7f6afdc104abf83a13ea1b33e35084eb02cfe211ef64b2b6acb83cef8346e3dcL33

We need this type for a wallet plugin 