### PR TITLE
[core] Added transaction input support for `signTransaction`

### DIFF
--- a/.changeset/nervous-bats-jog.md
+++ b/.changeset/nervous-bats-jog.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/wallet-adapter-core": minor
+---
+
+Added transaction input support for `signTransaction`

--- a/packages/wallet-adapter-core/package.json
+++ b/packages/wallet-adapter-core/package.json
@@ -50,8 +50,8 @@
     "typescript": "^4.5.3"
   },
   "dependencies": {
-    "@aptos-connect/wallet-adapter-plugin": "^1.0.1",
-    "@aptos-labs/wallet-standard": "^0.1.0",
+    "@aptos-connect/wallet-adapter-plugin": "^2.0.0",
+    "@aptos-labs/wallet-standard": "^0.2.0",
     "@atomrigslab/aptos-wallet-adapter": "^0.1.20",
     "@mizuwallet-sdk/aptos-wallet-adapter": "^0.2.3",
     "buffer": "^6.0.3",

--- a/packages/wallet-adapter-core/src/AIP62StandardWallets/WalletStandard.ts
+++ b/packages/wallet-adapter-core/src/AIP62StandardWallets/WalletStandard.ts
@@ -1,5 +1,6 @@
 import {
   UserResponse,
+  AptosSignTransactionInputV1_1,
   AptosSignTransactionOutput,
   AptosSignMessageOutput,
   AptosSignMessageInput,
@@ -8,6 +9,7 @@ import {
   AptosSignAndSubmitTransactionOutput,
   AccountInfo as StandardAccountInfo,
   AptosConnectOutput,
+  AptosSignTransactionOutputV1_1,
 } from "@aptos-labs/wallet-standard";
 import {
   AnyPublicKey,
@@ -128,9 +130,18 @@ export class WalletStandardCore {
     transaction: AnyRawTransaction,
     wallet: Wallet,
     asFeePayer?: boolean
-  ): Promise<AptosSignTransactionOutput> {
+  ): Promise<AptosSignTransactionOutput>
+  async signTransaction(
+    input: AptosSignTransactionInputV1_1,
+    wallet: Wallet,
+  ): Promise<AptosSignTransactionOutputV1_1>
+  async signTransaction(
+    transactionOrInput: AnyRawTransaction | AptosSignTransactionInputV1_1,
+    wallet: Wallet,
+    asFeePayer?: boolean
+  ): Promise<AptosSignTransactionOutput | AptosSignTransactionOutputV1_1> {
     const response = (await wallet.signTransaction!(
-      transaction,
+      transactionOrInput,
       asFeePayer
     )) as UserResponse<AptosSignTransactionOutput>;
     if (response.status === UserResponseStatus.REJECTED) {

--- a/packages/wallet-adapter-core/src/LegacyWalletPlugins/conversion.ts
+++ b/packages/wallet-adapter-core/src/LegacyWalletPlugins/conversion.ts
@@ -86,16 +86,27 @@ export function convertV2PayloadToV1JSONPayload(
   }
 }
 
-export async function generateTransactionPayloadFromV1Input(
-  aptosConfig: AptosConfig,
+export function convertPayloadInputV1ToV2(
   inputV1: Types.TransactionPayload
-): Promise<TransactionPayloadEntryFunction> {
+) {
   if ("function" in inputV1) {
     const inputV2: InputEntryFunctionData | InputMultiSigData = {
       function: inputV1.function as MoveFunctionId,
       functionArguments: inputV1.arguments,
       typeArguments: inputV1.type_arguments,
     };
+    return inputV2;
+  }
+
+  throw new Error("Payload type not supported");
+}
+
+export async function generateTransactionPayloadFromV1Input(
+  aptosConfig: AptosConfig,
+  inputV1: Types.TransactionPayload
+): Promise<TransactionPayloadEntryFunction> {
+  if ("function" in inputV1) {
+    const inputV2 = convertPayloadInputV1ToV2(inputV1);
     return generateTransactionPayload({ ...inputV2, aptosConfig });
   }
 

--- a/packages/wallet-adapter-core/src/LegacyWalletPlugins/types.ts
+++ b/packages/wallet-adapter-core/src/LegacyWalletPlugins/types.ts
@@ -156,6 +156,7 @@ export type AdapterPlugin<Name extends string = string> =
 export type Wallet<Name extends string = string> = AdapterPlugin<Name> & {
   readyState?: WalletReadyState;
   isAIP62Standard?: boolean;
+  isSignTransactionV1_1?: boolean;
 };
 
 export interface TransactionOptions {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -316,14 +316,14 @@ importers:
   packages/wallet-adapter-core:
     dependencies:
       '@aptos-connect/wallet-adapter-plugin':
-        specifier: ^1.0.1
-        version: 1.0.1(@aptos-labs/ts-sdk@1.27.1)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0)
+        specifier: ^2.0.0
+        version: 2.0.0(@aptos-labs/ts-sdk@1.27.1)(@aptos-labs/wallet-standard@0.2.0)(aptos@1.21.0)
       '@aptos-labs/ts-sdk':
         specifier: ^1.27.1
         version: 1.27.1
       '@aptos-labs/wallet-standard':
-        specifier: ^0.1.0
-        version: 0.1.0(@aptos-labs/ts-sdk@1.27.1)(@wallet-standard/core@1.0.3)
+        specifier: ^0.2.0
+        version: 0.2.0(@aptos-labs/ts-sdk@1.27.1)(@wallet-standard/core@1.0.3)
       '@atomrigslab/aptos-wallet-adapter':
         specifier: ^0.1.20
         version: 0.1.21(@aptos-labs/ts-sdk@1.27.1)
@@ -452,7 +452,7 @@ importers:
     dependencies:
       '@aptos-labs/wallet-adapter-core':
         specifier: 4.15.0
-        version: link:../wallet-adapter-core
+        version: 4.15.0(@aptos-labs/ts-sdk@1.18.1)(@mizuwallet-sdk/core@1.2.1)(@mizuwallet-sdk/protocol@0.0.1)(@wallet-standard/core@1.0.3)(aptos@1.21.0)
       vue:
         specifier: ^3.4.21
         version: 3.4.38(typescript@4.9.5)
@@ -465,7 +465,7 @@ importers:
         version: 8.57.0
       rollup-plugin-typescript2:
         specifier: ^0.36.0
-        version: 0.36.0(rollup@2.79.1)(typescript@4.9.5)
+        version: 0.36.0(rollup@4.21.1)(typescript@4.9.5)
       typescript:
         specifier: ^4.5.3
         version: 4.9.5
@@ -477,7 +477,7 @@ importers:
         version: 3.5.1(vite@5.3.3)
       vite-plugin-dts:
         specifier: 3.9.1
-        version: 3.9.1(rollup@2.79.1)(typescript@4.9.5)(vite@5.3.3)
+        version: 3.9.1(rollup@4.21.1)(typescript@4.9.5)(vite@5.3.3)
       vue-tsc:
         specifier: ^2.0.26
         version: 2.0.29(typescript@4.9.5)
@@ -568,6 +568,24 @@ packages:
     resolution: {integrity: sha512-+562v9k4aI80m1+VuMHehNJWLOFjBnXn3tdOitzD0il5b7smkSBal4+a3oKiQTbrwMmN/TBUMDvbdoWDehgOww==}
     dev: true
 
+  /@aptos-connect/wallet-adapter-plugin@1.0.1(@aptos-labs/ts-sdk@1.18.1)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0):
+    resolution: {integrity: sha512-yrnzO9gWMPqhgV0hz3Qv9XP98hefX/V7Pcj911SLM3NWktc+mL/5CW6BKz4VKcqnhewotd2Tek43VDZTSHKoeQ==}
+    peerDependencies:
+      '@aptos-labs/ts-sdk': 1.18.1
+      '@aptos-labs/wallet-standard': ^0.1.0
+      aptos: ^1.21.0
+    dependencies:
+      '@aptos-connect/wallet-api': 0.1.1(@aptos-labs/ts-sdk@1.18.1)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0)
+      '@aptos-labs/ts-sdk': 1.18.1
+      '@aptos-labs/wallet-adapter-core': 3.16.0(@aptos-labs/ts-sdk@1.18.1)(aptos@1.21.0)
+      '@aptos-labs/wallet-standard': 0.1.0(@aptos-labs/ts-sdk@1.18.1)(@wallet-standard/core@1.0.3)
+      '@identity-connect/crypto': 0.2.4(@aptos-labs/ts-sdk@1.18.1)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0)
+      '@identity-connect/dapp-sdk': 0.9.2(@aptos-labs/ts-sdk@1.18.1)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0)
+      aptos: 1.21.0
+    transitivePeerDependencies:
+      - debug
+    dev: false
+
   /@aptos-connect/wallet-adapter-plugin@1.0.1(@aptos-labs/ts-sdk@1.27.1)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0):
     resolution: {integrity: sha512-yrnzO9gWMPqhgV0hz3Qv9XP98hefX/V7Pcj911SLM3NWktc+mL/5CW6BKz4VKcqnhewotd2Tek43VDZTSHKoeQ==}
     peerDependencies:
@@ -575,15 +593,44 @@ packages:
       '@aptos-labs/wallet-standard': ^0.1.0
       aptos: ^1.21.0
     dependencies:
-      '@aptos-connect/wallet-api': 0.1.1(@aptos-labs/ts-sdk@1.27.1)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0)
+      '@aptos-connect/wallet-api': 0.1.2(@aptos-labs/ts-sdk@1.27.1)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0)
       '@aptos-labs/ts-sdk': 1.27.1
       '@aptos-labs/wallet-adapter-core': 3.16.0(@aptos-labs/ts-sdk@1.27.1)(aptos@1.21.0)
       '@aptos-labs/wallet-standard': 0.1.0(@aptos-labs/ts-sdk@1.27.1)(@wallet-standard/core@1.0.3)
       '@identity-connect/crypto': 0.2.4(@aptos-labs/ts-sdk@1.27.1)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0)
