### PR TITLE
[Fix] use `isAptosConnectWallet` function to verify a wallet is an `AptosConnect` wallet

### DIFF
--- a/.changeset/great-coats-train.md
+++ b/.changeset/great-coats-train.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/wallet-adapter-core": patch
+---
+
+use isAptosConnectWallet function to verify a wallet is an AptosConnect wallet in excludeWallet function

--- a/packages/wallet-adapter-core/src/WalletCore.ts
+++ b/packages/wallet-adapter-core/src/WalletCore.ts
@@ -65,6 +65,7 @@ import {
   fetchDevnetChainId,
   generalizedErrorMessage,
   getAptosConfig,
+  isAptosConnectWallet,
   isAptosNetwork,
   isRedirectable,
   removeLocalStorage,
@@ -224,7 +225,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
       // If AIP-62 wallet detected but it is excluded by the dapp, dont add it to the wallets array
       if (
         existingStandardWallet &&
-        this.excludeWallet(existingStandardWallet.name)
+        this.excludeWallet(existingStandardWallet)
       ) {
         return;
       }
@@ -254,7 +255,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
 
     [...this._sdkWallets, ...extensionwWallets].map(
       (wallet: AptosStandardWallet) => {
-        if (this.excludeWallet(wallet.name)) {
+        if (this.excludeWallet(wallet)) {
           return;
         }
         const isValid = isWalletWithRequiredFeatureSet(wallet);
@@ -275,14 +276,14 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
    * @param walletName
    * @returns
    */
-  excludeWallet(walletName: string): boolean {
+  excludeWallet(wallet: AptosStandardWallet): boolean {
     // for now, we always include AptosConnect
-    if (walletName === "Google (AptosConnect)") return false;
+    if (isAptosConnectWallet(wallet)) return false;
     // If _optInWallets is not empty, and does not include the provided wallet,
     // return true to exclude the wallet, otherwise return false
     if (
       this._optInWallets.length > 0 &&
-      !this._optInWallets.includes(walletName as AvailableWallets)
+      !this._optInWallets.includes(wallet.name as AvailableWallets)
     ) {
       return true;
     }

--- a/packages/wallet-adapter-core/src/utils/aptosConnect.ts
+++ b/packages/wallet-adapter-core/src/utils/aptosConnect.ts
@@ -1,3 +1,4 @@
+import { AptosStandardWallet } from "../AIP62StandardWallets";
 import { WalletInfo } from "../LegacyWalletPlugins";
 import { AnyAptosWallet } from "../WalletCore";
 import { partitionWallets } from "./helpers";
@@ -10,7 +11,9 @@ export const APTOS_CONNECT_ACCOUNT_URL =
   "https://aptosconnect.app/dashboard/main-account";
 
 /** Returns `true` if the provided wallet is an Aptos Connect wallet. */
-export function isAptosConnectWallet(wallet: WalletInfo | AnyAptosWallet) {
+export function isAptosConnectWallet(
+  wallet: WalletInfo | AnyAptosWallet | AptosStandardWallet
+) {
   return wallet.url.startsWith(APTOS_CONNECT_BASE_URL);
 }
 


### PR DESCRIPTION
Instead of checking if a wallet is an AptosConnect wallet by its explicit name, we use the recently introduced `isAptosConnectWallet` function