### PR TITLE
Fix the `useEffect` dependency in auto-connect

### DIFF
--- a/.changeset/odd-dingos-lie.md
+++ b/.changeset/odd-dingos-lie.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/wallet-adapter-react": patch
+---
+
+Updated the `useEffect` dependency array for auto-connecting

--- a/.changeset/odd-dingos-lie.md
+++ b/.changeset/odd-dingos-lie.md
@@ -2,4 +2,4 @@
 "@aptos-labs/wallet-adapter-react": patch
 ---
 
-Updated the `useEffect` dependency array for auto-connecting
+Fixed the `useEffect` dependency array for auto-connecting to be `[wallets]` instead of `wallets`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Aptos Wallet Adapter is a monorepo built with [turbo](https://turbo.build/repo/d
 #### Apps Workspace
 
 The App workspace hold different web apps such as the adapter demo app (a nextjs app).
-You are welcome to add different apps (react/vue/etc) in this workspace (make sure you are following turbo best pratices on how to do it)
+You are welcome to add different apps (react/vue/etc) in this workspace (make sure you are following turbo best practices on how to do it)
 
 #### Packages Workspace
 
@@ -18,7 +18,7 @@ The packages workspace holds 2 main packages
 1. `wallet-adapter-core` - the core adapter logic that responsible on the adapter functionality, state and the interaction between the dapp and wallet.
 2. `wallet-adapter-react` - a light react provider that dapps can import and use the adapter.
 
-You are welcome to add packages (vue-provider/UI frameworks/etc) in this workspace (make sure you are following turbo best pratices on how to do it)
+You are welcome to add packages (vue-provider/UI frameworks/etc) in this workspace (make sure you are following turbo best practices on how to do it)
 
 ### Develop Locally
 
@@ -30,7 +30,7 @@ You would need `pnpm@7.14.2` in order to bootstrap and test a local copy of this
 
 ### Creating a pull request
 
-You are welcome to create a pull reuqest against the `main` branch.
+You are welcome to create a pull request against the `main` branch.
 
 Before creating a PR
 

--- a/packages/wallet-adapter-core/src/WalletCore.ts
+++ b/packages/wallet-adapter-core/src/WalletCore.ts
@@ -126,9 +126,9 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
   constructor(plugins: ReadonlyArray<Wallet>) {
     super();
     this._wallets = plugins;
-    // Stretegy to detect legacy wallet adapter v1 wallet plugins
+    // Strategy to detect legacy wallet adapter v1 wallet plugins
     this.scopePollingDetectionStrategy();
-    // Stretegy to detect AIP-62 standard compatible wallets
+    // Strategy to detect AIP-62 standard compatible wallets
     this.fetchAptosWallets();
   }
 
@@ -869,7 +869,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
         return pendingTransaction;
       }
 
-      // Else have the adpater submits the transaction
+      // Else have the adapter submit the transaction
 
       const aptosConfig = new AptosConfig({
         network: convertNetwork(this.network),

--- a/packages/wallet-adapter-react/README.md
+++ b/packages/wallet-adapter-react/README.md
@@ -1,4 +1,4 @@
-> **_NOTE:_** This documentation is for Wallet Adapter `v2.0.0` and up that is fully comatible with the Aptos TypeScript SDK V2. For Wallet Adapter `v^1.*.*` refer to [this guide](./READMEV1.md)
+> **_NOTE:_** This documentation is for Wallet Adapter `v2.0.0` and up that is fully compatible with the Aptos TypeScript SDK V2. For Wallet Adapter `v^1.*.*` refer to [this guide](./READMEV1.md)
 
 # Wallet Adapter React Provider
 

--- a/packages/wallet-adapter-react/src/WalletProvider.tsx
+++ b/packages/wallet-adapter-react/src/WalletProvider.tsx
@@ -160,7 +160,7 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
         setIsLoading(false);
       }
     }
-  }, wallets);
+  }, [wallets]);
 
   useEffect(() => {
     if (connected) {


### PR DESCRIPTION
### Description

The `useEffect` dependency in the auto-connect block in `WalletProvider.tsx` was using the `wallets` array directly rather than as a single dependency in the dependency array, which seems like it was most likely a typo.

This wasn't an issue before because the `wallets` value was static and never changed upon load. Now that AIP-62 compliant wallets load at a separate time than the non-AIP-62 wallets, this value changes and thus React now warns you:

```shell
client.js:2 Warning: The final argument passed to useEffect changed size between renders. The order and size of this array must remain constant.

Previous: [[object Object], [object Object], [object Object], [object Object]]
Incoming: [[object Object], [object Object], [object Object], [object Object], [object Object]]
```

Note the additional object in the `Incoming` array is the `Nightly` wallet

I've updated it to be correct:

```tsx
  useEffect(() => {
    if (autoConnect) {
      if (localStorage.getItem("AptosWalletName") && !connected) {
        connect(localStorage.getItem("AptosWalletName") as WalletName);
      } else {
        // if we dont use autoconnect set the connect is loading to false
        setIsLoading(false);
      }
    }
  }, [wallets]);  //  <-------------- was `wallets` before
  ```
  
I also fixed a few typos in the repo 😄 