-      '@identity-connect/dapp-sdk': 0.9.2(@aptos-labs/ts-sdk@1.27.1)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0)
+      '@identity-connect/dapp-sdk': 0.9.3(@aptos-labs/ts-sdk@1.27.1)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0)
       aptos: 1.21.0
     transitivePeerDependencies:
       - debug
+    dev: false
+
+  /@aptos-connect/wallet-adapter-plugin@2.0.0(@aptos-labs/ts-sdk@1.27.1)(@aptos-labs/wallet-standard@0.2.0)(aptos@1.21.0):
+    resolution: {integrity: sha512-6IELDtPU9RdoqhOW/avy500FPI3c8eP9fnekOfkF7HOHv5xPG3S4Ac5S0tGP8daG9czMEy0R7HkVj3wDXzrJSw==}
+    peerDependencies:
+      '@aptos-labs/ts-sdk': 1.26.0
+      '@aptos-labs/wallet-standard': 0.2.0
+    dependencies:
+      '@aptos-connect/wallet-api': 0.1.2(@aptos-labs/ts-sdk@1.27.1)(@aptos-labs/wallet-standard@0.2.0)(aptos@1.21.0)
+      '@aptos-labs/ts-sdk': 1.27.1
+      '@aptos-labs/wallet-standard': 0.2.0(@aptos-labs/ts-sdk@1.27.1)(@wallet-standard/core@1.0.3)
+      '@identity-connect/crypto': 0.2.4(@aptos-labs/ts-sdk@1.27.1)(@aptos-labs/wallet-standard@0.2.0)(aptos@1.21.0)
+      '@identity-connect/dapp-sdk': 0.9.3(@aptos-labs/ts-sdk@1.27.1)(@aptos-labs/wallet-standard@0.2.0)(aptos@1.21.0)
+    transitivePeerDependencies:
+      - aptos
+      - debug
+    dev: false
+
+  /@aptos-connect/wallet-api@0.1.1(@aptos-labs/ts-sdk@1.18.1)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0):
+    resolution: {integrity: sha512-If666Wz7m+ZK/RzDhm5Wy3oDkhnv14wKHW0jEVtXtHwTzYEgaOdC92RhZHqzPAqysipKSatBJJNVk58PzJLAUQ==}
+    peerDependencies:
+      '@aptos-labs/ts-sdk': 1.18.1
+      '@aptos-labs/wallet-standard': ^0.1.0
+      aptos: ^1.20.0
+    dependencies:
+      '@aptos-labs/ts-sdk': 1.18.1
+      '@aptos-labs/wallet-standard': 0.1.0(@aptos-labs/ts-sdk@1.18.1)(@wallet-standard/core@1.0.3)
+      '@identity-connect/api': 0.6.3
+      aptos: 1.21.0
     dev: false
 
   /@aptos-connect/wallet-api@0.1.1(@aptos-labs/ts-sdk@1.27.1)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0):
