### PR TITLE
Support account prop to be of AIP-62 `AccountInfo` type

### DIFF
--- a/.changeset/red-days-laugh.md
+++ b/.changeset/red-days-laugh.md
@@ -1,0 +1,9 @@
+---
+"@aptos-labs/wallet-adapter-react": major
+"@aptos-labs/wallet-adapter-core": major
+"@aptos-labs/wallet-adapter-ant-design": minor
+"@aptos-labs/wallet-adapter-mui-design": minor
+"@aptos-labs/wallet-adapter-nextjs-example": minor
+---
+
+Support account prop to be of AIP-62 AccountInfo type

--- a/apps/nextjs-example/pages/index.tsx
+++ b/apps/nextjs-example/pages/index.tsx
@@ -13,11 +13,11 @@ import SponsorTransaction from "../components/transactionFlow/Sponsor";
 import MultiAgentTransaction from "../components/transactionFlow/MultiAgent";
 import Row from "../components/Row";
 import Col from "../components/Col";
-import { Network } from "@aptos-labs/ts-sdk";
-import { Select, Typography } from "antd";
+import { AccountAddress, Network } from "@aptos-labs/ts-sdk";
+import { Typography } from "antd";
 import {
   AptosChangeNetworkOutput,
-  StandardNetworkInfo,
+  NewStandardAccountInfo,
   isAptosNetwork,
 } from "@aptos-labs/wallet-adapter-core";
 import TransactionParameters from "../components/transactionFlow/TransactionParameters";
