### PR TITLE
[Hot Fix] Pontem wallet version 2.6.7 does not include a URL prop

### DIFF
--- a/.changeset/ten-garlics-move.md
+++ b/.changeset/ten-garlics-move.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/wallet-adapter-core": patch
+---
+
+[Hot Fix] Pontem wallet version 2.6.7 does not include a URL prop

--- a/packages/wallet-adapter-core/src/WalletCore.ts
+++ b/packages/wallet-adapter-core/src/WalletCore.ts
@@ -180,6 +180,15 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
       if (typeof window !== "undefined") {
         scopePollingDetectionStrategy(() => {
           const providerName = wallet.providerName || wallet.name.toLowerCase();
+          // Hot fix to manage Pontem wallet to not show duplications if user has the
+          // new standard version installed. Pontem uses "Pontem" wallet name for previous versions and
+          // "Pontem Wallet" with new version
+          if (providerName === "pontem") {
+            const existingStandardPontemWallet = this._standard_wallets.find(
+              (wallet) => wallet.name == "Pontem Wallet"
+            );
+            if (existingStandardPontemWallet) return false;
+          }
           if (Object.keys(window).includes(providerName)) {
             wallet.readyState = WalletReadyState.Installed;
             wallet.provider = window[providerName as any];

--- a/packages/wallet-adapter-core/src/utils/walletSelector.ts
+++ b/packages/wallet-adapter-core/src/utils/walletSelector.ts
@@ -53,6 +53,7 @@ export function truncateAddress(address: string | undefined) {
 export function isAptosConnectWallet(
   wallet: WalletInfo | AnyAptosWallet | AptosStandardWallet
 ) {
+  if (!wallet.url) return false;
   return wallet.url.startsWith(APTOS_CONNECT_BASE_URL);
 }
 


### PR DESCRIPTION
Pontem released a new Wallet version and it does not include a `URL` prop - that breaks some of the adapter internal checks.

Additionally, they changes their `name` prop from `Pontem` to `Pontem Wallet` and that also breaks some of the adapter checks on how to decide what wallets to show on the Wallet Selector so it wont have duplications