### PR TITLE
Add change network request support

### DIFF
--- a/.changeset/violet-onions-travel.md
+++ b/.changeset/violet-onions-travel.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/wallet-adapter-core": minor
+---
+
+Add change network request support

--- a/apps/nextjs-example/pages/index.tsx
+++ b/apps/nextjs-example/pages/index.tsx
@@ -14,8 +14,12 @@ import MultiAgentTransaction from "../components/transactionFlow/MultiAgent";
 import Row from "../components/Row";
 import Col from "../components/Col";
 import { Network } from "@aptos-labs/ts-sdk";
-import { Typography } from "antd";
-import { isAptosNetwork } from "@aptos-labs/wallet-adapter-core";
+import { Select, Typography } from "antd";
+import {
+  AptosChangeNetworkOutput,
+  StandardNetworkInfo,
+  isAptosNetwork,
+} from "@aptos-labs/wallet-adapter-core";
 
 const { Link } = Typography;
 
@@ -41,7 +45,7 @@ const isMainnet = (connected: boolean, networkName?: string): boolean => {
 };
 
 export default function App() {
-  const { account, connected, network, wallet } = useWallet();
+  const { account, connected, network, wallet, changeNetwork } = useWallet();
 
   return (
     <div>
@@ -70,7 +74,12 @@ export default function App() {
             </Row>
           )}
           {connected && (
-            <WalletProps wallet={wallet} network={network} account={account} />
+            <WalletProps
+              wallet={wallet}
+              network={network}
+              account={account}
+              changeNetwork={changeNetwork}
+            />
           )}
           {connected && isMainnet(connected, network?.name) && (
             <tr>
@@ -141,8 +150,9 @@ function WalletProps(props: {
   account: AccountInfo | null;
   network: NetworkInfo | null;
   wallet: WalletInfo | null;
+  changeNetwork: (network: Network) => Promise<AptosChangeNetworkOutput>;
 }) {
-  const { account, network, wallet } = props;
+  const { account, network, wallet, changeNetwork } = props;
   const isValidNetworkName = () => {
     if (isAptosNetwork(network)) {
       return Object.values<string | undefined>(Network).includes(
@@ -152,6 +162,11 @@ function WalletProps(props: {
     // If the configured network is not an Aptos network, i.e is a custom network
     // we resolve it as a valid network name
     return true;
+  };
+
+  const onChangeNetworkRequest = async (value: any) => {
+    console.log(`selected ${value}`);
+    await changeNetwork(value);
   };
 
   return (
@@ -221,6 +236,46 @@ function WalletProps(props: {
           />
           <DisplayOptionalValue name={"URL"} value={network?.url} />
           <DisplayOptionalValue name={"ChainId"} value={network?.chainId} />
+        </Col>
+      </Row>
+      <Row>
+        <Col title={true}>
+          <h3>Change Network</h3>
+        </Col>
+        <Col>
+          <button
+            className={`bg-blue-500  text-white font-bold py-2 px-4 rounded mr-4 hover:bg-blue-700 ${
+              network?.name === Network.DEVNET
+                ? "opacity-50 cursor-not-allowed"
+                : "hover:bg-blue-700"
+            }`}
+            onClick={() => onChangeNetworkRequest(Network.DEVNET)}
+            disabled={network?.name === "devnet"}
+          >
+            <>Devnet</>
+          </button>
+          <button
+            className={`bg-blue-500  text-white font-bold py-2 px-4 rounded mr-4 hover:bg-blue-700 ${
+              network?.name === Network.TESTNET
+                ? "opacity-50 cursor-not-allowed"
+                : "hover:bg-blue-700"
+            }`}
+            onClick={() => onChangeNetworkRequest(Network.TESTNET)}
+            disabled={network?.name === Network.TESTNET}
+          >
+            <>Testnet</>
+          </button>
+          <button
+            className={`bg-blue-500  text-white font-bold py-2 px-4 rounded mr-4 hover:bg-blue-700 ${
+              network?.name === Network.MAINNET
+                ? "opacity-50 cursor-not-allowed"
+                : "hover:bg-blue-700"
+            }`}
+            onClick={() => onChangeNetworkRequest(Network.MAINNET)}
+            disabled={network?.name === "mainnet"}
+          >
+            <>Mainnet</>
+          </button>
         </Col>
       </Row>
     </>

--- a/packages/wallet-adapter-core/src/LegacyWalletPlugins/types.ts
+++ b/packages/wallet-adapter-core/src/LegacyWalletPlugins/types.ts
@@ -27,7 +27,13 @@ export type {
   InputSubmitTransactionData,
   PendingTransactionResponse,
   AccountAuthenticator,
+  Network,
 } from "@aptos-labs/ts-sdk";
+
+export type {
+  NetworkInfo as StandardNetworkInfo,
+  AptosChangeNetworkOutput,
+} from "@aptos-labs/wallet-standard";
 
 // WalletName is a nominal type that wallet adapters should use, e.g. `'MyCryptoWallet' as WalletName<'MyCryptoWallet'>`
 export type WalletName<T extends string = string> = T & {

--- a/packages/wallet-adapter-core/src/LegacyWalletPlugins/types.ts
+++ b/packages/wallet-adapter-core/src/LegacyWalletPlugins/types.ts
@@ -16,6 +16,7 @@ import {
   UserResponse,
   AccountInfo as StandardAccountInfo,
   NetworkInfo as StandardNetworkInfo,
+  AptosChangeNetworkMethod,
 } from "@aptos-labs/wallet-standard";
 
 export { TxnBuilderTypes, Types } from "aptos";
@@ -136,6 +137,7 @@ export interface AdapterPluginProps<Name extends string = string> {
     optionsOrAsFeePayer?: any
   ): Promise<any>;
   account?: () => Promise<AccountInfo | StandardAccountInfo>;
+  changeNetwork?: AptosChangeNetworkMethod;
 }
 
 export type AdapterPlugin<Name extends string = string> =

--- a/packages/wallet-adapter-core/src/error/index.ts
+++ b/packages/wallet-adapter-core/src/error/index.ts
@@ -102,3 +102,7 @@ export class WalletResponseError extends WalletError {
 export class WalletNotSupportedMethod extends WalletError {
   name = "WalletNotSupportedMethod";
 }
+
+export class WalletChangeNetworkError extends WalletError {
+  name = "WalletChangeNetworkError";
+}

--- a/packages/wallet-adapter-core/src/utils/helpers.ts
+++ b/packages/wallet-adapter-core/src/utils/helpers.ts
@@ -1,4 +1,5 @@
 import {
+  Aptos,
   AptosConfig,
   EntryFunctionArgumentTypes,
   Network,
@@ -95,4 +96,12 @@ export const isAptosNetwork = (
     throw new Error("Undefined network");
   }
   return NetworkToNodeAPI[networkInfo.name] !== undefined;
+};
+
+/**
+ * Helper function to fetch Devnet chain id
+ */
+export const fetchDevnetChainId = async (): Promise<number> => {
+  const aptos = new Aptos(); // default to devnet
+  return await aptos.getChainId();
 };

--- a/packages/wallet-adapter-react/src/WalletProvider.tsx
+++ b/packages/wallet-adapter-react/src/WalletProvider.tsx
@@ -22,6 +22,8 @@ import type {
   WalletName,
   Types,
   InputTransactionData,
+  StandardNetworkInfo,
+  Network,
 } from "@aptos-labs/wallet-adapter-core";
 import { WalletCore } from "@aptos-labs/wallet-adapter-core";
 
@@ -134,6 +136,15 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
   ) => {
     try {
       return await walletCore.signAndSubmitTransaction(transaction);
+    } catch (error: any) {
+      if (onError) onError(error);
+      return Promise.reject(error);
+    }
+  };
+
+  const changeNetwork = async (network: Network) => {
+    try {
+      return await walletCore.changeNetwork(network);
     } catch (error: any) {
       if (onError) onError(error);
       return Promise.reject(error);
@@ -273,6 +284,7 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
         signMessageAndVerify,
         isLoading,
         submitTransaction,
+        changeNetwork,
       }}
     >
       {children}

--- a/packages/wallet-adapter-react/src/useWallet.tsx
+++ b/packages/wallet-adapter-react/src/useWallet.tsx
@@ -13,6 +13,9 @@ import {
   AccountAuthenticator,
   Types,
   WalletName,
+  StandardNetworkInfo,
+  AptosChangeNetworkOutput,
+  Network,
 } from "@aptos-labs/wallet-adapter-core";
 import { createContext, useContext } from "react";
 
@@ -36,6 +39,7 @@ export interface WalletContextState {
   ): Promise<PendingTransactionResponse>;
   signMessage(message: SignMessagePayload): Promise<SignMessageResponse>;
   signMessageAndVerify(message: SignMessagePayload): Promise<boolean>;
+  changeNetwork(network: Network): Promise<AptosChangeNetworkOutput>;
 }
 
 const DEFAULT_CONTEXT = {


### PR DESCRIPTION
Add change network request from a dapp to a wallet to change the wallet's current network

Can test with Nightly wallet https://aptos-labs.github.io/aptos-wallet-adapter/nextjs-example-testing/ 