### PR TITLE
Support AIP-62 connect wallet method response

### DIFF
--- a/.changeset/strange-penguins-decide.md
+++ b/.changeset/strange-penguins-decide.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/wallet-adapter-core": minor
+---
+
+Support AIP-62 connect wallet method response

--- a/packages/wallet-adapter-core/src/AIP62StandardWallets/WalletStandard.ts
+++ b/packages/wallet-adapter-core/src/AIP62StandardWallets/WalletStandard.ts
@@ -7,6 +7,7 @@ import {
   UserResponseStatus,
   AptosSignAndSubmitTransactionOutput,
   AccountInfo as StandardAccountInfo,
+  AptosConnectOutput,
 } from "@aptos-labs/wallet-standard";
 import {
   AnyRawTransaction,
@@ -35,6 +36,16 @@ export type AptosStandardWallet = AptosWallet & {
 };
 
 export class WalletStandardCore {
+  async connect(wallet: Wallet) {
+    const response =
+      (await wallet.connect()) as UserResponse<AptosConnectOutput>;
+
+    if (response.status === UserResponseStatus.REJECTED) {
+      throw new WalletConnectionError("User has rejected the request").message;
+    }
+    return response.args;
+  }
+
   /**
    * Signs and submits a transaction to chain
    *

--- a/packages/wallet-adapter-core/src/LegacyWalletPlugins/WalletCoreV1.ts
+++ b/packages/wallet-adapter-core/src/LegacyWalletPlugins/WalletCoreV1.ts
@@ -33,6 +33,11 @@ import {
 import { areBCSArguments, generalizedErrorMessage } from "../utils";
 
 export class WalletCoreV1 extends EventEmitter<WalletCoreEvents> {
+  async connect(wallet: Wallet) {
+    const account = await wallet.connect();
+    return account;
+  }
+
   /**
    * Resolve the transaction type (BCS arguments or Simple arguments)
    *

--- a/packages/wallet-adapter-core/src/WalletCore.ts
+++ b/packages/wallet-adapter-core/src/WalletCore.ts
@@ -530,7 +530,12 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
     try {
       this._connecting = true;
       this.setWallet(selectedWallet);
-      const account = await selectedWallet.connect();
+      let account;
+      if (selectedWallet.isAIP62Standard) {
+        account = await this.walletStandardCore.connect(selectedWallet);
+      } else {
+        account = await this.walletCoreV1.connect(selectedWallet);
+      }
       this.setAccount(account);
       const network = await selectedWallet.network();
       this.setNetwork(network);
@@ -653,8 +658,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
   ): Promise<AccountAuthenticator> {
     try {
       this.ensureWalletExists(this._wallet);
-      this.ensureAccountExists(this._account);
-
+      console.log("this._account", this._account);
       // Make sure wallet supports signTransaction
       if (this._wallet.signTransaction) {
         // If current connected wallet is AIP-62 standard compatible


### PR DESCRIPTION
AIP-62 connect wallet method returns `UserResponse` as it is a rejectable action.
Updating core package to respect it.