### PR TITLE
Have the option to exclude AptosConnect from the wallet selector modal

### DIFF
--- a/.changeset/slimy-pens-repeat.md
+++ b/.changeset/slimy-pens-repeat.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/wallet-adapter-core": minor
+---
+
+Have the option to exclude AptosConnect from the wallet selector modal

--- a/apps/nextjs-example/src/components/ui/use-toast.ts
+++ b/apps/nextjs-example/src/components/ui/use-toast.ts
@@ -83,7 +83,7 @@ export const reducer = (state: State, action: Action): State => {
       return {
         ...state,
         toasts: state.toasts.map((t) =>
-          t.id === action.toast.id ? { ...t, ...action.toast } : t,
+          t.id === action.toast.id ? { ...t, ...action.toast } : t
         ),
       };
 
@@ -108,7 +108,7 @@ export const reducer = (state: State, action: Action): State => {
                 ...t,
                 open: false,
               }
-            : t,
+            : t
         ),
       };
     }
@@ -155,7 +155,7 @@ function toast({ ...props }: Toast) {
       ...props,
       id,
       open: true,
-      onOpenChange: (open) => {
+      onOpenChange: (open: any) => {
         if (!open) dismiss();
       },
     },

--- a/packages/wallet-adapter-core/src/AIP62StandardWallets/types.ts
+++ b/packages/wallet-adapter-core/src/AIP62StandardWallets/types.ts
@@ -22,4 +22,5 @@ export type AvailableWallets =
   | "Petra"
   | "T wallet"
   | "Pontem Wallet"
-  | "Mizu Wallet";
+  | "Mizu Wallet"
+  | "Continue with Google";

--- a/packages/wallet-adapter-core/src/WalletCore.ts
+++ b/packages/wallet-adapter-core/src/WalletCore.ts
@@ -323,8 +323,6 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
    * @returns
    */
   excludeWallet(wallet: AptosStandardWallet): boolean {
-    // for now, we always include AptosConnect
-    if (isAptosConnectWallet(wallet)) return false;
     // If _optInWallets is not empty, and does not include the provided wallet,
     // return true to exclude the wallet, otherwise return false
     if (


### PR DESCRIPTION
AptosConnect is currently included by default in the wallet selector modal - this causes issues for dapps that run on platforms AptosConnect is yet supported on (TG, file upload service, etc)

This change provides the option for devs to not opt-in to AptosConnect