### PR TITLE
Add Aptos Connect section to shadcn/ui wallet selector

### DIFF
--- a/.changeset/good-goats-march.md
+++ b/.changeset/good-goats-march.md
@@ -2,4 +2,4 @@
 "@aptos-labs/wallet-adapter-react": minor
 ---
 
-Add `getAptosConnectWallets` utility function
+Added `getAptosConnectWallets` utility function

--- a/.changeset/good-goats-march.md
+++ b/.changeset/good-goats-march.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/wallet-adapter-react": minor
+---
+
+Add `getAptosConnectWallets` utility function

--- a/.changeset/tall-emus-jump.md
+++ b/.changeset/tall-emus-jump.md
@@ -2,4 +2,4 @@
 "@aptos-labs/wallet-adapter-core": minor
 ---
 
-Add `APTOS_CONNECT_BASE_URL`, `APTOS_CONNECT_ACCOUNT_URL`, and `isAptosConnectWallet`
+Added `APTOS_CONNECT_BASE_URL`, `APTOS_CONNECT_ACCOUNT_URL`, and `isAptosConnectWallet`

--- a/.changeset/tall-emus-jump.md
+++ b/.changeset/tall-emus-jump.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/wallet-adapter-core": minor
+---
+
+Add `APTOS_CONNECT_BASE_URL`, `APTOS_CONNECT_ACCOUNT_URL`, and `isAptosConnectWallet`

--- a/.changeset/tall-needles-breathe.md
+++ b/.changeset/tall-needles-breathe.md
@@ -2,4 +2,4 @@
 "@aptos-labs/wallet-adapter-nextjs-example": minor
 ---
 
-Move Aptos Connect wallets to separate section in shadcn/ui wallet selector
+Moved Aptos Connect wallets to separate section in shadcn/ui wallet selector

--- a/.changeset/tall-needles-breathe.md
+++ b/.changeset/tall-needles-breathe.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/wallet-adapter-nextjs-example": minor
+---
+
+Move Aptos Connect wallets to separate section in shadcn/ui wallet selector

