### PR TITLE
Fix for Adapter event communication

### DIFF
--- a/.changeset/soft-zebras-vanish.md
+++ b/.changeset/soft-zebras-vanish.md
@@ -1,0 +1,6 @@
+---
+"@aptos-labs/wallet-adapter-react": minor
+"@aptos-labs/wallet-adapter-core": minor
+---
+
+Fix adapter event communication

--- a/packages/wallet-adapter-core/src/AIP62StandardWallets/sdkWallets.ts
+++ b/packages/wallet-adapter-core/src/AIP62StandardWallets/sdkWallets.ts
@@ -6,6 +6,12 @@ import { DappConfig } from "../WalletCore";
 
 export function getSDKWallets(dappConfig?: DappConfig) {
   const sdkWallets: AptosStandardWallet[] = [];
+
+  // Need to check window is defined for AptosConnect
+  if (typeof window !== "undefined") {
+    sdkWallets.push(new AptosConnectWallet({ network: dappConfig?.network }));
+  }
+
   // Push production wallet if env is production, otherwise use dev wallet
   if (dappConfig?.network === Network.MAINNET) {
     // TODO twallet uses @aptos-labs/wallet-standard at version 0.0.11 while adapter uses
@@ -13,11 +19,6 @@ export function getSDKWallets(dappConfig?: DappConfig) {
     sdkWallets.push(new TWallet() as any);
   } else {
     sdkWallets.push(new DevTWallet() as any);
-  }
-
-  // Need to check window is defined for AptosConnect
-  if (typeof window !== "undefined") {
-    sdkWallets.push(new AptosConnectWallet({ network: dappConfig?.network, dappId: dappConfig?.aptosConnectDappId }));
   }
 
   return sdkWallets;

--- a/packages/wallet-adapter-core/src/WalletCore.ts
+++ b/packages/wallet-adapter-core/src/WalletCore.ts
@@ -102,7 +102,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
   private _optInWallets: ReadonlyArray<AvailableWallets> = [];
 
   // Private array to hold compatible AIP-62 standard wallets
-  private _standard_wallets: ReadonlyArray<AptosStandardWallet> = [];
+  private _standard_wallets: Array<AptosStandardWallet> = [];
 
   // Private array to hold all wallets (legacy wallet adapter plugins AND compatible AIP-62 standard wallets)
   // while providing support for legacy and new wallet standard
@@ -156,12 +156,16 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
     this._optInWallets = optInWallets;
     this._dappConfig = dappConfig;
     this._sdkWallets = getSDKWallets(this._dappConfig);
+    // Strategy to detect AIP-62 extension standard compatible wallets
+    this.fetchExtensionAIP62AptosWallets();
+    // Strategy to detect AIP-62 SDK standard compatible wallets.
+    // We separate the extension and sdk detection process so we dont refetch sdk wallets anytime a new
+    // extension wallet becomes available
+    this.fetchSDKAIP62AptosWallets();
     // Strategy to detect legacy wallet adapter v1 wallet plugins
     this.scopePollingDetectionStrategy();
-    // Strategy to detect AIP-62 standard compatible wallets (extension + SDK wallets)
-    this.fetchAptosWallets();
     // Append AIP-62 compatible wallets that are not detected on the user machine
-    this.appendNotDetectedStandardSupportedWallets(this._standard_wallets);
+    this.appendNotDetectedStandardSupportedWallets();
   }
 
   private scopePollingDetectionStrategy() {
@@ -188,9 +192,9 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
     });
   }
 
