### PR TITLE
Add multisig transaction support

### DIFF
--- a/.changeset/dry-starfishes-push.md
+++ b/.changeset/dry-starfishes-push.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/wallet-adapter-core": minor
+---
+
+Add multisig transaction support

--- a/packages/wallet-adapter-core/src/LegacyWalletPlugins/conversion.ts
+++ b/packages/wallet-adapter-core/src/LegacyWalletPlugins/conversion.ts
@@ -44,6 +44,25 @@ export function convertV2PayloadToV1JSONPayload(
   if ("bytecode" in payload) {
     // is a script payload
     throw new Error("script payload not supported");
+    // is multisig function payload
+  } else if ("multisigAddress" in payload) {
+    const stringTypeTags: string[] | undefined = payload.typeArguments?.map(
+      (typeTag) => {
+        if (typeTag instanceof TypeTag) {
+          return typeTag.toString();
+        }
+        return typeTag;
+      }
+    );
+    const newPayload: Types.TransactionPayload = {
+      type: "multisig_payload",
+      multisig_address: payload.multisigAddress.toString(),
+      function: payload.function,
+      type_arguments: stringTypeTags || [],
+      arguments: payload.functionArguments,
+    };
+
+    return newPayload;
   } else {
     // is entry function payload
     const stringTypeTags: string[] | undefined = payload.typeArguments?.map(
@@ -67,9 +86,9 @@ export function convertV2PayloadToV1JSONPayload(
 
 export async function generateTransactionPayloadFromV1Input(
   aptosConfig: AptosConfig,
-  inputV1: Types.TransactionPayload,
+  inputV1: Types.TransactionPayload
 ): Promise<TransactionPayloadEntryFunction> {
-  if ('function' in inputV1) {
+  if ("function" in inputV1) {
     const inputV2: InputEntryFunctionData | InputMultiSigData = {
       function: inputV1.function as MoveFunctionId,
       functionArguments: inputV1.arguments,
@@ -78,7 +97,7 @@ export async function generateTransactionPayloadFromV1Input(
     return generateTransactionPayload({ ...inputV2, aptosConfig });
   }
 
-  throw new Error('Payload type not supported');
+  throw new Error("Payload type not supported");
 }
 
 export interface CompatibleTransactionOptions {


### PR DESCRIPTION
Add multisig transaction submission support.

To execute a multisig transaction
```
const transaction: InputTransactionData = {
      data: {
        multisigAddress:"0x123"
        function: "0x1::coin::transfer",
        typeArguments: [APTOS_COIN],
        functionArguments: [account.address, 1],
      },
    };
```
On Petra
![image](https://github.com/aptos-labs/aptos-wallet-adapter/assets/29798064/f106c490-8d6b-4e15-86cc-6eff4bf17b30)

Transaction on explorer https://explorer.aptoslabs.com/txn/0xe4383d8f1d74722f211215d4e2f5e9d7c1d24de9890b0cd9660defa087435340?network=devnet