### PR TITLE
mizu wallet config as an optional prop

### DIFF
--- a/.changeset/good-rats-poke.md
+++ b/.changeset/good-rats-poke.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/wallet-adapter-core": patch
+---
+
+Change mizuWallet config to an optional prop

--- a/packages/wallet-adapter-core/src/AIP62StandardWallets/sdkWallets.ts
+++ b/packages/wallet-adapter-core/src/AIP62StandardWallets/sdkWallets.ts
@@ -18,6 +18,7 @@ export function getSDKWallets(dappConfig?: DappConfig) {
     );
 
     if (
+      dappConfig?.mizuwallet &&
       dappConfig?.network &&
       [Network.MAINNET, Network.TESTNET].includes(dappConfig.network)
     ) {

--- a/packages/wallet-adapter-core/src/WalletCore.ts
+++ b/packages/wallet-adapter-core/src/WalletCore.ts
@@ -87,7 +87,7 @@ export type IAptosWallet = AptosStandardWallet & Wallet;
 export interface DappConfig {
   network: Network;
   aptosConnectDappId?: string;
-  mizuwallet: {
+  mizuwallet?: {
     manifestURL: string;
     appId?: string;
   };


### PR DESCRIPTION
https://github.com/aptos-labs/aptos-wallet-adapter/pull/369 breaks dapps as it expects the mizuWallet config to be provided