### PR TITLE
Add back the aptos connect dapp id

### DIFF
--- a/.changeset/eighty-elephants-change.md
+++ b/.changeset/eighty-elephants-change.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/wallet-adapter-core": minor
+---
+
+Add dapp id to be passed to AptosConnect

--- a/packages/wallet-adapter-core/src/AIP62StandardWallets/sdkWallets.ts
+++ b/packages/wallet-adapter-core/src/AIP62StandardWallets/sdkWallets.ts
@@ -9,7 +9,7 @@ export function getSDKWallets(dappConfig?: DappConfig) {
 
   // Need to check window is defined for AptosConnect
   if (typeof window !== "undefined") {
-    sdkWallets.push(new AptosConnectWallet({ network: dappConfig?.network }));
+    sdkWallets.push(new AptosConnectWallet({ network: dappConfig?.network, dappId: dappConfig?.aptosConnectDappId }));
   }
 
   // Push production wallet if env is production, otherwise use dev wallet


### PR DESCRIPTION
This parameter wasn't passed through anymore. Likely because of resolutions to merge conflicts


https://github.com/aptos-labs/aptos-wallet-adapter/commit/f23cf43c73c8250ccb86b72c2a76d57fae41cb71