### PR TITLE
Exposing wallet adapter core into window object

### DIFF
--- a/.changeset/fifty-dryers-tap.md
+++ b/.changeset/fifty-dryers-tap.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/wallet-adapter-core": minor
+---
+
+Exposing wallet adapter core version into window object

--- a/packages/wallet-adapter-core/src/index.ts
+++ b/packages/wallet-adapter-core/src/index.ts
@@ -1,5 +1,11 @@
+import { WALLET_ADAPTER_CORE_VERSION } from './version';
+
 export { WalletCore } from "./WalletCore";
 export * from "./LegacyWalletPlugins";
 export * from "./constants";
 export * from "./utils";
 export * from "./AIP62StandardWallets";
+
+if (typeof window !== 'undefined') {
+  (window as any).WALLET_ADAPTER_CORE_VERSION = WALLET_ADAPTER_CORE_VERSION;
+}


### PR DESCRIPTION
In order to enable dynamic behaviors, we're now exposing the dapp's wallet adapter version through the window object, when available