@@ -599,6 +646,72 @@ packages:
       aptos: 1.21.0
     dev: false
 
+  /@aptos-connect/wallet-api@0.1.1(@aptos-labs/ts-sdk@1.27.1)(@aptos-labs/wallet-standard@0.2.0)(aptos@1.21.0):
+    resolution: {integrity: sha512-If666Wz7m+ZK/RzDhm5Wy3oDkhnv14wKHW0jEVtXtHwTzYEgaOdC92RhZHqzPAqysipKSatBJJNVk58PzJLAUQ==}
+    peerDependencies:
+      '@aptos-labs/ts-sdk': 1.18.1
+      '@aptos-labs/wallet-standard': ^0.1.0
+      aptos: ^1.20.0
+    dependencies:
+      '@aptos-labs/ts-sdk': 1.27.1
+      '@aptos-labs/wallet-standard': 0.2.0(@aptos-labs/ts-sdk@1.27.1)(@wallet-standard/core@1.0.3)
+      '@identity-connect/api': 0.6.3
+      aptos: 1.21.0
+    dev: false
+
+  /@aptos-connect/wallet-api@0.1.2(@aptos-labs/ts-sdk@1.18.1)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0):
+    resolution: {integrity: sha512-3jnPUNLP4pZKRKOqINWP2giPMTEeW4+RrVAWuyhsyDAh10/rcpXDIlhTmwUcTHLbbugqs41lCrepZo22u6ry6g==}
+    peerDependencies:
+      '@aptos-labs/ts-sdk': 1.26.0
+      '@aptos-labs/wallet-standard': ^0.1.0
+      aptos: ^1.20.0
+    dependencies:
+      '@aptos-labs/ts-sdk': 1.18.1
+      '@aptos-labs/wallet-standard': 0.1.0(@aptos-labs/ts-sdk@1.18.1)(@wallet-standard/core@1.0.3)
+      '@identity-connect/api': 0.7.0
+      aptos: 1.21.0
+    dev: false
+
+  /@aptos-connect/wallet-api@0.1.2(@aptos-labs/ts-sdk@1.27.1)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0):
+    resolution: {integrity: sha512-3jnPUNLP4pZKRKOqINWP2giPMTEeW4+RrVAWuyhsyDAh10/rcpXDIlhTmwUcTHLbbugqs41lCrepZo22u6ry6g==}
+    peerDependencies:
+      '@aptos-labs/ts-sdk': 1.26.0
+      '@aptos-labs/wallet-standard': ^0.1.0
+      aptos: ^1.20.0
+    dependencies:
+      '@aptos-labs/ts-sdk': 1.27.1
+      '@aptos-labs/wallet-standard': 0.1.0(@aptos-labs/ts-sdk@1.27.1)(@wallet-standard/core@1.0.3)
+      '@identity-connect/api': 0.7.0
+      aptos: 1.21.0
+    dev: false
+
+  /@aptos-connect/wallet-api@0.1.2(@aptos-labs/ts-sdk@1.27.1)(@aptos-labs/wallet-standard@0.2.0)(aptos@1.21.0):
+    resolution: {integrity: sha512-3jnPUNLP4pZKRKOqINWP2giPMTEeW4+RrVAWuyhsyDAh10/rcpXDIlhTmwUcTHLbbugqs41lCrepZo22u6ry6g==}
+    peerDependencies:
+      '@aptos-labs/ts-sdk': 1.26.0
+      '@aptos-labs/wallet-standard': ^0.1.0
+      aptos: ^1.20.0
+    dependencies:
+      '@aptos-labs/ts-sdk': 1.27.1
+      '@aptos-labs/wallet-standard': 0.2.0(@aptos-labs/ts-sdk@1.27.1)(@wallet-standard/core@1.0.3)
+      '@identity-connect/api': 0.7.0
+      aptos: 1.21.0
+    dev: false
+
+  /@aptos-connect/web-transport@0.0.7(@aptos-labs/ts-sdk@1.18.1)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0):
+    resolution: {integrity: sha512-4dYv/696bEZc75041ewKsWxg48/dTEDqP0TpIfK3KndGepKWDM9q3Lj8iZo+8Z9nhzxwulEqiAO7c0nvzXxVFA==}
+    peerDependencies:
+      '@aptos-labs/ts-sdk': 1.18.1
+      '@aptos-labs/wallet-standard': ^0.1.0
+      aptos: ^1.20.0
+    dependencies:
+      '@aptos-connect/wallet-api': 0.1.2(@aptos-labs/ts-sdk@1.18.1)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0)
+      '@aptos-labs/ts-sdk': 1.18.1
+      '@aptos-labs/wallet-standard': 0.1.0(@aptos-labs/ts-sdk@1.18.1)(@wallet-standard/core@1.0.3)
+      aptos: 1.21.0
+      uuid: 9.0.1
+    dev: false
+
   /@aptos-connect/web-transport@0.0.7(@aptos-labs/ts-sdk@1.27.1)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0):
     resolution: {integrity: sha512-4dYv/696bEZc75041ewKsWxg48/dTEDqP0TpIfK3KndGepKWDM9q3Lj8iZo+8Z9nhzxwulEqiAO7c0nvzXxVFA==}
     peerDependencies:
@@ -606,11 +719,30 @@ packages:
       '@aptos-labs/wallet-standard': ^0.1.0
       aptos: ^1.20.0
     dependencies:
-      '@aptos-connect/wallet-api': 0.1.1(@aptos-labs/ts-sdk@1.27.1)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0)
+      '@aptos-connect/wallet-api': 0.1.2(@aptos-labs/ts-sdk@1.27.1)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0)
       '@aptos-labs/ts-sdk': 1.27.1
       '@aptos-labs/wallet-standard': 0.1.0(@aptos-labs/ts-sdk@1.27.1)(@wallet-standard/core@1.0.3)
       aptos: 1.21.0
       uuid: 9.0.1
