### PR TITLE
build: fix eslint config and code issues

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
   root: true,
   // This tells ESLint to load the config from the package `eslint-config-custom`
-  extends: ["adapter"],
+  extends: ["@aptos-labs/eslint-config-adapter"],
   settings: {
     next: {
       rootDir: ["apps/*/"],

--- a/packages/wallet-adapter-ant-design/.eslintrc.js
+++ b/packages/wallet-adapter-ant-design/.eslintrc.js
@@ -1,4 +1,4 @@
 module.exports = {
   root: true,
-  extends: ["adapter"],
+  extends: ["@aptos-labs/eslint-config-adapter"],
 };

--- a/packages/wallet-adapter-core/.eslintrc.js
+++ b/packages/wallet-adapter-core/.eslintrc.js
@@ -1,4 +1,4 @@
 module.exports = {
   root: true,
-  extends: ["adapter"],
+  extends: ["@aptos-labs/eslint-config-adapter"],
 };

--- a/packages/wallet-adapter-core/src/error/index.ts
+++ b/packages/wallet-adapter-core/src/error/index.ts
@@ -1,7 +1,6 @@
 export class WalletError extends Error {
   public error: any;
 
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   constructor(message?: string, error?: any) {
     super(message);
     this.error = error;

--- a/packages/wallet-adapter-react/.eslintrc.js
+++ b/packages/wallet-adapter-react/.eslintrc.js
@@ -1,4 +1,4 @@
 module.exports = {
   root: true,
-  extends: ["adapter"],
+  extends: ["@aptos-labs/eslint-config-adapter"],
 };

--- a/packages/wallet-adapter-react/src/components/utils.tsx
+++ b/packages/wallet-adapter-react/src/components/utils.tsx
@@ -29,7 +29,7 @@ export function createHeadlessComponent<
   elementType: TElement,
   props?:
     | JSX.IntrinsicElements[TElement]
-    | ((displayName: string) => JSX.IntrinsicElements[TElement])
+    | ((displayName: string) => JSX.IntrinsicElements[TElement]),
 ) {
   const component = forwardRef<
     HTMLElementFromTag<TElement>,
@@ -38,7 +38,7 @@ export function createHeadlessComponent<
     const Component = asChild ? Slot : elementType;
 
     const { children: defaultChildren, ...resolvedProps } =
-      typeof props === "function" ? props(displayName) : props ?? {};
+      typeof props === "function" ? props(displayName) : (props ?? {});
 
     return (
       /**
@@ -52,12 +52,9 @@ export function createHeadlessComponent<
        * ignored for the JSX block below.
        */
       // @ts-expect-error
-      <Component
-        ref={ref}
-        className={className}
-        children={children ?? defaultChildren}
-        {...resolvedProps}
-      />
+      <Component ref={ref} className={className} {...resolvedProps}>
+        {children ?? defaultChildren}
+      </Component>
     );
   });
   component.displayName = displayName;

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "globalEnv": ["NEXT_PUBLIC_APTOS_API_KEY"],
+  "globalEnv": ["GAID", "NEXT_PUBLIC_APTOS_API_KEY"],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## Problem

Working on PR from e252fce1fc99cbef0e7a1ea0178c78c49a57e0a4, when running `pnpm turbo lint`, I get the following error:

<details>
<summary>console output</summary>
<pre>
aptos-wallet-adapter $ git rev-parse --short HEAD
e252fce

aptos-wallet-adapter $ pnpm turbo lint --output-logs errors-only
turbo 2.1.2

• Packages in scope: @aptos-labs/eslint-config-adapter, @aptos-labs/wallet-adapter-ant-design, @aptos-labs/wallet-adapter-core, @aptos-labs/wallet-adapter-mui-design, @aptos-labs/wallet-adapter-nextjs-example, @aptos-labs/wallet-adapter-react, @aptos-labs/wallet-adapter-tsconfig, @aptos-labs/wallet-adapter-vue, nuxt-app
• Running lint in 9 packages
• Remote caching disabled
@aptos-labs/wallet-adapter-mui-design:lint: cache miss, executing 761ce98588c784ed
@aptos-labs/wallet-adapter-mui-design:lint:
@aptos-labs/wallet-adapter-mui-design:lint:
@aptos-labs/wallet-adapter-mui-design:lint: > @aptos-labs/wallet-adapter-mui-design@3.0.13 lint /Users/george/src/hiai/aptos-wallet-adapter/packages/wallet-adapter-mui-design
@aptos-labs/wallet-adapter-mui-design:lint: > TIMING=1 eslint "src/**/*.ts*"
@aptos-labs/wallet-adapter-mui-design:lint:
@aptos-labs/wallet-adapter-mui-design:lint:
@aptos-labs/wallet-adapter-mui-design:lint: Oops! Something went wrong! :(
@aptos-labs/wallet-adapter-mui-design:lint:
@aptos-labs/wallet-adapter-mui-design:lint: ESLint: 8.57.0
@aptos-labs/wallet-adapter-mui-design:lint:
@aptos-labs/wallet-adapter-mui-design:lint: ESLint couldn't find the config "adapter" to extend from. Please check that the name of the config is correct.
@aptos-labs/wallet-adapter-mui-design:lint:
@aptos-labs/wallet-adapter-mui-design:lint: The config "adapter" was referenced from the config file in "/Users/george/src/hiai/aptos-wallet-adapter/.eslintrc.js".
@aptos-labs/wallet-adapter-mui-design:lint:
@aptos-labs/wallet-adapter-mui-design:lint: If you still have problems, please stop by https://eslint.org/chat/help to chat with the team.
@aptos-labs/wallet-adapter-mui-design:lint:
@aptos-labs/wallet-adapter-mui-design:lint: Rule | Time (ms) | Relative
@aptos-labs/wallet-adapter-mui-design:lint: :----|----------:|--------:
@aptos-labs/wallet-adapter-mui-design:lint:  ELIFECYCLE  Command failed with exit code 2.
@aptos-labs/wallet-adapter-mui-design:lint: ERROR: command finished with error: command (/Users/george/src/hiai/aptos-wallet-adapter/packages/wallet-adapter-mui-design) /Users/george/.nvm/versions/node/v20.17.0/bin/pnpm run lint exited (2)
@aptos-labs/wallet-adapter-mui-design#lint: command (/Users/george/src/hiai/aptos-wallet-adapter/packages/wallet-adapter-mui-design) /Users/george/.nvm/versions/node/v20.17.0/bin/pnpm run lint exited (2)

 Tasks:    0 successful, 5 total
Cached:    0 cached, 5 total
  Time:    440ms
Failed:    @aptos-labs/wallet-adapter-mui-design#lint

 ERROR  run failed: command  exited (2)
</pre>
</details>

## Solutions

1. Update `.eslintrc.js` with proper config name
2. Fix lint errors