### PR TITLE
Remove Nightly package dependency

### DIFF
--- a/apps/nextjs-example/components/AppContext.tsx
+++ b/apps/nextjs-example/components/AppContext.tsx
@@ -4,7 +4,6 @@ import { FaceWallet } from "@haechi-labs/face-aptos-adapter-plugin";
 import { FewchaWallet } from "fewcha-plugin-wallet-adapter";
 import { FlipperWallet } from "@flipperplatform/wallet-adapter-plugin";
 import { MartianWallet } from "@martianwallet/aptos-wallet-adapter";
-import { NightlyWallet } from "@nightlylabs/aptos-wallet-adapter-plugin";
 import { OpenBlockWallet } from "@openblockhq/aptos-wallet-adapter";
 import { PetraWallet } from "petra-plugin-wallet-adapter";
 import { PontemWallet } from "@pontem/wallet-adapter-plugin";
@@ -45,7 +44,6 @@ const WalletContextProvider: FC<{ children: ReactNode }> = ({ children }) => {
     new FlipperWallet(),
     new MartianWallet(),
     new MSafeWalletAdapter(),
-    new NightlyWallet(),
     new OpenBlockWallet(),
     new PetraWallet(),
     new PontemWallet(),

--- a/apps/nextjs-example/package.json
+++ b/apps/nextjs-example/package.json
@@ -26,7 +26,6 @@
     "@identity-connect/wallet-adapter-plugin": "^1.2.5",
     "@martianwallet/aptos-wallet-adapter": "^0.0.5",
     "@msafe/aptos-wallet-adapter": "^1.0.11",
-    "@nightlylabs/aptos-wallet-adapter-plugin": "^0.2.12",
     "@okwallet/aptos-wallet-adapter": "^0.0.3",
     "@onekeyfe/aptos-wallet-adapter": "^0.1.2",
     "@openblockhq/aptos-wallet-adapter": "^0.1.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,9 +72,6 @@ importers:
       '@msafe/aptos-wallet-adapter':
         specifier: ^1.0.11
         version: 1.0.14
-      '@nightlylabs/aptos-wallet-adapter-plugin':
-        specifier: ^0.2.12
-        version: 0.2.12
       '@okwallet/aptos-wallet-adapter':
         specifier: ^0.0.3
         version: 0.0.3
@@ -2520,17 +2517,6 @@ packages:
     requiresBuild: true
     dev: false
     optional: true
-
-  /@nightlylabs/aptos-wallet-adapter-plugin@0.2.12:
-    resolution: {integrity: sha512-caDmoy3Az060YXHSmRibDDyUDd4YHGj87px+coJx2RSA7MSA5ufXXts4yNGH756WB32yP68FDaU4IZggJrlgAA==}
-    dependencies:
-      '@aptos-labs/wallet-adapter-core': 0.2.3
-      aptos: 1.21.0
-      bs58: 5.0.0
-      js-sha3: 0.8.0
-    transitivePeerDependencies:
-      - debug
-    dev: false
 
   /@noble/curves@1.2.0:
     resolution: {integrity: sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==}


### PR DESCRIPTION
Now that we have migrated to the new wallet adapter, a dapp doesnt need to hold a package depndency of a wallet that is compatible with the new standard