### PR TITLE
feat: Change the return value of the connect function to Promise<AccountInfo | null>

### DIFF
--- a/.changeset/real-moose-own.md
+++ b/.changeset/real-moose-own.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/wallet-adapter-react": minor
+---
+
+Change the return value of the connect function to Promise<AccountInfo | null>

--- a/packages/wallet-adapter-react/src/WalletProvider.tsx
+++ b/packages/wallet-adapter-react/src/WalletProvider.tsx
@@ -66,6 +66,7 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
     try {
       setIsLoading(true);
       await walletCore.connect(walletName);
+      return walletCore.account;
     } catch (error: any) {
       console.log("connect error", error);
       if (onError) onError(error);

--- a/packages/wallet-adapter-react/src/useWallet.tsx
+++ b/packages/wallet-adapter-react/src/useWallet.tsx
@@ -21,7 +21,7 @@ export interface WalletContextState {
   isLoading: boolean;
   account: AccountInfo | null;
   network: NetworkInfo | null;
-  connect(walletName: WalletName): void;
+  connect(walletName: WalletName): Promise<AccountInfo | null>;
   disconnect(): void;
   wallet: WalletInfo | null;
   wallets: ReadonlyArray<Wallet>;


### PR DESCRIPTION
A Pull Request has been created to enable various operations without the necessity of using useEffect after invoking the connect function in the wallet-adapter-react library.

related docs: 
- https://react.dev/reference/rules/components-and-hooks-must-be-pure#side-effects-must-run-outside-of-render
- https://aptos.dev/standards/wallets/#connection-apis