-  private fetchAptosWallets() {
+  private fetchExtensionAIP62AptosWallets() {
     let { aptosWallets, on } = getAptosWallets();
-    this.setWallets(aptosWallets);
+    this.setExtensionAIP62Wallets(aptosWallets);
 
     if (typeof window === "undefined") return;
     // Adds an event listener for new wallets that get registered after the dapp has been loaded,
@@ -198,19 +202,20 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
     const that = this;
     const removeRegisterListener = on("register", function () {
       let { aptosWallets } = getAptosWallets();
-      that.setWallets(aptosWallets);
+      that.setExtensionAIP62Wallets(aptosWallets);
     });
 
     const removeUnregisterListener = on("unregister", function () {
       let { aptosWallets } = getAptosWallets();
-      that.setWallets(aptosWallets);
+      that.setExtensionAIP62Wallets(aptosWallets);
     });
   }
 
-  // Append wallets from wallet aip-62 standard registry to the `all_wallets` array
-  private appendNotDetectedStandardSupportedWallets(
-    aptosStandardWallets: ReadonlyArray<AptosStandardWallet>
-  ) {
+  // Since we can't discover AIP-62 wallets that are not installed on the user machine,
+  // We hold a AIP-62 wallets registry to show on the wallet selector modal for the users.
+  // Append wallets from wallet standard support registry to the `all_wallets` array
+  // when wallet is not installed on the user machine
+  private appendNotDetectedStandardSupportedWallets() {
     // Loop over the registry map
     aptosStandardSupportedWalletList.map((supportedWallet) => {
       // Check if we already have this wallet as an installed plugin
@@ -223,7 +228,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
       if (existingPluginWalletIndex !== -1) return;
 
       // Check if we already have this wallet as a AIP-62 wallet standard
-      const existingStandardWallet = aptosStandardWallets.find(
+      const existingStandardWallet = this._standard_wallets.find(
         (wallet) => wallet.name == supportedWallet.name
       );
 
@@ -245,34 +250,30 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
   }
 
   /**
-   * Set potential Standard compatible SDK + extension wallets
-   *
-   * Loop over local SDK and Extensions wallets
-   * 1) check it is Standard compatible
-   * 2) Update their readyState to Installed (for a future UI detection)
-   * 3) push the wallet into a local wallets array
-   * 4) standardize each wallet to the Wallet Plugin type interface for legacy compatibility
+   * Set AIP-62 SDK wallets
+   */
+  private fetchSDKAIP62AptosWallets() {
+    this._sdkWallets.map((wallet: AptosStandardWallet) => {
+      this.standardizeAIP62WalletType(wallet);
+    });
+  }
+
+  /**
+   * Set AIP-62 extension wallets
    *
    * @param extensionwWallets
    */
-  private setWallets(extensionwWallets: readonly AptosWallet[]) {
-    const aptosStandardWallets: AptosStandardWallet[] = [];
-
-    [...this._sdkWallets, ...extensionwWallets].map(
-      (wallet: AptosStandardWallet) => {
-        if (this.excludeWallet(wallet)) {
-          return;
-        }
-        const isValid = isWalletWithRequiredFeatureSet(wallet);
-        if (isValid) {
-          wallet.readyState = WalletReadyState.Installed;
-          aptosStandardWallets.push(wallet);
-          this.standardizeStandardWalletToPluginWalletType(wallet);
-        }
-      }
+  private setExtensionAIP62Wallets(extensionwWallets: readonly AptosWallet[]) {
+    // Twallet SDK fires a register event so the adapter assumes it is an extension wallet
+    // so filter out t wallet
+    const wallets = extensionwWallets.filter(
+      (wallet) => wallet.name !== "Dev T wallet" && wallet.name !== "T wallet"
     );
 
-    this._standard_wallets = aptosStandardWallets;
+    wallets.map((wallet: AptosStandardWallet) => {
+      this.standardizeAIP62WalletType(wallet);
+      this._standard_wallets.push(wallet);
+    });
   }
 
   /**
@@ -293,6 +294,29 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
       return true;
     }
     return false;
+  }
+
+  /**
+   * Standardize AIP62 wallet
+   *
+   * 1) check it is Standard compatible
+   * 2) Update its readyState to Installed (for a future UI detection)
+   * 3) convert it to the Wallet Plugin type interface for legacy compatibility
+   * 4) push the wallet into a local standard wallets array
+   *
+   * @param wallet
+   * @returns
+   */
+  private standardizeAIP62WalletType(wallet: AptosStandardWallet) {
+    if (this.excludeWallet(wallet)) {
+      return;
+    }
+    const isValid = isWalletWithRequiredFeatureSet(wallet);
+    if (isValid) {
+      wallet.readyState = WalletReadyState.Installed;
+      this.standardizeStandardWalletToPluginWalletType(wallet);
+      this._standard_wallets.push(wallet);
+    }
   }
 
   /**

--- a/packages/wallet-adapter-core/src/WalletCore.ts
+++ b/packages/wallet-adapter-core/src/WalletCore.ts
@@ -156,11 +156,11 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
     this._optInWallets = optInWallets;
     this._dappConfig = dappConfig;
     this._sdkWallets = getSDKWallets(this._dappConfig);
-    // Strategy to detect AIP-62 extension standard compatible wallets
+    // Strategy to detect AIP-62 standard compatible extension wallets
     this.fetchExtensionAIP62AptosWallets();
-    // Strategy to detect AIP-62 SDK standard compatible wallets.
-    // We separate the extension and sdk detection process so we dont refetch sdk wallets anytime a new
-    // extension wallet becomes available
+    // Strategy to detect AIP-62 standard compatible SDK wallets.
+    // We separate the extension and sdk detection process so we dont refetch sdk wallets everytime a new
+    // extension wallet is detected
     this.fetchSDKAIP62AptosWallets();
     // Strategy to detect legacy wallet adapter v1 wallet plugins
     this.scopePollingDetectionStrategy();
@@ -212,7 +212,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
   }
 
   // Since we can't discover AIP-62 wallets that are not installed on the user machine,
-  // We hold a AIP-62 wallets registry to show on the wallet selector modal for the users.
+  // we hold a AIP-62 wallets registry to show on the wallet selector modal for the users.
   // Append wallets from wallet standard support registry to the `all_wallets` array
   // when wallet is not installed on the user machine
   private appendNotDetectedStandardSupportedWallets() {
@@ -265,7 +265,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
    */
   private setExtensionAIP62Wallets(extensionwWallets: readonly AptosWallet[]) {
     // Twallet SDK fires a register event so the adapter assumes it is an extension wallet
-    // so filter out t wallet
+    // so filter out t wallet, remove it when twallet fixes it
     const wallets = extensionwWallets.filter(
       (wallet) => wallet.name !== "Dev T wallet" && wallet.name !== "T wallet"
     );
@@ -277,7 +277,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
   }
 
   /**
-   * A function that excludes a wallet the dapp doesnt want to include
+   * A function that excludes an AIP-62 compatible wallet the dapp doesnt want to include
    *
    * @param walletName
    * @returns

--- a/packages/wallet-adapter-react/src/WalletProvider.tsx
+++ b/packages/wallet-adapter-react/src/WalletProvider.tsx
@@ -67,7 +67,7 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
   // https://github.com/aptos-labs/aptos-wallet-adapter/issues/94
   const [isLoading, setIsLoading] = useState<boolean>(true);
 
-  const [walletCore, SetWalletCore] = useState<WalletCore>();
+  const [walletCore, setWalletCore] = useState<WalletCore>();
 
   const [wallets, setWallets] = useState<
     ReadonlyArray<Wallet | AptosStandardSupportedWallet>
@@ -80,7 +80,7 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
       optInWallets ?? [],
       dappConfig
     );
-    SetWalletCore(walletCore);
+    setWalletCore(walletCore);
   }, []);
 
   // Update initial Wallets state once WalletCore has been initialized

--- a/packages/wallet-adapter-react/src/WalletProvider.tsx
+++ b/packages/wallet-adapter-react/src/WalletProvider.tsx
@@ -77,8 +77,9 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
 
   const [wallets, setWallets] = useState<
     ReadonlyArray<Wallet | AptosStandardSupportedWallet>
-  >([]);
+  >(plugins ?? []);
 
+  // A global ref to assign WalletCore to so we can use outside of the useEffect context
   const walletCoreRef = useRef<WalletCore>();
 
   // Initialize WalletCore on first load


### PR DESCRIPTION
Currently, the AdapterProvider initializes a WalletCore instance and sets the Wallet state on the first load. Then, the WalletCore constructor executes wallet detection strategies that fire events for the AdapterProvider to listen to. This causes some potential race condition issues, especially when detecting AIP-62 standard wallets, as the events fired from WalletCore might not have registered as listeners in the AdapterProvider yet, and the events are being fired into the void, resulting in wallets not appearing on the Selector Modal.

This PR fixes it by initializing WalletCore in a useEffect hook only once after the initial render and then setting it to a state to have access to WalletCore outside of the useEffect context and to trigger a re-render which ensures the event listeners are reattached and listen to any events coming from WalletCore.