+    dev: false
+
+  /@aptos-connect/web-transport@0.0.7(@aptos-labs/ts-sdk@1.27.1)(@aptos-labs/wallet-standard@0.2.0)(aptos@1.21.0):
+    resolution: {integrity: sha512-4dYv/696bEZc75041ewKsWxg48/dTEDqP0TpIfK3KndGepKWDM9q3Lj8iZo+8Z9nhzxwulEqiAO7c0nvzXxVFA==}
+    peerDependencies:
+      '@aptos-labs/ts-sdk': 1.18.1
+      '@aptos-labs/wallet-standard': ^0.1.0
+      aptos: ^1.20.0
+    dependencies:
+      '@aptos-connect/wallet-api': 0.1.2(@aptos-labs/ts-sdk@1.27.1)(@aptos-labs/wallet-standard@0.2.0)(aptos@1.21.0)
+      '@aptos-labs/ts-sdk': 1.27.1
+      '@aptos-labs/wallet-standard': 0.2.0(@aptos-labs/ts-sdk@1.27.1)(@wallet-standard/core@1.0.3)
+      aptos: 1.21.0
+      uuid: 9.0.1
+    dev: false
+
+  /@aptos-labs/aptos-cli@0.1.9:
+    resolution: {integrity: sha512-76uPNZ6JrpruN9H8bEU37GVhAHwdhmvp7ZXpMTFnlFOJnBYt0LHCxR3x+HCk4WZ1CRrPQ57lmO+5A58PiGuweA==}
+    hasBin: true
     dev: false
 
   /@aptos-labs/aptos-cli@0.2.0:
@@ -634,6 +766,25 @@ packages:
     dependencies:
       axios: 1.7.4
       got: 11.8.6
+    transitivePeerDependencies:
+      - debug
+    dev: false
+
+  /@aptos-labs/ts-sdk@1.18.1:
+    resolution: {integrity: sha512-+tsm+UAT8BEMJsT30RpIT8rv6yDwFcs7W/YvyHPG2wnOvTjnGQe1CT8sB/qqUt4OiVhyPdddPQDB4+4oJBVyAQ==}
+    engines: {node: '>=11.0.0'}
+    dependencies:
+      '@aptos-labs/aptos-cli': 0.1.9
+      '@aptos-labs/aptos-client': 0.1.1
+      '@noble/curves': 1.4.2
+      '@noble/hashes': 1.4.0
+      '@scure/bip32': 1.4.0
+      '@scure/bip39': 1.3.0
+      eventemitter3: 5.0.1
+      form-data: 4.0.0
+      js-base64: 3.7.7
+      jwt-decode: 4.0.0
+      poseidon-lite: 0.2.0
     transitivePeerDependencies:
       - debug
     dev: false
@@ -688,6 +839,23 @@ packages:
       - debug
     dev: false
 
+  /@aptos-labs/wallet-adapter-core@3.16.0(@aptos-labs/ts-sdk@1.18.1)(aptos@1.21.0):
+    resolution: {integrity: sha512-4pBNoDLzuIOxdNwJEO770bkxROuEIQis0H0lFOVVCL33jK8/MWLlQo8hFgc71ovN1vWfdERDEgPLbAtVChploQ==}
+    peerDependencies:
+      '@aptos-labs/ts-sdk': ^1.13.2
+      aptos: ^1.21.0
+    dependencies:
+      '@aptos-labs/ts-sdk': 1.18.1
+      '@aptos-labs/wallet-standard': 0.0.11
+      '@atomrigslab/aptos-wallet-adapter': 0.1.21(@aptos-labs/ts-sdk@1.18.1)
+      aptos: 1.21.0
+      buffer: 6.0.3
+      eventemitter3: 4.0.7
+      tweetnacl: 1.0.3
+    transitivePeerDependencies:
+      - debug
+    dev: false
+
   /@aptos-labs/wallet-adapter-core@3.16.0(@aptos-labs/ts-sdk@1.27.1)(aptos@1.21.0):
     resolution: {integrity: sha512-4pBNoDLzuIOxdNwJEO770bkxROuEIQis0H0lFOVVCL33jK8/MWLlQo8hFgc71ovN1vWfdERDEgPLbAtVChploQ==}
     peerDependencies:
@@ -703,6 +871,30 @@ packages:
       tweetnacl: 1.0.3
     transitivePeerDependencies:
       - debug
+    dev: false
+
+  /@aptos-labs/wallet-adapter-core@4.15.0(@aptos-labs/ts-sdk@1.18.1)(@mizuwallet-sdk/core@1.2.1)(@mizuwallet-sdk/protocol@0.0.1)(@wallet-standard/core@1.0.3)(aptos@1.21.0):
+    resolution: {integrity: sha512-5FpdBWDA+YVEMktGB1UbO5GOL2x01DjvdVsDC25asubOnrx0HEYVsY/YCqgNo3aFYPN1hGExjNQBspg/nh4cxQ==}
+    peerDependencies:
+      '@aptos-labs/ts-sdk': ^1.18.1
+      aptos: ^1.21.0
+    dependencies:
+      '@aptos-connect/wallet-adapter-plugin': 1.0.1(@aptos-labs/ts-sdk@1.18.1)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0)
+      '@aptos-labs/ts-sdk': 1.18.1
+      '@aptos-labs/wallet-standard': 0.1.0(@aptos-labs/ts-sdk@1.18.1)(@wallet-standard/core@1.0.3)
+      '@atomrigslab/aptos-wallet-adapter': 0.1.21(@aptos-labs/ts-sdk@1.18.1)
+      '@mizuwallet-sdk/aptos-wallet-adapter': 0.2.3(@mizuwallet-sdk/core@1.2.1)(@mizuwallet-sdk/protocol@0.0.1)(@wallet-standard/core@1.0.3)(aptos@1.21.0)
+      aptos: 1.21.0
+      buffer: 6.0.3
+      eventemitter3: 4.0.7
+      tweetnacl: 1.0.3
+    transitivePeerDependencies:
+      - '@mizuwallet-sdk/core'
+      - '@mizuwallet-sdk/protocol'
+      - '@wallet-standard/core'
+      - bufferutil
+      - debug
+      - utf-8-validate
     dev: false
 
   /@aptos-labs/wallet-adapter-core@4.15.0(@aptos-labs/ts-sdk@1.27.1)(@mizuwallet-sdk/core@1.2.1)(@mizuwallet-sdk/protocol@0.0.1)(@wallet-standard/core@1.0.3)(aptos@1.21.0):
@@ -738,6 +930,16 @@ packages:
       - debug
     dev: false
 
