### PR TITLE
Bypass verification for Keyless wallet accounts

### DIFF
--- a/.changeset/four-onions-teach.md
+++ b/.changeset/four-onions-teach.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/wallet-adapter-core": patch
+---
+
+Skip verification for Keyless accounts

--- a/packages/wallet-adapter-core/src/AIP62StandardWallets/WalletStandard.ts
+++ b/packages/wallet-adapter-core/src/AIP62StandardWallets/WalletStandard.ts
@@ -15,6 +15,7 @@ import {
   Aptos,
   MultiEd25519Signature,
   MultiEd25519PublicKey,
+  KeylessPublicKey,
 } from "@aptos-labs/ts-sdk";
 
 import { WalletReadyState } from "../constants";
@@ -182,6 +183,12 @@ export class WalletStandardCore {
 
       if (response.status === UserResponseStatus.REJECTED) {
         throw new WalletConnectionError("Failed to sign a message").message;
+      }
+
+      // For Keyless wallet accounts we skip verification for now.
+      // TODO: Remove when client-side verification is done in SDK.
+      if (account.publicKey instanceof KeylessPublicKey) {
+        return true;
       }
 
       let verified = false;

--- a/packages/wallet-adapter-core/src/AIP62StandardWallets/WalletStandard.ts
+++ b/packages/wallet-adapter-core/src/AIP62StandardWallets/WalletStandard.ts
@@ -16,6 +16,7 @@ import {
   MultiEd25519Signature,
   MultiEd25519PublicKey,
   KeylessPublicKey,
+  KeylessSignature,
 } from "@aptos-labs/ts-sdk";
 
 import { WalletReadyState } from "../constants";
@@ -187,7 +188,7 @@ export class WalletStandardCore {
 
       // For Keyless wallet accounts we skip verification for now.
       // TODO: Remove when client-side verification is done in SDK.
-      if (account.publicKey instanceof KeylessPublicKey) {
+      if (account.publicKey instanceof KeylessPublicKey && response.args.signature instanceof KeylessSignature) {
         return true;
       }
 


### PR DESCRIPTION
To be removed when verification in the SDK is done.  For now, instead of erroring, just return true.