--- a/apps/nextjs-example/src/components/WalletSelector.tsx
+++ b/apps/nextjs-example/src/components/WalletSelector.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import {
+  APTOS_CONNECT_ACCOUNT_URL,
   AnyAptosWallet,
   WalletItem,
   getAptosConnectWallets,
+  isAptosConnectWallet,
   isInstallRequired,
   partitionWallets,
   truncateAddress,
@@ -67,10 +69,10 @@ export function WalletSelector() {
         <DropdownMenuItem onSelect={copyAddress} className="gap-2">
           <Copy className="h-4 w-4" /> Copy address
         </DropdownMenuItem>
-        {wallet?.url.includes("aptosconnect.app") && (
+        {wallet && isAptosConnectWallet(wallet) && (
           <DropdownMenuItem asChild>
             <a
-              href="https://aptosconnect.app/dashboard/main-account"
+              href={APTOS_CONNECT_ACCOUNT_URL}
               target="_blank"
               rel="noopener noreferrer"
               className="flex gap-2"
@@ -100,8 +102,20 @@ interface ConnectWalletDialogProps {
 
 function ConnectWalletDialog({ close }: ConnectWalletDialogProps) {
   const { wallets = [] } = useWallet();
-  const { aptosConnectWallets, otherWallets } = getAptosConnectWallets(wallets);
-  const { defaultWallets, moreWallets } = partitionWallets(otherWallets);
+
+  const {
+    /** Wallets that use social login to create an account on the blockchain */
+    aptosConnectWallets,
+    /** Wallets that use traditional wallet extensions */
+    otherWallets,
+  } = getAptosConnectWallets(wallets);
+
+  const {
+    /** Wallets that are currently installed or loadable. */
+    defaultWallets,
+    /** Wallets that are NOT currently installed or loadable. */
+    moreWallets,
+  } = partitionWallets(otherWallets);
 
   return (
     <DialogContent className="max-h-screen overflow-auto">

--- a/packages/wallet-adapter-core/src/utils/aptosConnect.ts
+++ b/packages/wallet-adapter-core/src/utils/aptosConnect.ts
@@ -1,0 +1,14 @@
+import { WalletInfo } from "../LegacyWalletPlugins";
+import { AnyAptosWallet } from "../WalletCore";
+
+/** The base URL for all Aptos Connect wallets. */
+export const APTOS_CONNECT_BASE_URL = "https://aptosconnect.app";
+
+/** The URL to the Aptos Connect account page if the user is signed in to Aptos Connect. */
+export const APTOS_CONNECT_ACCOUNT_URL =
+  "https://aptosconnect.app/dashboard/main-account";
+
+/** Returns `true` if the provided wallet is an Aptos Connect wallet. */
+export function isAptosConnectWallet(wallet: WalletInfo | AnyAptosWallet) {
+  return wallet.url.includes(APTOS_CONNECT_BASE_URL);
+}

--- a/packages/wallet-adapter-core/src/utils/aptosConnect.ts
+++ b/packages/wallet-adapter-core/src/utils/aptosConnect.ts
@@ -10,5 +10,5 @@ export const APTOS_CONNECT_ACCOUNT_URL =
 
 /** Returns `true` if the provided wallet is an Aptos Connect wallet. */
 export function isAptosConnectWallet(wallet: WalletInfo | AnyAptosWallet) {
-  return wallet.url.includes(APTOS_CONNECT_BASE_URL);
+  return wallet.url.startsWith(APTOS_CONNECT_BASE_URL);
 }

--- a/packages/wallet-adapter-core/src/utils/index.ts
+++ b/packages/wallet-adapter-core/src/utils/index.ts
@@ -1,3 +1,4 @@
-export { scopePollingDetectionStrategy } from "./scopePollingDetectionStrategy";
-export * from "./localStorage";
+export * from "./aptosConnect";
 export * from "./helpers";
+export * from "./localStorage";
+export { scopePollingDetectionStrategy } from "./scopePollingDetectionStrategy";

--- a/packages/wallet-adapter-react/src/utils.tsx
+++ b/packages/wallet-adapter-react/src/utils.tsx
@@ -32,7 +32,10 @@ export function isInstalledOrLoadable(wallet: AnyAptosWallet) {
   );
 }
 
-/** Partitions the `wallets` array so that Aptos Connect wallets are grouped separately from the rest. */
+/**
+ * Partitions the `wallets` array so that Aptos Connect wallets are grouped separately from the rest.
+ * Aptos Connect is a web wallet that uses social login to create accounts on the blockchain.
+ */
 export function getAptosConnectWallets(wallets: ReadonlyArray<AnyAptosWallet>) {
   const { defaultWallets, moreWallets } = partitionWallets(wallets, (wallet) =>
     wallet.url.includes("aptosconnect.app")

--- a/packages/wallet-adapter-react/src/utils.tsx
+++ b/packages/wallet-adapter-react/src/utils.tsx
@@ -32,6 +32,14 @@ export function isInstalledOrLoadable(wallet: AnyAptosWallet) {
   );
 }
 
+/** Partitions the `wallets` array so that Aptos Connect wallets are grouped separately from the rest. */
+export function getAptosConnectWallets(wallets: ReadonlyArray<AnyAptosWallet>) {
+  const { defaultWallets, moreWallets } = partitionWallets(wallets, (wallet) =>
+    wallet.url.includes("aptosconnect.app")
+  );
+  return { aptosConnectWallets: defaultWallets, otherWallets: moreWallets };
+}
+
 /**
  * Returns true if the user is on desktop and the provided wallet requires installation of a browser extension.
  * This can be used to decide whether to show a "Connect" button or "Install" link in the UI.


### PR DESCRIPTION
This PR moves the Aptos Connect wallets to a separate section in the shadcn/ui wallet selector and adds a new utility function to `wallet-adapter-react` to facilitate that.

The education screens for Aptos Connect will be added in a separate PR.

https://github.com/aptos-labs/aptos-wallet-adapter/assets/25761639/85f30b78-d046-439f-a14b-3b7d53eb18ec