### PR TITLE
Add wallet sorting props to MUI wallet selector

### DIFF
--- a/.changeset/great-suns-yell.md
+++ b/.changeset/great-suns-yell.md
@@ -2,4 +2,4 @@
 "@aptos-labs/wallet-adapter-mui-design": minor
 ---
 
-Added `sortDefaultWallets` and `sortMoreWallets` props to `WalletConnector`
+Added `sortDefaultWallets` and `sortMoreWallets` props to `WalletConnector`.

--- a/.changeset/great-suns-yell.md
+++ b/.changeset/great-suns-yell.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/wallet-adapter-mui-design": minor
+---
+
+Added `sortDefaultWallets` and `sortMoreWallets` props to `WalletConnector`

--- a/.changeset/shy-eyes-tease.md
+++ b/.changeset/shy-eyes-tease.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/wallet-adapter-mui-design": minor
+---
+
+Exposed `WalletConnectorProps` interface.

--- a/packages/wallet-adapter-mui-design/src/WalletConnector.tsx
+++ b/packages/wallet-adapter-mui-design/src/WalletConnector.tsx
@@ -1,15 +1,28 @@
+import { AnyAptosWallet } from "@aptos-labs/wallet-adapter-react";
 import { useState } from "react";
 import WalletButton from "./WalletButton";
 import WalletsModal from "./WalletModel";
 
-type WalletConnectorProps = {
+export interface WalletConnectorProps {
   networkSupport?: string;
   handleNavigate?: () => void;
-};
+  /**
+   * An optional function for sorting wallets that are currently installed or
+   * loadable in the wallet connector modal.
+   */
+  sortDefaultWallets?: (a: AnyAptosWallet, b: AnyAptosWallet) => number;
+  /**
+   * An optional function for sorting wallets that are NOT currently installed or
+   * loadable in the wallet connector modal.
+   */
+  sortMoreWallets?: (a: AnyAptosWallet, b: AnyAptosWallet) => number;
+}
 
 export function WalletConnector({
   networkSupport,
   handleNavigate,
+  sortDefaultWallets,
+  sortMoreWallets,
 }: WalletConnectorProps) {
   const [modalOpen, setModalOpen] = useState(false);
   const handleModalOpen = () => setModalOpen(true);
@@ -25,6 +38,8 @@ export function WalletConnector({
         handleClose={handleClose}
         modalOpen={modalOpen}
         networkSupport={networkSupport}
+        sortDefaultWallets={sortDefaultWallets}
+        sortMoreWallets={sortMoreWallets}
       />
     </>
   );

--- a/packages/wallet-adapter-mui-design/src/WalletModel.tsx
+++ b/packages/wallet-adapter-mui-design/src/WalletModel.tsx
@@ -27,17 +27,23 @@ import {
   LanOutlined as LanOutlinedIcon,
 } from "@mui/icons-material";
 import { useState } from "react";
+import { WalletConnectorProps } from "./WalletConnector";
 
-type WalletsModalProps = {
+interface WalletsModalProps
+  extends Pick<
+    WalletConnectorProps,
+    "networkSupport" | "sortDefaultWallets" | "sortMoreWallets"
+  > {
   handleClose: () => void;
   modalOpen: boolean;
-  networkSupport?: string;
-};
+}
 
 export default function WalletsModal({
   handleClose,
   modalOpen,
   networkSupport,
+  sortDefaultWallets,
+  sortMoreWallets,
 }: WalletsModalProps): JSX.Element {
   const theme = useTheme();
   const [expanded, setExpanded] = useState(false);
@@ -57,6 +63,9 @@ export default function WalletsModal({
     /** Wallets that are NOT currently installed or loadable. */
     moreWallets,
   } = partitionWallets(otherWallets);
+
+  if (sortDefaultWallets) defaultWallets.sort(sortDefaultWallets);
+  if (sortMoreWallets) moreWallets.sort(sortMoreWallets);
 
   const hasAptosConnectWallets = !!aptosConnectWallets.length;
 


### PR DESCRIPTION
- Added `sortDefaultWallets` and `sortMoreWallets` props to `WalletConnector`.
- Exposed `WalletConnectorProps` interface.

This will be used to place Petra at the top of the wallets list in Aptos Names and Explorer.