### PR TITLE
made network name in WalletCore lowercased for consistent behaviour from different wallets

### DIFF
--- a/.changeset/twenty-suns-train.md
+++ b/.changeset/twenty-suns-train.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/wallet-adapter-core": minor
+---
+
+Convert uppercase network name to lowercase in NetworkInfo

--- a/apps/nextjs-example/pages/index.tsx
+++ b/apps/nextjs-example/pages/index.tsx
@@ -138,9 +138,8 @@ function WalletProps(props: {
 }) {
   const { account, network, wallet } = props;
   const isValidNetworkName = () => {
-    // TODO: Do we allow non lowercase
     return Object.values<string | undefined>(Network).includes(
-      props.network?.name
+      props.network?.name.toLowerCase()
     );
   };
 

--- a/apps/nextjs-example/pages/index.tsx
+++ b/apps/nextjs-example/pages/index.tsx
@@ -139,7 +139,7 @@ function WalletProps(props: {
   const { account, network, wallet } = props;
   const isValidNetworkName = () => {
     return Object.values<string | undefined>(Network).includes(
-      props.network?.name.toLowerCase()
+      props.network?.name
     );
   };
 

--- a/packages/wallet-adapter-core/src/WalletCore.ts
+++ b/packages/wallet-adapter-core/src/WalletCore.ts
@@ -1,5 +1,6 @@
 import { TxnBuilderTypes, Types, BCS } from "aptos";
 import {
+  Network,
   AnyRawTransaction,
   AccountAuthenticator,
   AccountAuthenticatorEd25519,
@@ -383,13 +384,13 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
     if (this._wallet?.isAIP62Standard) {
       const standardizeNetwork = network as StandardNetworkInfo;
       this._network = {
-        name: standardizeNetwork.name.toLowerCase(),
+        name: standardizeNetwork.name.toLowerCase() as Network,
         chainId: standardizeNetwork.chainId.toString(),
         url: standardizeNetwork.url,
       };
       return;
     }
-    this._network = { ...(network as NetworkInfo) };
+    this._network = { ...(network as NetworkInfo), name: network.name.toLowerCase() as Network };
   }
 
   /**

--- a/packages/wallet-adapter-core/src/WalletCore.ts
+++ b/packages/wallet-adapter-core/src/WalletCore.ts
@@ -383,7 +383,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
     if (this._wallet?.isAIP62Standard) {
       const standardizeNetwork = network as StandardNetworkInfo;
       this._network = {
-        name: standardizeNetwork.name,
+        name: standardizeNetwork.name.toLowerCase(),
         chainId: standardizeNetwork.chainId.toString(),
         url: standardizeNetwork.url,
       };


### PR DESCRIPTION
Petra Wallet made by Aptos Labs uses uppercase for the first letter of network names, so I'd say it's reasonable to accept this.