### PR TITLE
Add the proper type for the dapp config in wallet core

### DIFF
--- a/.changeset/violet-pigs-impress.md
+++ b/.changeset/violet-pigs-impress.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/wallet-adapter-core": minor
+---
+
+Add proper dappconfig type to wallet core

--- a/packages/wallet-adapter-core/src/WalletCore.ts
+++ b/packages/wallet-adapter-core/src/WalletCore.ts
@@ -149,7 +149,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
   constructor(
     plugins: ReadonlyArray<Wallet>,
     optInWallets: ReadonlyArray<AvailableWallets>,
-    dappConfig?: { network: Network }
+    dappConfig?: DappConfig
   ) {
     super();
     this._wallets = plugins;


### PR DESCRIPTION
This was working from wallet-adapter-react because it gets casted into dappconfig below, but when using wallet adapter core directly you would run into a type error.