+  /@aptos-labs/wallet-standard@0.1.0(@aptos-labs/ts-sdk@1.18.1)(@wallet-standard/core@1.0.3):
+    resolution: {integrity: sha512-DC4cWuvgXKBVQC+seGQc/nwIZoggZmGOIoN8EtEKHBSBMijwVfgRjD6cXPx8xWaXANyr5d32BGnWvYfMyWk3Pg==}
+    peerDependencies:
+      '@aptos-labs/ts-sdk': ^1.17.0
+      '@wallet-standard/core': ^1.0.3
+    dependencies:
+      '@aptos-labs/ts-sdk': 1.18.1
+      '@wallet-standard/core': 1.0.3
+    dev: false
+
   /@aptos-labs/wallet-standard@0.1.0(@aptos-labs/ts-sdk@1.27.1)(@wallet-standard/core@1.0.3):
     resolution: {integrity: sha512-DC4cWuvgXKBVQC+seGQc/nwIZoggZmGOIoN8EtEKHBSBMijwVfgRjD6cXPx8xWaXANyr5d32BGnWvYfMyWk3Pg==}
     peerDependencies:
@@ -756,6 +958,28 @@ packages:
     dependencies:
       '@aptos-labs/ts-sdk': 1.27.1
       '@wallet-standard/core': 1.0.3
+    dev: false
+
+  /@aptos-labs/wallet-standard@0.2.0(@aptos-labs/ts-sdk@1.27.1)(@wallet-standard/core@1.0.3):
+    resolution: {integrity: sha512-4aoO4MlqzrW+CtO83MwbHMMtu91DL5B7YKRvhJbRnVB4R+QCOwBI/aQTkNZbKBDfOplLlqWTTl6Li0l6e02YLQ==}
+    peerDependencies:
+      '@aptos-labs/ts-sdk': ^1.17.0
+      '@wallet-standard/core': ^1.0.3
+    dependencies:
+      '@aptos-labs/ts-sdk': 1.27.1
+      '@wallet-standard/core': 1.0.3
+    dev: false
+
+  /@atomrigslab/aptos-wallet-adapter@0.1.21(@aptos-labs/ts-sdk@1.18.1):
+    resolution: {integrity: sha512-LwT0OTOaGglctggMcihXLd4mzBFwRoJsR0aeFBHQRfTxZV1agNTgN/PxJl6N13+WYAvzc00j/WByxAmWgonorA==}
+    peerDependencies:
+      '@aptos-labs/ts-sdk': ^1.9.0
+    dependencies:
+      '@aptos-labs/ts-sdk': 1.18.1
+      '@aptos-labs/wallet-standard': 0.0.11
+      '@atomrigslab/dekey-web-wallet-provider': 1.2.1
+    transitivePeerDependencies:
+      - debug
     dev: false
 
   /@atomrigslab/aptos-wallet-adapter@0.1.21(@aptos-labs/ts-sdk@1.27.1):
@@ -2762,6 +2986,25 @@ packages:
     resolution: {integrity: sha512-wLbGY10+YBtYfEPyA1in5c6TvS2dm7vv8kz1hA+pdSOEOniguBoZOtSXpaIfnjL7t7NBVZNRZ9NaMp4rpgcQHQ==}
     dev: false
 
+  /@identity-connect/api@0.7.0:
+    resolution: {integrity: sha512-mn/LZGeb3xgBD644p67tYOjvYSSdZpwxiO4/ZjwjsJZ8eYvGha5FiZg+pqVH73lg1S36qikwbkA3HUQOAE5GKA==}
+    dev: false
+
+  /@identity-connect/crypto@0.2.4(@aptos-labs/ts-sdk@1.18.1)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0):
+    resolution: {integrity: sha512-31C89CHwE+2jSmIzaFEXOHpOLbdwPH5cctynSaQzLX18UsATtiMGoWQA8/LlGkM/7HUrQgbWmB2szcEGzYakCQ==}
+    peerDependencies:
+      '@aptos-labs/ts-sdk': 1.18.1
+    dependencies:
+      '@aptos-connect/wallet-api': 0.1.1(@aptos-labs/ts-sdk@1.18.1)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0)
+      '@aptos-labs/ts-sdk': 1.18.1
+      '@noble/hashes': 1.4.0
+      ed2curve: 0.3.0
+      tweetnacl: 1.0.3
+    transitivePeerDependencies:
+      - '@aptos-labs/wallet-standard'
+      - aptos
+    dev: false
+
   /@identity-connect/crypto@0.2.4(@aptos-labs/ts-sdk@1.27.1)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0):
     resolution: {integrity: sha512-31C89CHwE+2jSmIzaFEXOHpOLbdwPH5cctynSaQzLX18UsATtiMGoWQA8/LlGkM/7HUrQgbWmB2szcEGzYakCQ==}
     peerDependencies:
@@ -2777,24 +3020,89 @@ packages:
       - aptos
     dev: false
 
-  /@identity-connect/dapp-sdk@0.9.2(@aptos-labs/ts-sdk@1.27.1)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0):
+  /@identity-connect/crypto@0.2.4(@aptos-labs/ts-sdk@1.27.1)(@aptos-labs/wallet-standard@0.2.0)(aptos@1.21.0):
+    resolution: {integrity: sha512-31C89CHwE+2jSmIzaFEXOHpOLbdwPH5cctynSaQzLX18UsATtiMGoWQA8/LlGkM/7HUrQgbWmB2szcEGzYakCQ==}
+    peerDependencies:
+      '@aptos-labs/ts-sdk': 1.18.1
+    dependencies:
+      '@aptos-connect/wallet-api': 0.1.1(@aptos-labs/ts-sdk@1.27.1)(@aptos-labs/wallet-standard@0.2.0)(aptos@1.21.0)
+      '@aptos-labs/ts-sdk': 1.27.1
+      '@noble/hashes': 1.4.0
+      ed2curve: 0.3.0
+      tweetnacl: 1.0.3
+    transitivePeerDependencies:
+      - '@aptos-labs/wallet-standard'
+      - aptos
+    dev: false
+
+  /@identity-connect/dapp-sdk@0.9.2(@aptos-labs/ts-sdk@1.18.1)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0):
     resolution: {integrity: sha512-jeS8P75G6OprcxzOjZK3xY7x5rSIzQCLSQgR+e1GVhyOYdJ7BLCHnUv3X5uAqZs9owZ4DmkqhkhjQ/tCuzxnlw==}
     peerDependencies:
       '@aptos-labs/ts-sdk': 1.18.1
       '@aptos-labs/wallet-standard': ^0.1.0
     dependencies:
