### PR TITLE
fix iOS extension

### DIFF
--- a/.changeset/metal-poems-exist.md
+++ b/.changeset/metal-poems-exist.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/wallet-adapter-core": minor
+---
+
+Trigger connect if iOS extension is detected.

--- a/packages/wallet-adapter-core/src/WalletCore.ts
+++ b/packages/wallet-adapter-core/src/WalletCore.ts
@@ -538,7 +538,8 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
     }
 
     // Check if we are in a redirectable view (i.e on mobile AND not in an in-app browser)
-    if (isRedirectable()) {
+    // Ignore if wallet is installed (iOS extension)
+    if (isRedirectable() && selectedWallet.readyState !== WalletReadyState.Installed) {
       // use wallet deep link
       if (selectedWallet.isAIP62Standard && selectedWallet.openInMobileApp) {
         selectedWallet.openInMobileApp();


### PR DESCRIPTION
Fix connection using iOS extension.

Selector will now trigger connect on detected extension instead of trying to redirect.