### PR TITLE
Add modalMaxWidth prop to MUI wallet selector

### DIFF
--- a/.changeset/eight-geese-pay.md
+++ b/.changeset/eight-geese-pay.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/wallet-adapter-mui-design": minor
+---
+
+Added optional `modalMaxWidth` prop.

--- a/packages/wallet-adapter-mui-design/src/WalletConnector.tsx
+++ b/packages/wallet-adapter-mui-design/src/WalletConnector.tsx
@@ -1,4 +1,5 @@
 import { AnyAptosWallet } from "@aptos-labs/wallet-adapter-react";
+import { Breakpoint } from "@mui/material";
 import { useState } from "react";
 import WalletButton from "./WalletButton";
 import WalletsModal from "./WalletModel";
@@ -16,6 +17,8 @@ export interface WalletConnectorProps {
    * loadable in the wallet connector modal.
    */
   sortMoreWallets?: (a: AnyAptosWallet, b: AnyAptosWallet) => number;
+  /** The max width of the wallet selector modal. Defaults to `xs`. */
+  modalMaxWidth?: Breakpoint;
 }
 
 export function WalletConnector({
@@ -23,6 +26,7 @@ export function WalletConnector({
   handleNavigate,
   sortDefaultWallets,
   sortMoreWallets,
+  modalMaxWidth,
 }: WalletConnectorProps) {
   const [modalOpen, setModalOpen] = useState(false);
   const handleModalOpen = () => setModalOpen(true);
@@ -40,6 +44,7 @@ export function WalletConnector({
         networkSupport={networkSupport}
         sortDefaultWallets={sortDefaultWallets}
         sortMoreWallets={sortMoreWallets}
+        maxWidth={modalMaxWidth}
       />
     </>
   );

--- a/packages/wallet-adapter-mui-design/src/WalletModel.tsx
+++ b/packages/wallet-adapter-mui-design/src/WalletModel.tsx
@@ -9,6 +9,7 @@ import {
 } from "@aptos-labs/wallet-adapter-react";
 import {
   Box,
+  Breakpoint,
   Button,
   Collapse,
   Dialog,
@@ -37,6 +38,7 @@ interface WalletsModalProps
   > {
   handleClose: () => void;
   modalOpen: boolean;
+  maxWidth?: Breakpoint;
 }
 
 export default function WalletsModal({
@@ -45,6 +47,7 @@ export default function WalletsModal({
   networkSupport,
   sortDefaultWallets,
   sortMoreWallets,
+  maxWidth,
 }: WalletsModalProps): JSX.Element {
   const theme = useTheme();
   const [expanded, setExpanded] = useState(false);
@@ -76,7 +79,7 @@ export default function WalletsModal({
       onClose={handleClose}
       aria-label="wallet selector modal"
       sx={{ borderRadius: `${theme.shape.borderRadius}px` }}
-      maxWidth="xs"
+      maxWidth={maxWidth ?? "xs"}
       fullWidth
     >
       <Stack


### PR DESCRIPTION
This PR adds an optional `modalMaxWidth` prop to the MUI wallet selector.