### PR TITLE
Monkey patched `signTransaction` v1 for AIP62 wallets

### DIFF
--- a/.changeset/loud-days-jog.md
+++ b/.changeset/loud-days-jog.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/wallet-adapter-core": patch
+---
+
+Monkey-patched `signTransaction` v1 to be compatible with AIP62 wallets

--- a/packages/wallet-adapter-core/package.json
+++ b/packages/wallet-adapter-core/package.json
@@ -29,7 +29,9 @@
   ],
   "scripts": {
     "update-version": "node -p \"'export const WALLET_ADAPTER_CORE_VERSION = ' + JSON.stringify(require('./package.json').version) + ';'\" > src/version.ts",
-    "build-package": "export $(cat .env | xargs) && tsup src/index.ts --format esm,cjs --dts --env.GAID $GAID",
+    "build-package": "export $(cat .env | xargs) && pnpm build:bundle && pnpm build:declarations",
+    "build:bundle": "tsup src/index.ts --format cjs,esm --sourcemap --env.GAID $GAID",
+    "build:declarations": "tsc --emitDeclarationOnly --declaration --declarationMap",
     "build": "pnpm run update-version && pnpm run build-package",
     "dev": "export $(cat .env | xargs) && tsup src/index.ts --format esm,cjs --watch --dts --env.GAID $GAID",
     "test": "jest",
@@ -56,5 +58,11 @@
   "peerDependencies": {
     "@aptos-labs/ts-sdk": "^1.13.2",
     "aptos": "^1.21.0"
-  }
+  },
+  "files": [
+    "dist",
+    "src",
+    "!src/**.test.ts",
+    "!src/**/__tests__"
+  ]
 }

--- a/packages/wallet-adapter-core/src/LegacyWalletPlugins/conversion.ts
+++ b/packages/wallet-adapter-core/src/LegacyWalletPlugins/conversion.ts
@@ -3,6 +3,12 @@ import {
   TransactionPayload,
   InputGenerateTransactionPayloadData,
   TypeTag,
+  AptosConfig,
+  InputEntryFunctionData,
+  InputMultiSigData,
+  MoveFunctionId,
+  generateTransactionPayload,
+  TransactionPayloadEntryFunction,
 } from "@aptos-labs/ts-sdk";
 import { NetworkInfo as StandardNetworkInfo } from "@aptos-labs/wallet-standard";
 import { BCS, TxnBuilderTypes, Types } from "aptos";
@@ -57,4 +63,32 @@ export function convertV2PayloadToV1JSONPayload(
 
     return newPayload;
   }
+}
+
+export async function generateTransactionPayloadFromV1Input(
+  aptosConfig: AptosConfig,
+  inputV1: Types.TransactionPayload,
+): Promise<TransactionPayloadEntryFunction> {
+  if ('function' in inputV1) {
+    const inputV2: InputEntryFunctionData | InputMultiSigData = {
+      function: inputV1.function as MoveFunctionId,
+      functionArguments: inputV1.arguments,
+      typeArguments: inputV1.type_arguments,
+    };
+    return generateTransactionPayload({ ...inputV2, aptosConfig });
+  }
+
+  throw new Error('Payload type not supported');
+}
+
+export interface CompatibleTransactionOptions {
+  expireTimestamp?: number;
+  expirationSecondsFromNow?: number;
+  expirationTimestamp?: number;
+  gasUnitPrice?: number;
+  gas_unit_price?: number;
+  maxGasAmount?: number;
+  max_gas_amount?: number;
+  sender?: string;
+  sequenceNumber?: number;
 }

--- a/packages/wallet-adapter-core/tsconfig.json
+++ b/packages/wallet-adapter-core/tsconfig.json
@@ -4,6 +4,8 @@
   "exclude": ["dist", "build", "node_modules"],
   "compilerOptions": {
     "target": "es5",
-    "lib": ["es2020", "dom"]
+    "lib": ["es2020", "dom"],
+    "rootDir": "src",
+    "outDir": "dist"
   }
 }

--- a/packages/wallet-adapter-react/package.json
+++ b/packages/wallet-adapter-react/package.json
@@ -29,8 +29,10 @@
     "React"
   ],
   "scripts": {
-    "build": "tsup src/index.tsx --format esm,cjs --dts --external react",
-    "dev": "tsup src/index.tsx --format esm,cjs --watch --dts --external react",
+    "build:bundle": "tsup src/index.tsx --format esm,cjs --sourcemap",
+    "build:declarations": "tsc --emitDeclarationOnly --declaration --declarationMap",
+    "build": "pnpm build:bundle && pnpm build:declarations",
+    "dev": "tsup src/index.tsx --format esm,cjs --watch",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",
     "lint": "TIMING=1 eslint \"src/**/*.ts*\""
   },
@@ -47,5 +49,11 @@
   },
   "peerDependencies": {
     "react": "^18"
-  }
+  },
+  "files": [
+    "dist",
+    "src",
+    "!src/**.test.ts",
+    "!src/**/__tests__"
+  ]
 }

--- a/packages/wallet-adapter-react/tsconfig.json
+++ b/packages/wallet-adapter-react/tsconfig.json
@@ -1,5 +1,9 @@
 {
   "extends": "@aptos-labs/wallet-adapter-tsconfig/react-library.json",
   "include": ["."],
-  "exclude": ["dist", "build", "node_modules"]
+  "exclude": ["dist", "build", "node_modules"],
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  }
 }


### PR DESCRIPTION
Just making sure that, if for whatever reason we have a `signTransaction` with v1 input, an AIP62 wallet can still handle it properly and avoid regressions.