### PR TITLE
Fix signAndVerify for Keyless

### DIFF
--- a/.changeset/good-doors-design.md
+++ b/.changeset/good-doors-design.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/wallet-adapter-core": patch
+---
+
+Fix Keyless sign and verify

--- a/packages/wallet-adapter-core/src/AIP62StandardWallets/WalletStandard.ts
+++ b/packages/wallet-adapter-core/src/AIP62StandardWallets/WalletStandard.ts
@@ -10,13 +10,13 @@ import {
   AptosConnectOutput,
 } from "@aptos-labs/wallet-standard";
 import {
+  AnyPublicKey,
+  AnyPublicKeyVariant,
   AnyRawTransaction,
   PendingTransactionResponse,
   Aptos,
   MultiEd25519Signature,
   MultiEd25519PublicKey,
-  KeylessPublicKey,
-  KeylessSignature,
 } from "@aptos-labs/ts-sdk";
 
 import { WalletReadyState } from "../constants";
@@ -188,7 +188,10 @@ export class WalletStandardCore {
 
       // For Keyless wallet accounts we skip verification for now.
       // TODO: Remove when client-side verification is done in SDK.
-      if (account.publicKey instanceof KeylessPublicKey && response.args.signature instanceof KeylessSignature) {
+      if (
+        account.publicKey instanceof AnyPublicKey &&
+        account.publicKey.variant === AnyPublicKeyVariant.Keyless
+      ) {
         return true;
       }
 


### PR DESCRIPTION
Need to unnest the AnyPublicKey and check the variant underneath.