### PR TITLE
Wallets opt-in support

### DIFF
--- a/.changeset/good-tigers-appear.md
+++ b/.changeset/good-tigers-appear.md
@@ -1,0 +1,6 @@
+---
+"@aptos-labs/wallet-adapter-react": minor
+"@aptos-labs/wallet-adapter-core": minor
+---
+
+Wallets opt-in support

--- a/packages/wallet-adapter-core/src/AIP62StandardWallets/types.ts
+++ b/packages/wallet-adapter-core/src/AIP62StandardWallets/types.ts
@@ -8,3 +8,5 @@ export interface AptosStandardSupportedWallet<Name extends string = string> {
   readyState: WalletReadyState.NotDetected;
   isAIP62Standard: true;
 }
+
+export type AvailableWallets = "Nightly" | "T wallet";

--- a/packages/wallet-adapter-core/src/WalletCore.ts
+++ b/packages/wallet-adapter-core/src/WalletCore.ts
@@ -242,7 +242,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
    * @param walletName
    * @returns
    */
-  private excludeWallet(walletName: string): boolean {
+  excludeWallet(walletName: string): boolean {
     // If _optInWallets is not empty, and does not include the provided wallet,
     // return true to exclude the wallet, otherwise return false
     if (

--- a/packages/wallet-adapter-core/src/WalletCore.ts
+++ b/packages/wallet-adapter-core/src/WalletCore.ts
@@ -75,6 +75,7 @@ import {
   AptosStandardWallet,
   WalletStandardCore,
   AptosStandardSupportedWallet,
+  AvailableWallets,
 } from "./AIP62StandardWallets";
 import { GA4 } from "./ga";
 import { WALLET_ADAPTER_CORE_VERSION } from "./version";
@@ -85,6 +86,9 @@ export type IAptosWallet = AptosStandardWallet & Wallet;
 export class WalletCore extends EventEmitter<WalletCoreEvents> {
   // Private array to hold legacy wallet adapter plugins
   private _wallets: ReadonlyArray<Wallet> = [];
+
+  // Private array that holds all the Wallets a dapp decided to opt-in to
+  private _optInWallets: ReadonlyArray<AvailableWallets> = [];
 
   // Private array to hold compatible AIP-62 standard wallets
   private _standard_wallets: ReadonlyArray<AptosStandardWallet> = [];
@@ -125,15 +129,17 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
    *
    * @param plugins legacy wallet adapter v1 wallet plugins
    */
-  constructor(plugins: ReadonlyArray<Wallet>) {
+  constructor(
+    plugins: ReadonlyArray<Wallet>,
+    optInWallets: ReadonlyArray<AvailableWallets>
+  ) {
     super();
     this._wallets = plugins;
+    this._optInWallets = optInWallets;
     // Strategy to detect legacy wallet adapter v1 wallet plugins
     this.scopePollingDetectionStrategy();
     // Strategy to detect AIP-62 standard compatible wallets (extension + SDK wallets)
     this.fetchAptosWallets();
-    // Append AIP-62 compatible wallets that are not detected on the user machine
-    this.appendNotDetectedStandardSupportedWallets(this._standard_wallets);
   }
 
   private scopePollingDetectionStrategy() {
@@ -184,6 +190,9 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
     aptosStandardWallets: ReadonlyArray<AptosStandardWallet>
   ) {
     aptosStandardSupportedWalletList.map((supportedWallet) => {
+      if (this.excludeWallet(supportedWallet.name)) {
+        return;
+      }
       const existingWalletIndex = aptosStandardWallets.findIndex(
         (wallet) => wallet.name == supportedWallet.name
       );
@@ -211,8 +220,10 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
     const aptosStandardWallets: AptosStandardWallet[] = [];
 
     [...SDKWallets, ...extensionwWallets].map((wallet: AptosStandardWallet) => {
+      if (this.excludeWallet(wallet.name)) {
+        return;
+      }
       const isValid = isWalletWithRequiredFeatureSet(wallet);
-      // TODO add user opt-in check
       if (isValid) {
         wallet.readyState = WalletReadyState.Installed;
         aptosStandardWallets.push(wallet);
@@ -221,6 +232,26 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
     });
 
     this._standard_wallets = aptosStandardWallets;
+    // Append AIP-62 compatible wallets that are not detected on the user machine
+    this.appendNotDetectedStandardSupportedWallets(this._standard_wallets);
+  }
+
+  /**
+   * A function that excludes a wallet the dapp doesnt want to include
+   *
+   * @param walletName
+   * @returns
+   */
+  private excludeWallet(walletName: string): boolean {
+    // If _optInWallets is not empty, and does not include the provided wallet,
+    // return true to exclude the wallet, otherwise return false
+    if (
+      this._optInWallets.length > 0 &&
+      !this._optInWallets.includes(walletName as AvailableWallets)
+    ) {
+      return true;
+    }
+    return false;
   }
 
   /**

--- a/packages/wallet-adapter-core/src/__tests__/WalletCore.test.ts
+++ b/packages/wallet-adapter-core/src/__tests__/WalletCore.test.ts
@@ -55,7 +55,7 @@ const walletMock: Wallet = {
 
 const pluginsMock: Wallet[] = [walletMock];
 
-const walletCoreMock = new WalletCore(pluginsMock);
+const walletCoreMock = new WalletCore(pluginsMock, []);
 
 describe("signMessageAndVerify", () => {
   walletCoreMock.setWallet(walletMock);

--- a/packages/wallet-adapter-react/src/WalletProvider.tsx
+++ b/packages/wallet-adapter-react/src/WalletProvider.tsx
@@ -24,12 +24,14 @@ import type {
   InputTransactionData,
   Network,
   AptosStandardSupportedWallet,
+  AvailableWallets,
 } from "@aptos-labs/wallet-adapter-core";
 import { WalletCore } from "@aptos-labs/wallet-adapter-core";
 
 export interface AptosWalletProviderProps {
   children: ReactNode;
   plugins?: ReadonlyArray<Wallet>;
+  optInWallets?: ReadonlyArray<AvailableWallets>;
   autoConnect?: boolean;
   onError?: (error: any) => void;
 }
@@ -46,9 +48,19 @@ const initialState: {
   wallet: null,
 };
 
+/**
+ * Supported props to pass into the provider
+ *
+ * @param plugins Non AIP-62 supported wallet plugins array
+ * @param optInWallets AIP-62 supported wallet names array to only include in the adapter wallets
+ * @param autoConnect A boolean flag to indicate if the adapter should auto connect to a wallet
+ * @param onError A callback function to execute when there is an error in the adapter
+ *
+ */
 export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
   children,
   plugins,
+  optInWallets,
   autoConnect = false,
   onError,
 }: AptosWalletProviderProps) => {
@@ -59,7 +71,10 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
   // https://github.com/aptos-labs/aptos-wallet-adapter/issues/94
   const [isLoading, setIsLoading] = useState<boolean>(true);
 
-  const walletCore = useMemo(() => new WalletCore(plugins ?? []), []);
+  const walletCore = useMemo(
+    () => new WalletCore(plugins ?? [], optInWallets ?? []),
+    []
+  );
   const [wallets, setWallets] = useState<
     ReadonlyArray<Wallet | AptosStandardSupportedWallet>
   >(walletCore.wallets);


### PR DESCRIPTION
Add support for the user to opt-in to specific wallets they want to include in their dapp.

This logic is only for AIP-62 compatible wallets.

```
 <AptosWalletAdapterProvider
      plugins={wallets}
      optInWallets=["Nightly","T wallet"] // include Nightly and T wallet wallets
    >
  {children}
</AptosWalletAdapterProvider>
```