### PR TITLE
Fix standard wallet detection

### DIFF
--- a/.changeset/modern-chairs-act.md
+++ b/.changeset/modern-chairs-act.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/wallet-adapter-react": minor
+---
+
+Fix wallet detection

--- a/packages/wallet-adapter-react/src/WalletProvider.tsx
+++ b/packages/wallet-adapter-react/src/WalletProvider.tsx
@@ -224,13 +224,20 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
   const handleStandardWalletsAdded = (standardWallet: Wallet) => {
     // Manage current wallet state by removing optional duplications
     // as new wallets are coming
-    const updatedWallets = wallets?.map((wallet) => {
-      if (wallet.name === standardWallet.name) {
-        return { ...standardWallet };
-      }
-      return wallet;
-    });
-    setWallets(updatedWallets);
+    const existingWalletIndex = wallets.findIndex(
+      (wallet) => wallet.name == standardWallet.name
+    );
+    if (existingWalletIndex !== -1) {
+      // If wallet exists, replace it with the new wallet
+      setWallets((wallets) => [
+        ...wallets.slice(0, existingWalletIndex),
+        standardWallet,
+        ...wallets.slice(existingWalletIndex + 1),
+      ]);
+    } else {
+      // If wallet doesn't exist, add it to the array
+      setWallets((wallets) => [...wallets, standardWallet]);
+    }
   };
 
   useEffect(() => {


### PR DESCRIPTION
Fix standard wallet detection by
- If wallet already exists (maybe a legacy wallet plugin), replace the existing wallet with the AIP-62 standard
- If wallet does not exist, add it to the wallets array