### PR TITLE
Handle arguments conversion when submitting a package publish transac…

### DIFF
--- a/.changeset/new-readers-develop.md
+++ b/.changeset/new-readers-develop.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/wallet-adapter-core": minor
+---
+
+Handle arguments conversion when submitting a package publish transaction

--- a/packages/wallet-adapter-core/src/WalletCore.ts
+++ b/packages/wallet-adapter-core/src/WalletCore.ts
@@ -15,6 +15,7 @@ import {
   generateRawTransaction,
   SimpleTransaction,
   NetworkToChainId,
+  Hex,
 } from "@aptos-labs/ts-sdk";
 import EventEmitter from "eventemitter3";
 import {
@@ -67,6 +68,7 @@ import {
   fetchDevnetChainId,
   generalizedErrorMessage,
   getAptosConfig,
+  handlePublishPackageTransaction,
   isAptosNetwork,
   isRedirectable,
   removeLocalStorage,
@@ -838,6 +840,15 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
         ) {
           throw new WalletSignAndSubmitMessageError("SCAM SITE DETECTED")
             .message;
+        }
+
+        if (
+          transactionInput.data.function === "0x1::code::publish_package_txn"
+        ) {
+          ({
+            metadataBytes: transactionInput.data.functionArguments[0],
+            byteCode: transactionInput.data.functionArguments[1],
+          } = handlePublishPackageTransaction(transactionInput));
         }
       }
 


### PR DESCRIPTION
…tion

The Aptos SDK expects the `metadataBytes` and `byteCode` to be `Uint8Array`, but in case the arguments are passed in
as a string, this function converts the string to Uint8Array. 

Now we can use the wallet adapter to submit a package publish transaction like

```
const response = await signAndSubmitTransaction({
      data: {
        function: "0x1::code::publish_package_txn",
        functionArguments: [
         "0x123",
          ["0x456"],
        ],
      },
    });
```

and
```
const response = await signAndSubmitTransaction({
      data: {
        function: "0x1::code::publish_package_txn",
        functionArguments: [
          Hex.fromHexInput( "0x123").toUint8Array(),
          [Hex.fromHexInput("0x456").toUint8Array()],
        ],
      },
    });
```

https://aptos-org.slack.com/archives/C05161WELKZ/p1726562237760779