### PR TITLE
Fix bug in shadcn/ui wallet selector

### DIFF
--- a/.changeset/fresh-cheetahs-promise.md
+++ b/.changeset/fresh-cheetahs-promise.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/wallet-adapter-nextjs-example": patch
+---
+
+Fixed a bug where "More wallets" would still be displayed in the shadcn/ui wallet selector even if there aren't more wallets.

--- a/apps/nextjs-example/src/components/WalletSelector.tsx
+++ b/apps/nextjs-example/src/components/WalletSelector.tsx
@@ -99,18 +99,20 @@ function ConnectWalletDialog({ close }: ConnectWalletDialogProps) {
           <WalletRow key={wallet.name} wallet={wallet} onConnect={close} />
         ))}
       </div>
-      <Collapsible className="flex flex-col gap-4">
-        <CollapsibleTrigger asChild>
-          <Button size="sm" variant="ghost" className="gap-2">
-            More wallets <ChevronDown />
-          </Button>
-        </CollapsibleTrigger>
-        <CollapsibleContent className="flex flex-col gap-3">
-          {moreWallets.map((wallet) => (
-            <WalletRow key={wallet.name} wallet={wallet} onConnect={close} />
-          ))}
-        </CollapsibleContent>
-      </Collapsible>
+      {!!moreWallets.length && (
+        <Collapsible className="flex flex-col gap-4">
+          <CollapsibleTrigger asChild>
+            <Button size="sm" variant="ghost" className="gap-2">
+              More wallets <ChevronDown />
+            </Button>
+          </CollapsibleTrigger>
+          <CollapsibleContent className="flex flex-col gap-3">
+            {moreWallets.map((wallet) => (
+              <WalletRow key={wallet.name} wallet={wallet} onConnect={close} />
+            ))}
+          </CollapsibleContent>
+        </Collapsible>
+      )}
     </DialogContent>
   );
 }


### PR DESCRIPTION
Fixed a bug where "More wallets" would still be displayed in the shadcn/ui wallet selector even if there aren't more wallets.