### PR TITLE
Improve compositionability a bit in react lib's createHeadlessComponent helper

### DIFF
--- a/packages/wallet-adapter-react/src/components/utils.tsx
+++ b/packages/wallet-adapter-react/src/components/utils.tsx
@@ -1,5 +1,5 @@
 import { Slot } from "@radix-ui/react-slot";
-import { ReactNode, forwardRef } from "react";
+import { ReactNode, cloneElement, forwardRef, isValidElement } from "react";
 
 export interface HeadlessComponentProps {
   /** A class name for styling the element. */
@@ -38,7 +38,14 @@ export function createHeadlessComponent<
     const Component = asChild ? Slot : elementType;
 
     const { children: defaultChildren, ...resolvedProps } =
-      typeof props === "function" ? props(displayName) : (props ?? {});
+      typeof props === "function" ? props(displayName) : props ?? {};
+    const resolvedChildren =
+      /**
+       * Use props' default children if no children are set in the component element's children and when asChild is true.
+       */
+      asChild && isValidElement(children) && !children.props.children
+        ? cloneElement(children, {}, defaultChildren)
+        : (children ?? defaultChildren);
 
     return (
       /**
@@ -53,7 +60,7 @@ export function createHeadlessComponent<
        */
       // @ts-expect-error
       <Component ref={ref} className={className} {...resolvedProps}>
-        {children ?? defaultChildren}
+        {resolvedChildren}
       </Component>
     );
   });


### PR DESCRIPTION
This PR improves `createHeadlessComponent` util behavior: if `asChild` is set and `children` is valid react element with empty `children` props (to not override custom children there) then will be used `children` from props.


# Before change
Right now if you use `asChild` for passing props to children you won't get a default children value from the defaults.

For example this won't work and will give empty `<p class="text-primary"></p>`
```
<AptosPrivacyPolicy.Disclaimer asChild>
  <p className="text-primary" />
</AptosPrivacyPolicy.Disclaimer>
```

# After the change

```
<AptosPrivacyPolicy.Disclaimer asChild>
  <p className="text-primary" />
</AptosPrivacyPolicy.Disclaimer>
```
will give you `<p class="text-primary">By continuing, you agree to Aptos Labs'</p>`

and if you specify children in internal element, then

```
<AptosPrivacyPolicy.Disclaimer asChild>
  <p className="text-primary">By continuing, you agree with the policy</p>
</AptosPrivacyPolicy.Disclaimer>
```
will give you `<p className="text-primary">By continuing, you agree with the policy</p>`