### PR TITLE
Support a custom network defined in a Wallet

### DIFF
--- a/.changeset/eleven-pillows-march.md
+++ b/.changeset/eleven-pillows-march.md
@@ -1,0 +1,6 @@
+---
+"@aptos-labs/wallet-adapter-core": minor
+"@aptos-labs/wallet-adapter-nextjs-example": minor
+---
+
+Support a custom network defined in a Wallet

--- a/apps/nextjs-example/components/AlertProvider.tsx
+++ b/apps/nextjs-example/components/AlertProvider.tsx
@@ -9,9 +9,10 @@ import {
   useState,
 } from "react";
 import { ErrorAlert, SuccessAlert } from "./Alert";
+import { isAptosNetwork, NetworkInfo } from "@aptos-labs/wallet-adapter-core";
 
 interface AlertContextState {
-  setSuccessAlertHash: (hash: string, networkName?: string) => void;
+  setSuccessAlertHash: (hash: string, network: NetworkInfo | null) => void;
   setSuccessAlertMessage: Dispatch<SetStateAction<ReactNode | null>>;
   setErrorAlertMessage: Dispatch<SetStateAction<ReactNode | null>>;
 }
@@ -35,18 +36,25 @@ export const AlertProvider: FC<{ children: ReactNode }> = ({ children }) => {
   );
 
   const setSuccessAlertHash = useCallback(
-    (hash: string, networkName?: string) => {
-      const explorerLink = `https://explorer.aptoslabs.com/txn/${hash}${
-        networkName ? `?network=${networkName.toLowerCase()}` : ""
-      }`;
-      setSuccessAlertMessage(
-        <>
-          View on Explorer:{" "}
-          <a className="underline" target="_blank" href={explorerLink} rel={"noreferrer"}>
-            {explorerLink}
-          </a>
-        </>
-      );
+    (hash: string, network: NetworkInfo | null) => {
+      if (isAptosNetwork(network)) {
+        const explorerLink = `https://explorer.aptoslabs.com/txn/${hash}${network?.name ? `?network=${network.name.toLowerCase()}` : ""}`;
+        return setSuccessAlertMessage(
+          <>
+            View on Explorer:{" "}
+            <a
+              className="underline"
+              target="_blank"
+              href={explorerLink}
+              rel={"noreferrer"}
+            >
+              {explorerLink}
+            </a>
+          </>
+        );
+      }
+
+      return setSuccessAlertMessage(<>Transaction Hash: {hash}</>);
     },
     []
   );

--- a/apps/nextjs-example/components/AlertProvider.tsx
+++ b/apps/nextjs-example/components/AlertProvider.tsx
@@ -38,7 +38,7 @@ export const AlertProvider: FC<{ children: ReactNode }> = ({ children }) => {
   const setSuccessAlertHash = useCallback(
     (hash: string, network: NetworkInfo | null) => {
       if (isAptosNetwork(network)) {
-        const explorerLink = `https://explorer.aptoslabs.com/txn/${hash}${network?.name ? `?network=${network.name.toLowerCase()}` : ""}`;
+        const explorerLink = `https://explorer.aptoslabs.com/txn/${hash}${network?.name ? `?network=${network.name}` : ""}`;
         return setSuccessAlertMessage(
           <>
             View on Explorer:{" "}

--- a/apps/nextjs-example/components/transactionFlow/MultiAgent.tsx
+++ b/apps/nextjs-example/components/transactionFlow/MultiAgent.tsx
@@ -44,14 +44,15 @@ export default function MultiAgentTransaction({
     }
 
     const secondarySigner = Account.generate();
-    await aptosClient(network.name.toLowerCase()).fundAccount({
+    // TODO support custom network
+    await aptosClient(network).fundAccount({
       accountAddress: secondarySigner.accountAddress.toString(),
       amount: 100_000_000,
     });
     setSecondarySignerAccount(secondarySigner);
 
     const transactionToSign = await aptosClient(
-      network?.name.toLowerCase()
+      network
     ).transaction.build.multiAgent({
       sender: account.address,
       secondarySignerAddresses: [secondarySigner.accountAddress],
@@ -103,7 +104,7 @@ export default function MultiAgentTransaction({
         senderAuthenticator: senderAuthenticator,
         additionalSignersAuthenticators: [secondarySignerAuthenticator],
       });
-      setSuccessAlertHash(response.hash, network?.name);
+      setSuccessAlertHash(response.hash, network);
     } catch (error) {
       console.error(error);
     }

--- a/apps/nextjs-example/components/transactionFlow/SingleSigner.tsx
+++ b/apps/nextjs-example/components/transactionFlow/SingleSigner.tsx
@@ -61,10 +61,10 @@ export default function SingleSignerTransaction({
     };
     try {
       const response = await signAndSubmitTransaction(transaction);
-      await aptosClient(network?.name.toLowerCase()).waitForTransaction({
+      await aptosClient(network).waitForTransaction({
         transactionHash: response.hash,
       });
-      setSuccessAlertHash(response.hash, network?.name);
+      setSuccessAlertHash(response.hash, network);
     } catch (error) {
       console.error(error);
     }
@@ -81,10 +81,10 @@ export default function SingleSignerTransaction({
           functionArguments: [AccountAddress.from(account.address), new U64(1)], // 1 is in Octas
         },
       });
-      await aptosClient(network?.name.toLowerCase()).waitForTransaction({
+      await aptosClient(network).waitForTransaction({
         transactionHash: response.hash,
       });
-      setSuccessAlertHash(response.hash, network?.name);
+      setSuccessAlertHash(response.hash, network);
     } catch (error) {
       console.error(error);
     }
@@ -111,7 +111,7 @@ export default function SingleSignerTransaction({
 
     try {
       const transactionToSign = await aptosClient(
-        network?.name.toLowerCase()
+        network
       ).transaction.build.simple({
         sender: account.address,
         data: {

--- a/apps/nextjs-example/components/transactionFlow/Sponsor.tsx
+++ b/apps/nextjs-example/components/transactionFlow/Sponsor.tsx
@@ -38,7 +38,7 @@ export default function SponsorTransaction({
       throw new Error("no account");
     }
     const transactionToSign = await aptosClient(
-      network?.name.toLowerCase()
+      network
     ).transaction.build.simple({
       sender: account.address,
       withFeePayer: true,
@@ -93,7 +93,7 @@ export default function SponsorTransaction({
         senderAuthenticator: senderAuthenticator,
         feePayerAuthenticator: feepayerAuthenticator,
       });
-      setSuccessAlertHash(response.hash, network?.name);
+      setSuccessAlertHash(response.hash, network);
     } catch (error) {
       console.error(error);
     }

--- a/apps/nextjs-example/pages/index.tsx
+++ b/apps/nextjs-example/pages/index.tsx
@@ -32,12 +32,12 @@ const WalletSelectorAntDesign = dynamic(
   }
 );
 
-const isSendableNetwork = (connected: boolean, network?: string): boolean => {
-  return connected && !isMainnet(connected, network);
+const isSendableNetwork = (connected: boolean): boolean => {
+  return connected && !isMainnet(connected);
 };
 
-const isMainnet = (connected: boolean, network?: string): boolean => {
-  return connected && network?.toLowerCase() === Network.MAINNET.toLowerCase();
+const isMainnet = (connected: boolean, networkName?: string): boolean => {
+  return connected && networkName === Network.MAINNET;
 };
 
 export default function App() {

--- a/apps/nextjs-example/pages/index.tsx
+++ b/apps/nextjs-example/pages/index.tsx
@@ -1,4 +1,9 @@
-import { useWallet, AccountInfo, NetworkInfo, WalletInfo} from "@aptos-labs/wallet-adapter-react";
+import {
+  useWallet,
+  AccountInfo,
+  NetworkInfo,
+  WalletInfo,
+} from "@aptos-labs/wallet-adapter-react";
 import { WalletConnector } from "@aptos-labs/wallet-adapter-mui-design";
 import dynamic from "next/dynamic";
 import Image from "next/image";
@@ -10,6 +15,7 @@ import Row from "../components/Row";
 import Col from "../components/Col";
 import { Network } from "@aptos-labs/ts-sdk";
 import { Typography } from "antd";
+import { isAptosNetwork } from "@aptos-labs/wallet-adapter-core";
 
 const { Link } = Typography;
 
@@ -27,11 +33,11 @@ const WalletSelectorAntDesign = dynamic(
 );
 
 const isSendableNetwork = (connected: boolean, network?: string): boolean => {
-  return (
-    connected &&
-    (network?.toLowerCase() === Network.DEVNET.toLowerCase() ||
-      network?.toLowerCase() === Network.TESTNET.toLowerCase())
-  );
+  return connected && !isMainnet(connected, network);
+};
+
+const isMainnet = (connected: boolean, network?: string): boolean => {
+  return connected && network?.toLowerCase() === Network.MAINNET.toLowerCase();
 };
 
 export default function App() {
@@ -66,12 +72,12 @@ export default function App() {
           {connected && (
             <WalletProps wallet={wallet} network={network} account={account} />
           )}
-          {connected && !isSendableNetwork(connected, network?.name) && (
+          {connected && isMainnet(connected, network?.name) && (
             <tr>
               <Col title={true}></Col>
               <Col>
                 <p style={{ color: "red" }}>
-                  Transactions only work with Devnet or Testnet networks
+                  Transactions dont work with Mainnet network
                 </p>
               </Col>
             </tr>
@@ -138,9 +144,14 @@ function WalletProps(props: {
 }) {
   const { account, network, wallet } = props;
   const isValidNetworkName = () => {
-    return Object.values<string | undefined>(Network).includes(
-      props.network?.name
-    );
+    if (isAptosNetwork(network)) {
+      return Object.values<string | undefined>(Network).includes(
+        props.network?.name
+      );
+    }
+    // If the configured network is not an Aptos network, i.e is a custom network
+    // we resolve it as a valid network name
+    return true;
   };
 
   return (

--- a/apps/nextjs-example/utils/index.ts
+++ b/apps/nextjs-example/utils/index.ts
@@ -2,11 +2,11 @@ import { Aptos, AptosConfig, Network } from "@aptos-labs/ts-sdk";
 import { NetworkInfo } from "@aptos-labs/wallet-adapter-core";
 
 export const aptosClient = (network?: NetworkInfo | null) => {
-  if (network?.name.toLowerCase() === Network.DEVNET.toLowerCase()) {
+  if (network?.name === Network.DEVNET) {
     return DEVNET_CLIENT;
-  } else if (network?.name.toLowerCase() === Network.TESTNET.toLowerCase()) {
+  } else if (network?.name === Network.TESTNET) {
     return TESTNET_CLIENT;
-  } else if (network?.name.toLowerCase() === Network.MAINNET.toLowerCase()) {
+  } else if (network?.name === Network.MAINNET) {
     throw new Error("Please use devnet or testnet for testing");
   } else {
     const CUSTOM_CONFIG = new AptosConfig({

--- a/apps/nextjs-example/utils/index.ts
+++ b/apps/nextjs-example/utils/index.ts
@@ -1,19 +1,28 @@
 import { Aptos, AptosConfig, Network } from "@aptos-labs/ts-sdk";
+import { NetworkInfo } from "@aptos-labs/wallet-adapter-core";
 
-export const aptosClient = (network?: string) => {
-  if (network === Network.DEVNET.toLowerCase()) {
+export const aptosClient = (network?: NetworkInfo | null) => {
+  if (network?.name.toLowerCase() === Network.DEVNET.toLowerCase()) {
     return DEVNET_CLIENT;
-  } else if (network === Network.TESTNET.toLowerCase()) {
+  } else if (network?.name.toLowerCase() === Network.TESTNET.toLowerCase()) {
     return TESTNET_CLIENT;
-  } else if (network === Network.MAINNET.toLowerCase()) {
+  } else if (network?.name.toLowerCase() === Network.MAINNET.toLowerCase()) {
     throw new Error("Please use devnet or testnet for testing");
   } else {
-    throw new Error(`Unknown network: ${network}`);
+    const CUSTOM_CONFIG = new AptosConfig({
+      network: Network.CUSTOM,
+      fullnode: network?.url,
+    });
+    return new Aptos(CUSTOM_CONFIG);
   }
 };
+
+// Devnet client
 export const DEVNET_CONFIG = new AptosConfig({
   network: Network.DEVNET,
 });
 export const DEVNET_CLIENT = new Aptos(DEVNET_CONFIG);
+
+// Testnet client
 export const TESTNET_CONFIG = new AptosConfig({ network: Network.TESTNET });
 export const TESTNET_CLIENT = new Aptos(TESTNET_CONFIG);

--- a/packages/wallet-adapter-core/src/LegacyWalletPlugins/WalletCoreV1.ts
+++ b/packages/wallet-adapter-core/src/LegacyWalletPlugins/WalletCoreV1.ts
@@ -2,7 +2,6 @@ import { HexString, TxnBuilderTypes, Types } from "aptos";
 import EventEmitter from "eventemitter3";
 import { Buffer } from "buffer";
 import {
-  AptosConfig,
   InputEntryFunctionDataWithRemoteABI,
   InputGenerateTransactionPayloadData,
   generateTransactionPayload,
@@ -26,11 +25,14 @@ import {
 } from "./types";
 
 import {
-  convertNetwork,
   convertV2PayloadToV1JSONPayload,
   convertV2TransactionPayloadToV1BCSPayload,
 } from "./conversion";
-import { areBCSArguments, generalizedErrorMessage } from "../utils";
+import {
+  areBCSArguments,
+  generalizedErrorMessage,
+  getAptosConfig,
+} from "../utils";
 
 export class WalletCoreV1 extends EventEmitter<WalletCoreEvents> {
   async connect(wallet: Wallet) {
@@ -56,9 +58,7 @@ export class WalletCoreV1 extends EventEmitter<WalletCoreEvents> {
   ) {
     // first check if each argument is a BCS serialized argument
     if (areBCSArguments(payloadData.functionArguments)) {
-      const aptosConfig = new AptosConfig({
-        network: convertNetwork(network),
-      });
+      const aptosConfig = getAptosConfig(network);
       const newPayload = await generateTransactionPayload({
         ...(payloadData as InputEntryFunctionDataWithRemoteABI),
         aptosConfig: aptosConfig,

--- a/packages/wallet-adapter-core/src/LegacyWalletPlugins/conversion.ts
+++ b/packages/wallet-adapter-core/src/LegacyWalletPlugins/conversion.ts
@@ -20,7 +20,7 @@ export function convertNetwork(
     case "devnet" as Network:
       return Network.DEVNET;
     default:
-      throw new Error("Invalid network name");
+      throw new Error("Invalid Aptos network name");
   }
 }
 

--- a/packages/wallet-adapter-core/src/LegacyWalletPlugins/conversion.ts
+++ b/packages/wallet-adapter-core/src/LegacyWalletPlugins/conversion.ts
@@ -12,7 +12,7 @@ import { NetworkInfo } from "./types";
 export function convertNetwork(
   networkInfo: NetworkInfo | StandardNetworkInfo | null
 ): Network {
-  switch (networkInfo?.name.toLowerCase()) {
+  switch (networkInfo?.name) {
     case "mainnet" as Network:
       return Network.MAINNET;
     case "testnet" as Network:

--- a/packages/wallet-adapter-core/src/WalletCore.ts
+++ b/packages/wallet-adapter-core/src/WalletCore.ts
@@ -48,6 +48,8 @@ import {
   scopePollingDetectionStrategy,
   isRedirectable,
   generalizedErrorMessage,
+  getAptosConfig,
+  isAptosNetwork,
 } from "./utils";
 import { convertNetwork } from "./LegacyWalletPlugins/conversion";
 import { WalletCoreV1 } from "./LegacyWalletPlugins/WalletCoreV1";
@@ -225,6 +227,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
     this.ga4.gtag("event", `wallet_adapter_${eventName}`, {
       wallet: this._wallet?.name,
       network: this._network?.name,
+      network_url: this._network?.url,
       adapter_core_version: WALLET_ADAPTER_CORE_VERSION,
       send_to: process.env.GAID,
       ...additionalInfo,
@@ -300,7 +303,10 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
   private async setAnsName(): Promise<void> {
     if (this._network?.chainId && this._account) {
       // ANS supports only MAINNET or TESTNET
-      if (!ChainIdToAnsSupportedNetworkMap[this._network.chainId]) {
+      if (
+        !ChainIdToAnsSupportedNetworkMap[this._network.chainId] ||
+        !isAptosNetwork(this._network)
+      ) {
         this._account.ansName = undefined;
         return;
       }
@@ -620,9 +626,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
       this.recordEvent("sign_and_submit_transaction");
       // get the payload piece from the input
       const payloadData = transactionInput.data;
-      const aptosConfig = new AptosConfig({
-        network: convertNetwork(this._network),
-      });
+      const aptosConfig = getAptosConfig(this._network);
 
       const aptos = new Aptos(aptosConfig);
 

--- a/packages/wallet-adapter-core/src/WalletCore.ts
+++ b/packages/wallet-adapter-core/src/WalletCore.ts
@@ -33,30 +33,30 @@ import {
 } from "./error";
 import {
   AccountInfo,
+  InputTransactionData,
   NetworkInfo,
   SignMessagePayload,
-  Wallet,
-  WalletInfo,
-  WalletCoreEvents,
   SignMessageResponse,
-  InputTransactionData,
+  Wallet,
+  WalletCoreEvents,
+  WalletInfo,
   WalletName,
 } from "./LegacyWalletPlugins/types";
 import {
-  removeLocalStorage,
-  setLocalStorage,
-  scopePollingDetectionStrategy,
-  isRedirectable,
   generalizedErrorMessage,
   getAptosConfig,
   isAptosNetwork,
+  isRedirectable,
+  removeLocalStorage,
+  scopePollingDetectionStrategy,
+  setLocalStorage,
 } from "./utils";
 import { convertNetwork } from "./LegacyWalletPlugins/conversion";
 import { WalletCoreV1 } from "./LegacyWalletPlugins/WalletCoreV1";
 import {
+  AccountInfo as StandardAccountInfo,
   AptosWallet,
   getAptosWallets,
-  AccountInfo as StandardAccountInfo,
   NetworkInfo as StandardNetworkInfo,
   UserResponse,
   UserResponseStatus,

--- a/packages/wallet-adapter-core/src/utils/helpers.ts
+++ b/packages/wallet-adapter-core/src/utils/helpers.ts
@@ -1,8 +1,14 @@
 import {
+  AptosConfig,
   EntryFunctionArgumentTypes,
+  Network,
+  NetworkToNodeAPI,
   Serializable,
   SimpleEntryFunctionArgumentTypes,
 } from "@aptos-labs/ts-sdk";
+import { NetworkInfo as StandardNetworkInfo } from "@aptos-labs/wallet-standard";
+import { NetworkInfo } from "../LegacyWalletPlugins/types";
+import { convertNetwork } from "../LegacyWalletPlugins/conversion";
 
 export function isMobile(): boolean {
   return /Mobile|iP(hone|od|ad)|Android|BlackBerry|IEMobile|Kindle|NetFront|Silk-Accelerated|(hpw|web)OS|Fennec|Minimo|Opera M(obi|ini)|Blazer|Dolfin|Dolphin|Skyfire|Zune/i.test(
@@ -51,4 +57,42 @@ export const areBCSArguments = (
     (arg: EntryFunctionArgumentTypes | SimpleEntryFunctionArgumentTypes) =>
       arg instanceof Serializable
   );
+};
+
+/**
+ * Helper function to get AptosConfig that supports Aptos and Custom networks
+ *
+ * @param networkInfo
+ * @returns AptosConfig
+ */
+export const getAptosConfig = (
+  networkInfo: NetworkInfo | StandardNetworkInfo | null
+): AptosConfig => {
+  if (!networkInfo) {
+    throw new Error("Undefined network");
+  }
+  if (isAptosNetwork(networkInfo)) {
+    return new AptosConfig({
+      network: convertNetwork(networkInfo),
+    });
+  }
+  return new AptosConfig({
+    network: Network.CUSTOM,
+    fullnode: networkInfo.url,
+  });
+};
+
+/**
+ * Helper function to resolve if the current connected network is an Aptos network
+ *
+ * @param networkInfo
+ * @returns boolean
+ */
+export const isAptosNetwork = (
+  networkInfo: NetworkInfo | StandardNetworkInfo | null
+): boolean => {
+  if (!networkInfo) {
+    throw new Error("Undefined network");
+  }
+  return NetworkToNodeAPI[networkInfo.name] ? true : false;
 };

--- a/packages/wallet-adapter-core/src/utils/helpers.ts
+++ b/packages/wallet-adapter-core/src/utils/helpers.ts
@@ -94,5 +94,5 @@ export const isAptosNetwork = (
   if (!networkInfo) {
     throw new Error("Undefined network");
   }
-  return NetworkToNodeAPI[networkInfo.name] ? true : false;
+  return NetworkToNodeAPI[networkInfo.name] !== undefined;
 };


### PR DESCRIPTION
Some Wallets support the option to provide a custom RPC to work with,  this PR adds support for custom networks defined in a wallet to be respected by the Wallet Adapter.

If the current connected wallet configured to work with a non Aptos network, the adapter resolves the custom network to use when submitting a transaction