-      '@aptos-connect/wallet-api': 0.1.1(@aptos-labs/ts-sdk@1.27.1)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0)
-      '@aptos-connect/web-transport': 0.0.7(@aptos-labs/ts-sdk@1.27.1)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0)
-      '@aptos-labs/ts-sdk': 1.27.1
-      '@aptos-labs/wallet-standard': 0.1.0(@aptos-labs/ts-sdk@1.27.1)(@wallet-standard/core@1.0.3)
+      '@aptos-connect/wallet-api': 0.1.1(@aptos-labs/ts-sdk@1.18.1)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0)
+      '@aptos-connect/web-transport': 0.0.7(@aptos-labs/ts-sdk@1.18.1)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0)
+      '@aptos-labs/ts-sdk': 1.18.1
+      '@aptos-labs/wallet-standard': 0.1.0(@aptos-labs/ts-sdk@1.18.1)(@wallet-standard/core@1.0.3)
       '@identity-connect/api': 0.6.3
-      '@identity-connect/crypto': 0.2.4(@aptos-labs/ts-sdk@1.27.1)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0)
-      '@identity-connect/wallet-api': 0.1.1(@aptos-labs/ts-sdk@1.27.1)(aptos@1.21.0)
-      axios: 1.7.2
+      '@identity-connect/crypto': 0.2.4(@aptos-labs/ts-sdk@1.18.1)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0)
+      '@identity-connect/wallet-api': 0.1.1(@aptos-labs/ts-sdk@1.18.1)(aptos@1.21.0)
+      axios: 1.7.4
       uuid: 9.0.1
     transitivePeerDependencies:
       - aptos
       - debug
