### PR TITLE
[Docs] Fix wallet-adapter-react README.md [network -> Network]

### DIFF
--- a/packages/wallet-adapter-react/README.md
+++ b/packages/wallet-adapter-react/README.md
@@ -75,7 +75,7 @@ const wallets = [new AptosLegacyStandardWallet()];
   plugins={wallets}
   autoConnect={true}
   optInWallets={["Petra"]}
-  dappConfig={{ netwrok: network.MAINNET }}
+  dappConfig={{ netwrok: Network.MAINNET }}
   onError={(error) => {
     console.log("error", error);
   }}


### PR DESCRIPTION
`Network` is the correct way to import network, not `network`.