### PR TITLE
Add a boolean flag to disable the adapter telemetry tool

### DIFF
--- a/.changeset/chatty-cheetahs-yawn.md
+++ b/.changeset/chatty-cheetahs-yawn.md
@@ -1,0 +1,6 @@
+---
+"@aptos-labs/wallet-adapter-react": minor
+"@aptos-labs/wallet-adapter-core": minor
+---
+
+Support a boolean flag to disable the adapter telemetry tool

--- a/packages/wallet-adapter-react/README.md
+++ b/packages/wallet-adapter-react/README.md
@@ -91,6 +91,7 @@ const wallets = [new AptosLegacyStandardWallet()];
 - `optInWallets` - the adapter detects and adds AIP-62 standard wallets by default, sometimes you might want to opt-in with specific wallets. This props lets you define the AIP-62 standard wallets you want to support in your dapp.
 - `dappConfig` - the adapter comes built-in with AIP-62 standard SDK wallets and it needs to know what configuration your dapp is in to render the current instance.
 - `onError` - a callback function to fire when the adapter throws an error
+- (optional) `disableTelemetry` - A boolean flag to disable the adapter telemetry tool, false by default
 
 #### Use Wallet
 

--- a/packages/wallet-adapter-react/src/WalletProvider.tsx
+++ b/packages/wallet-adapter-react/src/WalletProvider.tsx
@@ -27,6 +27,7 @@ export interface AptosWalletProviderProps {
   optInWallets?: ReadonlyArray<AvailableWallets>;
   autoConnect?: boolean;
   dappConfig?: DappConfig;
+  disableTelemetry?: boolean;
   onError?: (error: any) => void;
 }
 
@@ -49,6 +50,7 @@ const initialState: {
  * @param optInWallets AIP-62 supported wallet names array to only include in the adapter wallets
  * @param autoConnect A boolean flag to indicate if the adapter should auto connect to a wallet
  * @param dappConfig The dapp configurations to be used by SDK wallets to set their configurations
+ * @param disableTelemetry A boolean flag to disable the adapter telemetry tool
  * @param onError A callback function to execute when there is an error in the adapter
  *
  */
@@ -58,6 +60,7 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
   optInWallets,
   autoConnect = false,
   dappConfig,
+  disableTelemetry = false,
   onError,
 }: AptosWalletProviderProps) => {
   const [{ connected, account, network, wallet }, setState] =
@@ -78,7 +81,8 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
     const walletCore = new WalletCore(
       plugins ?? [],
       optInWallets ?? [],
-      dappConfig
+      dappConfig,
+      disableTelemetry
     );
     setWalletCore(walletCore);
   }, []);


### PR DESCRIPTION
The adapter uses GA4 to record anonymous adapter events. This PR adds a boolean flag that allows the dapp to disable this feature.

Note: GA4 injects cookies with a 1-year expiration. If cookies were previously injected and GA4 was enabled on the adapter side, you will need to manually or programmatically clear the user's browser cookies.

```
<AptosWalletAdapterProvider
  plugins={wallets}
  disableTelemetry={true}
  ...
>
  <App />
</AptosWalletAdapterProvider>;
```