+    dev: false
+
+  /@identity-connect/dapp-sdk@0.9.3(@aptos-labs/ts-sdk@1.27.1)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0):
+    resolution: {integrity: sha512-yZvUrCRu6/WZdaPo9DRNfOriMTQq4wGIrIag//ivbnUGzVGDwis8zCECf01gkhigCyhjNn0/EUVn3UV5Gj9xrQ==}
+    peerDependencies:
+      '@aptos-labs/ts-sdk': 1.26.0
+      '@aptos-labs/wallet-standard': ^0.1.0
+    dependencies:
+      '@aptos-connect/wallet-api': 0.1.2(@aptos-labs/ts-sdk@1.27.1)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0)
+      '@aptos-connect/web-transport': 0.0.7(@aptos-labs/ts-sdk@1.27.1)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0)
+      '@aptos-labs/ts-sdk': 1.27.1
+      '@aptos-labs/wallet-standard': 0.1.0(@aptos-labs/ts-sdk@1.27.1)(@wallet-standard/core@1.0.3)
+      '@identity-connect/api': 0.7.0
+      '@identity-connect/crypto': 0.2.4(@aptos-labs/ts-sdk@1.27.1)(@aptos-labs/wallet-standard@0.1.0)(aptos@1.21.0)
+      '@identity-connect/wallet-api': 0.1.1(@aptos-labs/ts-sdk@1.27.1)(aptos@1.21.0)
+      axios: 1.7.4
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - aptos
+      - debug
+    dev: false
+
+  /@identity-connect/dapp-sdk@0.9.3(@aptos-labs/ts-sdk@1.27.1)(@aptos-labs/wallet-standard@0.2.0)(aptos@1.21.0):
+    resolution: {integrity: sha512-yZvUrCRu6/WZdaPo9DRNfOriMTQq4wGIrIag//ivbnUGzVGDwis8zCECf01gkhigCyhjNn0/EUVn3UV5Gj9xrQ==}
+    peerDependencies:
+      '@aptos-labs/ts-sdk': 1.26.0
+      '@aptos-labs/wallet-standard': ^0.1.0
+    dependencies:
+      '@aptos-connect/wallet-api': 0.1.2(@aptos-labs/ts-sdk@1.27.1)(@aptos-labs/wallet-standard@0.2.0)(aptos@1.21.0)
+      '@aptos-connect/web-transport': 0.0.7(@aptos-labs/ts-sdk@1.27.1)(@aptos-labs/wallet-standard@0.2.0)(aptos@1.21.0)
+      '@aptos-labs/ts-sdk': 1.27.1
+      '@aptos-labs/wallet-standard': 0.2.0(@aptos-labs/ts-sdk@1.27.1)(@wallet-standard/core@1.0.3)
+      '@identity-connect/api': 0.7.0
+      '@identity-connect/crypto': 0.2.4(@aptos-labs/ts-sdk@1.27.1)(@aptos-labs/wallet-standard@0.2.0)(aptos@1.21.0)
+      '@identity-connect/wallet-api': 0.1.1(@aptos-labs/ts-sdk@1.27.1)(aptos@1.21.0)
+      axios: 1.7.4
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - aptos
+      - debug
+    dev: false
+
+  /@identity-connect/wallet-api@0.1.1(@aptos-labs/ts-sdk@1.18.1)(aptos@1.21.0):
+    resolution: {integrity: sha512-PGcJQrSnk6PLr/w5D1FKRP/Ip0DH8nvDuWe/5ZfStrGwKhG0L8yDZPbAmDfSOH2mUvVtafmayRYv/FOnqGtLLw==}
+    peerDependencies:
+      '@aptos-labs/ts-sdk': 1.18.1
+      aptos: ^1.20.0
+    dependencies:
+      '@aptos-labs/ts-sdk': 1.18.1
+      aptos: 1.21.0
     dev: false
 
   /@identity-connect/wallet-api@0.1.1(@aptos-labs/ts-sdk@1.27.1)(aptos@1.21.0):
@@ -3759,7 +4067,7 @@ packages:
       simple-git: 3.25.0
       sirv: 2.0.4
       tinyglobby: 0.2.5
-      unimport: 3.11.1
+      unimport: 3.11.1(rollup@4.21.1)
       vite: 5.3.3
       vite-plugin-inspect: 0.8.7(@nuxt/kit@3.13.0)(vite@5.3.3)
       vite-plugin-vue-inspector: 5.1.3(vite@5.3.3)
@@ -3794,7 +4102,7 @@ packages:
       semver: 7.6.3
       ufo: 1.5.4
       unctx: 2.3.1
-      unimport: 3.11.1
+      unimport: 3.11.1(rollup@4.21.1)
       untyped: 1.4.2
     transitivePeerDependencies:
       - magicast
@@ -3815,7 +4123,7 @@ packages:
       std-env: 3.7.0
       ufo: 1.5.4
       uncrypto: 0.1.3
-      unimport: 3.11.1
+      unimport: 3.11.1(rollup@4.21.1)
       untyped: 1.4.2
     transitivePeerDependencies:
       - rollup
@@ -3855,7 +4163,7 @@ packages:
       vue: ^3.3.4
     dependencies:
       '@nuxt/kit': 3.13.0(magicast@0.3.5)
-      '@rollup/plugin-replace': 5.0.7
+      '@rollup/plugin-replace': 5.0.7(rollup@4.21.1)
       '@vitejs/plugin-vue': 5.1.2(vite@5.4.2)(vue@3.4.38)
       '@vitejs/plugin-vue-jsx': 4.0.1(vite@5.4.2)(vue@3.4.38)
       autoprefixer: 10.4.20(postcss@8.4.41)
@@ -4119,6 +4427,7 @@ packages:
     dependencies:
       is-glob: 4.0.3
       micromatch: 4.0.7
+      napi-wasm: 1.1.3
     dev: true
     bundledDependencies:
       - napi-wasm
@@ -5037,19 +5346,6 @@ packages:
       rollup: 4.21.1
     dev: true
 
-  /@rollup/plugin-replace@5.0.7:
-    resolution: {integrity: sha512-PqxSfuorkHz/SPpyngLyg5GCEkOcee9M1bkxiVDr41Pd61mqP1PLOoDPbpl44SB2mQGKwV/In74gqQmGITOhEQ==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
-    peerDependenciesMeta:
-      rollup:
-        optional: true
-    dependencies:
-      '@rollup/pluginutils': 5.1.0(rollup@2.79.1)
-      magic-string: 0.30.11
-    dev: true
-
   /@rollup/plugin-replace@5.0.7(rollup@4.21.1):
     resolution: {integrity: sha512-PqxSfuorkHz/SPpyngLyg5GCEkOcee9M1bkxiVDr41Pd61mqP1PLOoDPbpl44SB2mQGKwV/In74gqQmGITOhEQ==}
     engines: {node: '>=14.0.0'}
@@ -5087,20 +5383,6 @@ packages:
       picomatch: 2.3.1
     dev: true
 
-  /@rollup/pluginutils@5.1.0(rollup@2.79.1):
-    resolution: {integrity: sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
-    peerDependenciesMeta:
-      rollup:
-        optional: true
-    dependencies:
-      '@types/estree': 1.0.5
-      estree-walker: 2.0.2
-      picomatch: 2.3.1
-      rollup: 2.79.1
-
   /@rollup/pluginutils@5.1.0(rollup@4.21.1):
     resolution: {integrity: sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==}
     engines: {node: '>=14.0.0'}
@@ -5114,14 +5396,12 @@ packages:
       estree-walker: 2.0.2
       picomatch: 2.3.1
       rollup: 4.21.1
-    dev: true
 
   /@rollup/rollup-android-arm-eabi@4.21.1:
     resolution: {integrity: sha512-2thheikVEuU7ZxFXubPDOtspKn1x0yqaYQwvALVtEcvFhMifPADBrgRPyHV0TF3b+9BgvgjgagVyvA/UqPZHmg==}
     cpu: [arm]
     os: [android]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-android-arm64@4.21.1:
@@ -5129,7 +5409,6 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-darwin-arm64@4.21.1:
@@ -5137,7 +5416,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-darwin-x64@4.21.1:
@@ -5145,7 +5423,6 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-linux-arm-gnueabihf@4.21.1:
@@ -5153,7 +5430,6 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-linux-arm-musleabihf@4.21.1:
@@ -5161,7 +5437,6 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-linux-arm64-gnu@4.21.1:
@@ -5169,7 +5444,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-linux-arm64-musl@4.21.1:
@@ -5177,7 +5451,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-linux-powerpc64le-gnu@4.21.1:
@@ -5185,7 +5458,6 @@ packages:
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-linux-riscv64-gnu@4.21.1:
@@ -5193,7 +5465,6 @@ packages:
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-linux-s390x-gnu@4.21.1:
@@ -5201,7 +5472,6 @@ packages:
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-linux-x64-gnu@4.21.1:
@@ -5209,7 +5479,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-linux-x64-musl@4.21.1:
@@ -5217,7 +5486,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-win32-arm64-msvc@4.21.1:
@@ -5225,7 +5493,6 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-win32-ia32-msvc@4.21.1:
@@ -5233,7 +5500,6 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@rollup/rollup-win32-x64-msvc@4.21.1:
@@ -5241,7 +5507,6 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: true
     optional: true
 
   /@rushstack/eslint-patch@1.10.4:
@@ -6002,7 +6267,7 @@ packages:
         optional: true
     dependencies:
       '@babel/types': 7.25.2
-      '@rollup/pluginutils': 5.1.0(rollup@2.79.1)
+      '@rollup/pluginutils': 5.1.0(rollup@4.21.1)
       '@vue/compiler-sfc': 3.4.38
       ast-kit: 1.1.0
       local-pkg: 0.5.0
@@ -6892,16 +7157,6 @@ packages:
 
   /axios@1.6.2:
     resolution: {integrity: sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==}
-    dependencies:
-      follow-redirects: 1.15.6
-      form-data: 4.0.0
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-    dev: false
-
-  /axios@1.7.2:
-    resolution: {integrity: sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==}
     dependencies:
       follow-redirects: 1.15.6
       form-data: 4.0.0
@@ -12064,6 +12319,10 @@ packages:
     engines: {node: ^18 || >=20}
     hasBin: true
 
+  /napi-wasm@1.1.3:
+    resolution: {integrity: sha512-h/4nMGsHjZDCYmQVNODIrYACVJ+I9KItbG+0si6W/jSjdA9JbWDoU4LLeMXVcEQGHjttI2tuXqDrbGF7qkUHHg==}
+    dev: true
+
   /natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
@@ -12392,7 +12651,7 @@ packages:
       uncrypto: 0.1.3
       unctx: 2.3.1
       unenv: 1.10.0
-      unimport: 3.11.1
+      unimport: 3.11.1(rollup@4.21.1)
       unplugin: 1.12.2
       unplugin-vue-router: 0.10.7(vue-router@4.4.3)(vue@3.4.38)
       unstorage: 1.10.2(ioredis@5.4.1)
@@ -14254,7 +14513,7 @@ packages:
     dependencies:
       glob: 7.2.3
 
-  /rollup-plugin-typescript2@0.36.0(rollup@2.79.1)(typescript@4.9.5):
+  /rollup-plugin-typescript2@0.36.0(rollup@4.21.1)(typescript@4.9.5):
     resolution: {integrity: sha512-NB2CSQDxSe9+Oe2ahZbf+B4bh7pHwjV5L+RSYpCu7Q5ROuN94F9b6ioWwKfz3ueL3KTtmX4o2MUH2cgHDIEUsw==}
     peerDependencies:
       rollup: '>=1.26.3'
@@ -14263,7 +14522,7 @@ packages:
       '@rollup/pluginutils': 4.2.1
       find-cache-dir: 3.3.2
       fs-extra: 10.1.0
-      rollup: 2.79.1
+      rollup: 4.21.1
       semver: 7.6.3
       tslib: 2.6.3
       typescript: 4.9.5
@@ -14292,6 +14551,7 @@ packages:
     hasBin: true
     optionalDependencies:
       fsevents: 2.3.3
+    dev: true
 
   /rollup@4.21.1:
     resolution: {integrity: sha512-ZnYyKvscThhgd3M5+Qt3pmhO4jIRR5RGzaSovB6Q7rGNrK5cUncrtLmcTTJVSdcKXyZjW8X8MB0JMSuH9bcAJg==}
@@ -14317,7 +14577,6 @@ packages:
       '@rollup/rollup-win32-ia32-msvc': 4.21.1
       '@rollup/rollup-win32-x64-msvc': 4.21.1
       fsevents: 2.3.3
-    dev: true
 
   /rpc-websockets@7.11.2:
     resolution: {integrity: sha512-pL9r5N6AVHlMN/vT98+fcO+5+/UcPLf/4tq+WUaid/PPUGS/ttJ3y8e9IqmaWKtShNAysMSjkczuEA49NuV7UQ==}
@@ -15607,25 +15866,6 @@ packages:
     resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
     engines: {node: '>=18'}
 
-  /unimport@3.11.1:
-    resolution: {integrity: sha512-DuB1Uoq01LrrXTScxnwOoMSlTXxyKcULguFxbLrMDFcE/CO0ZWHpEiyhovN0mycPt7K6luAHe8laqvwvuoeUPg==}
-    dependencies:
-      '@rollup/pluginutils': 5.1.0(rollup@2.79.1)
-      acorn: 8.12.1
-      escape-string-regexp: 5.0.0
-      estree-walker: 3.0.3
-      fast-glob: 3.3.2
-      local-pkg: 0.5.0
-      magic-string: 0.30.11
-      mlly: 1.7.1
-      pathe: 1.1.2
-      pkg-types: 1.2.0
-      scule: 1.3.0
-      strip-literal: 2.1.0
-      unplugin: 1.12.2
-    transitivePeerDependencies:
-      - rollup
-
   /unimport@3.11.1(rollup@4.21.1):
     resolution: {integrity: sha512-DuB1Uoq01LrrXTScxnwOoMSlTXxyKcULguFxbLrMDFcE/CO0ZWHpEiyhovN0mycPt7K6luAHe8laqvwvuoeUPg==}
     dependencies:
@@ -15644,7 +15884,6 @@ packages:
       unplugin: 1.12.2
     transitivePeerDependencies:
       - rollup
-    dev: true
 
   /universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
@@ -15664,7 +15903,7 @@ packages:
         optional: true
     dependencies:
       '@babel/types': 7.25.2
-      '@rollup/pluginutils': 5.1.0(rollup@2.79.1)
+      '@rollup/pluginutils': 5.1.0(rollup@4.21.1)
       '@vue-macros/common': 1.12.2(vue@3.4.38)
       ast-walker-scope: 0.6.2
       chokidar: 3.6.0
@@ -15990,7 +16229,7 @@ packages:
       vite: 5.3.3
     dev: true
 
-  /vite-plugin-dts@3.9.1(rollup@2.79.1)(typescript@4.9.5)(vite@5.3.3):
+  /vite-plugin-dts@3.9.1(rollup@4.21.1)(typescript@4.9.5)(vite@5.3.3):
     resolution: {integrity: sha512-rVp2KM9Ue22NGWB8dNtWEr+KekN3rIgz1tWD050QnRGlriUCmaDwa7qA5zDEjbXg5lAXhYMSBJtx3q3hQIJZSg==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
@@ -16001,7 +16240,7 @@ packages:
         optional: true
     dependencies:
       '@microsoft/api-extractor': 7.43.0
-      '@rollup/pluginutils': 5.1.0(rollup@2.79.1)
+      '@rollup/pluginutils': 5.1.0(rollup@4.21.1)
       '@vue/language-core': 1.8.27(typescript@4.9.5)
       debug: 4.3.6
       kolorist: 1.8.0
@@ -16040,7 +16279,7 @@ packages:
     dependencies:
       '@antfu/utils': 0.7.10
       '@nuxt/kit': 3.13.0(magicast@0.3.5)
-      '@rollup/pluginutils': 5.1.0(rollup@2.79.1)
+      '@rollup/pluginutils': 5.1.0(rollup@4.21.1)
       debug: 4.3.6
       error-stack-parser-es: 0.1.5
       fs-extra: 11.2.0
@@ -16357,7 +16596,7 @@ packages:
       '@webassemblyjs/wasm-parser': 1.12.1
       acorn: 8.12.1
       acorn-import-attributes: 1.9.5(acorn@8.12.1)
-      browserslist: 4.23.2
+      browserslist: 4.23.3
       chrome-trace-event: 1.0.4
       enhanced-resolve: 5.17.1
       es-module-lexer: 1.5.4


### PR DESCRIPTION
Part of a PR series to enable transaction input when using `signTransaction`

- https://github.com/aptos-labs/wallet-standard/pull/13
- https://github.com/aptos-labs/aptos-connect/pull/599

Previously, the only supported input type was an AnyRawTransaction instance.
The problem with this is that we're requiring the dapp to generate the transaction (and possibly payload) right before calling signTransaction.
This requires async calls which don't play well with certain browsers and popups.