@@ -151,7 +151,7 @@ function WalletSelect() {
 
 // TODO: Verify public key matches account
 function WalletProps(props: {
-  account: AccountInfo | null;
+  account: AccountInfo | NewStandardAccountInfo | null;
   network: NetworkInfo | null;
   wallet: WalletInfo | null;
   changeNetwork: (network: Network) => Promise<AptosChangeNetworkOutput>;
@@ -221,10 +221,12 @@ function WalletProps(props: {
             name={"ANS Name (only if attached)"}
             value={account?.ansName}
           />
-          <DisplayOptionalValue
-            name={"Min keys required (only for multisig)"}
-            value={account?.minKeysRequired?.toString()}
-          />
+          {account && "minKeysRequired" in account && (
+            <DisplayOptionalValue
+              name={"Min keys required (only for multisig)"}
+              value={account.minKeysRequired?.toString()}
+            />
+          )}
         </Col>
       </Row>
       <Row>
@@ -289,7 +291,7 @@ function WalletProps(props: {
 function DisplayRequiredValue(props: {
   name: string;
   isCorrect: boolean;
-  value?: string;
+  value?: string | AccountAddress;
   expected?: string;
 }) {
   const { name, isCorrect, value, expected } = props;
@@ -305,7 +307,7 @@ function DisplayRequiredValue(props: {
   return (
     <div style={successStyling()}>
       <p>
-        <b>{name}:</b> {value ?? "Not present"}{" "}
+        <b>{name}:</b> {value?.toString() ?? "Not present"}{" "}
         {!isCorrect && expected && (
           <>
             <b>Expected:</b> {expected}

--- a/packages/wallet-adapter-ant-design/src/WalletSelector.tsx
+++ b/packages/wallet-adapter-ant-design/src/WalletSelector.tsx
@@ -54,7 +54,7 @@ export function WalletSelector({
   };
   const buttonText = account?.ansName
     ? account?.ansName
-    : truncateAddress(account?.address);
+    : truncateAddress(account?.address.toString());
   return (
     <>
       <Button className="wallet-button" onClick={() => onWalletButtonClick()}>

--- a/packages/wallet-adapter-core/src/AIP62StandardWallets/types.ts
+++ b/packages/wallet-adapter-core/src/AIP62StandardWallets/types.ts
@@ -1,3 +1,4 @@
+import { AccountAddress, PublicKey } from "@aptos-labs/ts-sdk";
 import { WalletName } from "../LegacyWalletPlugins/types";
 import { WalletReadyState } from "../constants";
 
@@ -10,3 +11,11 @@ export interface AptosStandardSupportedWallet<Name extends string = string> {
 }
 
 export type AvailableWallets = "Nightly" | "Petra" | "T wallet";
+
+export type NewStandardAccountInfo = {
+  address: AccountAddress;
+  publicKey: PublicKey;
+  ansName?: string;
+};
+
+export { AccountAddress } from "@aptos-labs/ts-sdk";

--- a/packages/wallet-adapter-core/src/LegacyWalletPlugins/types.ts
+++ b/packages/wallet-adapter-core/src/LegacyWalletPlugins/types.ts
@@ -18,7 +18,10 @@ import {
   NetworkInfo as StandardNetworkInfo,
   AptosChangeNetworkMethod,
 } from "@aptos-labs/wallet-standard";
-import { AptosStandardSupportedWallet } from "../AIP62StandardWallets/types";
+import {
+  AptosStandardSupportedWallet,
+  NewStandardAccountInfo,
+} from "../AIP62StandardWallets/types";
 
 export { TxnBuilderTypes, Types } from "aptos";
 export type {
@@ -72,7 +75,7 @@ export declare interface WalletCoreEvents {
   readyStateChange(wallet: Wallet): void;
   standardWalletsAdded(wallets: Wallet | AptosStandardSupportedWallet): void;
   networkChange(network: NetworkInfo | null): void;
-  accountChange(account: AccountInfo | null): void;
+  accountChange(account: AccountInfo | NewStandardAccountInfo | null): void;
 }
 
 export interface SignMessagePayload {

--- a/packages/wallet-adapter-core/src/WalletCore.ts
+++ b/packages/wallet-adapter-core/src/WalletCore.ts
@@ -76,6 +76,7 @@ import {
   WalletStandardCore,
   AptosStandardSupportedWallet,
   AvailableWallets,
+  NewStandardAccountInfo,
 } from "./AIP62StandardWallets";
 import { GA4 } from "./ga";
 import { WALLET_ADAPTER_CORE_VERSION } from "./version";
@@ -101,7 +102,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
   private _wallet: Wallet | null = null;
 
   // Current connected account
-  private _account: AccountInfo | null = null;
+  private _account: AccountInfo | NewStandardAccountInfo | null = null;
 
   // Current connected network
   private _network: NetworkInfo | null = null;
@@ -335,7 +336,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
    * @param account An account
    */
   private ensureAccountExists(
-    account: AccountInfo | null
+    account: AccountInfo | NewStandardAccountInfo | null
   ): asserts account is AccountInfo {
     if (!account) {
       throw new WalletAccountError("Account is not set").name;
@@ -444,8 +445,8 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
         }
         // account is of type
         this._account = {
-          address: connectStandardAccount.args.address.toString(),
-          publicKey: connectStandardAccount.args.publicKey.toString(),
+          address: connectStandardAccount.args.address,
+          publicKey: connectStandardAccount.args.publicKey,
           ansName: connectStandardAccount.args.ansName,
         };
         return;
@@ -453,8 +454,8 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
         // account is of type `StandardAccountInfo` which means it comes from onAccountChange event
         const standardAccount = account as StandardAccountInfo;
         this._account = {
-          address: standardAccount.address.toString(),
-          publicKey: standardAccount.publicKey.toString(),
+          address: standardAccount.address,
+          publicKey: standardAccount.publicKey,
           ansName: standardAccount.ansName,
         };
         return;
@@ -559,7 +560,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
    * @return account info
    * @throws WalletAccountError
    */
-  get account(): AccountInfo | null {
+  get account(): AccountInfo | NewStandardAccountInfo | null {
     try {
       return this._account;
     } catch (error: any) {

--- a/packages/wallet-adapter-mui-design/src/WalletButton.tsx
+++ b/packages/wallet-adapter-mui-design/src/WalletButton.tsx
@@ -52,7 +52,7 @@ export default function WalletButton({
             <Typography noWrap ml={2}>
               {account?.ansName
                 ? account?.ansName
-                : truncateAddress(account?.address!)}
+                : truncateAddress(account?.address.toString()!)}
             </Typography>
           </>
         ) : (

--- a/packages/wallet-adapter-mui-design/src/WalletMenu.tsx
+++ b/packages/wallet-adapter-mui-design/src/WalletMenu.tsx
@@ -37,7 +37,7 @@ export default function WalletMenu({
   const [tooltipOpen, setTooltipOpen] = useState<boolean>(false);
 
   const copyAddress = async (event: React.MouseEvent<HTMLDivElement>) => {
-    await navigator.clipboard.writeText(account?.address!);
+    await navigator.clipboard.writeText(account?.address.toString()!);
 
     setTooltipOpen(true);
 

--- a/packages/wallet-adapter-react/src/WalletProvider.tsx
+++ b/packages/wallet-adapter-react/src/WalletProvider.tsx
@@ -25,6 +25,7 @@ import type {
   Network,
   AptosStandardSupportedWallet,
   AvailableWallets,
+  NewStandardAccountInfo,
 } from "@aptos-labs/wallet-adapter-core";
 import { WalletCore } from "@aptos-labs/wallet-adapter-core";
 
@@ -37,7 +38,7 @@ export interface AptosWalletProviderProps {
 }
 
 const initialState: {
-  account: AccountInfo | null;
+  account: AccountInfo | NewStandardAccountInfo | null;
   network: NetworkInfo | null;
   connected: boolean;
   wallet: WalletInfo | null;

--- a/packages/wallet-adapter-react/src/useWallet.tsx
+++ b/packages/wallet-adapter-react/src/useWallet.tsx
@@ -16,13 +16,14 @@ import {
   AptosChangeNetworkOutput,
   Network,
   AptosStandardSupportedWallet,
+  NewStandardAccountInfo,
 } from "@aptos-labs/wallet-adapter-core";
 import { createContext, useContext } from "react";
 
 export interface WalletContextState {
   connected: boolean;
   isLoading: boolean;
-  account: AccountInfo | null;
+  account: AccountInfo | NewStandardAccountInfo | null;
   network: NetworkInfo | null;
   connect(walletName: WalletName): void;
   disconnect(): void;


### PR DESCRIPTION
The adapter returns the current connected wallet account address and public key as a `string` type. With the latest AIP-62 upgrade, the Wallet now returns the account address as a `AccountAddress` type and the public ket as `PublicKey` type.

This change is to support the 2 new types to be returned correctly from the adapter.
With this change, the `account` type returned by the adapter is of type [AccountInfo](https://github.com/aptos-labs/aptos-wallet-adapter/blob/main/packages/wallet-adapter-core/src/LegacyWalletPlugins/types.ts#L56) | [NewStandardAccountInfo](https://github.com/aptos-labs/wallet-standard/blob/main/src/AccountInfo.ts#L17)

Before
```
const {account} = useWallet();
account.address // string type
account.publicKey // string type
```

Now
```
const {account} = useWallet();
account.address // string | AccountAddress type
account.publicKey // string | PublicKey type
```