### PR TITLE
Refactor the account info output type to be compatible with `AIP-62` standard

### DIFF
--- a/.changeset/nervous-mayflies-reply.md
+++ b/.changeset/nervous-mayflies-reply.md
@@ -1,0 +1,7 @@
+---
+"@aptos-labs/wallet-adapter-react": major
+"@aptos-labs/wallet-adapter-core": major
+"@aptos-labs/wallet-adapter-nextjs-example": major
+---
+
+Refactor the account info output type to be compatible with AIP-62

--- a/apps/nextjs-example/src/app/page.tsx
+++ b/apps/nextjs-example/src/app/page.tsx
@@ -25,6 +25,7 @@ import { WalletSelector as AntdWalletSelector } from "@aptos-labs/wallet-adapter
 import { WalletConnector as MuiWalletSelector } from "@aptos-labs/wallet-adapter-mui-design";
 import {
   AccountInfo,
+  AccountInfoOutput,
   AptosChangeNetworkOutput,
   NetworkInfo,
   WalletInfo,
@@ -48,7 +49,9 @@ import { registerWallet } from "@aptos-labs/wallet-standard";
   registerWallet(myWallet);
 })();
 
-const isTelegramMiniApp = typeof window !== 'undefined' && (window as any).TelegramWebviewProxy !== undefined;
+const isTelegramMiniApp =
+  typeof window !== "undefined" &&
+  (window as any).TelegramWebviewProxy !== undefined;
 if (isTelegramMiniApp) {
   initTelegram();
 }
@@ -147,7 +150,7 @@ function WalletSelection() {
 }
 
 interface WalletConnectionProps {
-  account: AccountInfo | null;
+  account: AccountInfoOutput | null;
   network: NetworkInfo | null;
   wallet: WalletInfo | null;
   changeNetwork: (network: Network) => Promise<AptosChangeNetworkOutput>;
@@ -225,7 +228,7 @@ function WalletConnection({
                 label: "Address",
                 value: (
                   <DisplayValue
-                    value={account?.address ?? "Not Present"}
+                    value={account?.address.toString() ?? "Not Present"}
                     isCorrect={!!account?.address}
                   />
                 ),

--- a/apps/nextjs-example/src/components/WalletSelector.tsx
+++ b/apps/nextjs-example/src/components/WalletSelector.tsx
@@ -54,7 +54,7 @@ export function WalletSelector(walletSortingOptions: WalletSortingOptions) {
   const copyAddress = useCallback(async () => {
     if (!account?.address) return;
     try {
-      await navigator.clipboard.writeText(account.address);
+      await navigator.clipboard.writeText(account.address.toString());
       toast({
         title: "Success",
         description: "Copied wallet address to clipboard.",

--- a/apps/nextjs-example/src/components/transactionFlows/SingleSigner.tsx
+++ b/apps/nextjs-example/src/components/transactionFlows/SingleSigner.tsx
@@ -77,7 +77,7 @@ export function SingleSigner() {
         data: {
           function: "0x1::coin::transfer",
           typeArguments: [parseTypeTag(APTOS_COIN)],
-          functionArguments: [AccountAddress.from(account.address), new U64(1)], // 1 is in Octas
+          functionArguments: [account.address, new U64(1)], // 1 is in Octas
         },
       });
       await aptosClient(network).waitForTransaction({
@@ -99,7 +99,7 @@ export function SingleSigner() {
         type: "entry_function_payload",
         function: "0x1::coin::transfer",
         type_arguments: ["0x1::aptos_coin::AptosCoin"],
-        arguments: [account?.address, 1], // 1 is in Octas
+        arguments: [account?.address.toString(), 1], // 1 is in Octas
       };
       const response = await signTransaction(payload);
       toast({
@@ -116,13 +116,13 @@ export function SingleSigner() {
 
     try {
       const transactionToSign = await aptosClient(
-        network,
+        network
       ).transaction.build.simple({
         sender: account.address,
         data: {
           function: "0x1::coin::transfer",
           typeArguments: [APTOS_COIN],
-          functionArguments: [account.address, 1], // 1 is in Octas
+          functionArguments: [account.address.toString(), 1], // 1 is in Octas
         },
       });
       const response = await signTransaction(transactionToSign);

--- a/packages/wallet-adapter-core/src/AIP62StandardWallets/WalletStandard.ts
+++ b/packages/wallet-adapter-core/src/AIP62StandardWallets/WalletStandard.ts
@@ -130,11 +130,11 @@ export class WalletStandardCore {
     transaction: AnyRawTransaction,
     wallet: Wallet,
     asFeePayer?: boolean
-  ): Promise<AptosSignTransactionOutput>
+  ): Promise<AptosSignTransactionOutput>;
   async signTransaction(
     input: AptosSignTransactionInputV1_1,
-    wallet: Wallet,
-  ): Promise<AptosSignTransactionOutputV1_1>
+    wallet: Wallet
+  ): Promise<AptosSignTransactionOutputV1_1>;
   async signTransaction(
     transactionOrInput: AnyRawTransaction | AptosSignTransactionInputV1_1,
     wallet: Wallet,

--- a/packages/wallet-adapter-core/src/AIP62StandardWallets/types.ts
+++ b/packages/wallet-adapter-core/src/AIP62StandardWallets/types.ts
@@ -1,3 +1,4 @@
+import { AccountAddress, PublicKey } from "@aptos-labs/ts-sdk";
 import { WalletName } from "../LegacyWalletPlugins/types";
 import { WalletReadyState } from "../constants";
 
@@ -15,6 +16,21 @@ export interface AptosStandardSupportedWallet<Name extends string = string> {
   // See https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-62.md for more details.
   isAIP62Standard: true;
 }
+
+export type StandardAccountInfoInput = {
+  address: AccountAddress;
+  publicKey: PublicKey;
+  ansName?: string;
+};
+
+// Output type for the account to support AIP-62 standard wallets
+export type AccountInfoOutput = {
+  address: AccountAddress;
+  // PublicKey[] for backward compatibility,
+  publicKey: PublicKey | PublicKey[];
+  minKeysRequired?: number;
+  ansName?: string | null;
+};
 
 // Update this with the name of your wallet when you create a new wallet plugin.
 export type AvailableWallets =

--- a/packages/wallet-adapter-core/src/LegacyWalletPlugins/types.ts
+++ b/packages/wallet-adapter-core/src/LegacyWalletPlugins/types.ts
@@ -8,7 +8,8 @@ import {
   InputGenerateTransactionPayloadData,
   AnyRawTransaction,
   Signature,
-  AccountAuthenticator,
+  AccountAddress,
+  PublicKey,
 } from "@aptos-labs/ts-sdk";
 import { WalletReadyState } from "../constants";
 import {
@@ -20,7 +21,10 @@ import {
   AptosChangeNetworkMethod,
   AptosSignAndSubmitTransactionInput,
 } from "@aptos-labs/wallet-standard";
-import { AptosStandardSupportedWallet } from "../AIP62StandardWallets/types";
+import {
+  AptosStandardSupportedWallet,
+  StandardAccountInfoInput,
+} from "../AIP62StandardWallets/types";
 
 export { TxnBuilderTypes, Types } from "aptos";
 export type {
@@ -55,6 +59,7 @@ export type WalletInfo = {
   url: string;
 };
 
+// Input type to handle legacy wallets that are not AIP-62 compatible
 export type AccountInfo = {
   address: string;
   publicKey: string | string[];
@@ -74,7 +79,7 @@ export declare interface WalletCoreEvents {
   readyStateChange(wallet: Wallet): void;
   standardWalletsAdded(wallets: Wallet | AptosStandardSupportedWallet): void;
   networkChange(network: NetworkInfo | null): void;
-  accountChange(account: AccountInfo | null): void;
+  accountChange(account: AccountInfo | StandardAccountInfoInput | null): void;
 }
 
 export interface SignMessagePayload {

--- a/packages/wallet-adapter-core/src/utils/walletSelector.ts
+++ b/packages/wallet-adapter-core/src/utils/walletSelector.ts
@@ -1,3 +1,4 @@
+import { AccountAddress } from "@aptos-labs/ts-sdk";
 import { AptosStandardWallet } from "../AIP62StandardWallets";
 import { WalletInfo } from "../LegacyWalletPlugins";
 import { AnyAptosWallet } from "../WalletCore";
@@ -44,9 +45,9 @@ export function isInstallRequired(wallet: AnyAptosWallet) {
 }
 
 /** Truncates the provided wallet address at the middle with an ellipsis. */
-export function truncateAddress(address: string | undefined) {
+export function truncateAddress(address: AccountAddress | undefined) {
   if (!address) return;
-  return `${address.slice(0, 6)}...${address.slice(-5)}`;
+  return `${address.toString().slice(0, 6)}...${address.toString().slice(-5)}`;
 }
 
 /** Returns `true` if the provided wallet is an Aptos Connect wallet. */

--- a/packages/wallet-adapter-react/src/WalletProvider.tsx
+++ b/packages/wallet-adapter-react/src/WalletProvider.tsx
@@ -18,6 +18,7 @@ import type {
   Network,
   AptosStandardSupportedWallet,
   AvailableWallets,
+  AccountInfoOutput,
 } from "@aptos-labs/wallet-adapter-core";
 import { DappConfig, WalletCore } from "@aptos-labs/wallet-adapter-core";
 
@@ -32,7 +33,7 @@ export interface AptosWalletProviderProps {
 }
 
 const initialState: {
-  account: AccountInfo | null;
+  account: AccountInfoOutput | null;
   network: NetworkInfo | null;
   connected: boolean;
   wallet: WalletInfo | null;

--- a/packages/wallet-adapter-react/src/useWallet.tsx
+++ b/packages/wallet-adapter-react/src/useWallet.tsx
@@ -16,13 +16,14 @@ import {
   AptosChangeNetworkOutput,
   Network,
   AptosStandardSupportedWallet,
+  AccountInfoOutput,
 } from "@aptos-labs/wallet-adapter-core";
 import { createContext, useContext } from "react";
 
 export interface WalletContextState {
   connected: boolean;
   isLoading: boolean;
-  account: AccountInfo | null;
+  account: AccountInfoOutput | null;
   network: NetworkInfo | null;
   connect(walletName: WalletName): void;
   disconnect(): void;


### PR DESCRIPTION
To support the different Public Key types and for developers to easily be able to pass the account info down to SDK functions, changing the Account Info return type to be compatible with AIP-62

An updated version with this change here: https://aptos-labs.github.io/aptos-wallet-adapter/nextjs-example-testing/

Will be released with a major version update

OLD
```
export type AccountInfo = {
  address: string;
  publicKey: string | string[];
  minKeysRequired?: number;
  ansName?: string | null;
};
```

NEW
```
export type AccountInfoOutput = {
  address: AccountAddress;
  publicKey: PublicKey | PublicKey[]; // PublicKey[] for backward compatibility
  minKeysRequired?: number;
  ansName?: string | null;
};
```

This way, one can do
```
  const signWithSDK = async () => {
    if (!account) return;

    // make sure it is not an array of public keys
    if (Array.isArray(account.publicKey)) return;

    const transaction = await aptosClient(network).transaction.build.simple({
      sender: account.address,
      data: {
        function: "0x1::coin::transfer",
        typeArguments: [APTOS_COIN],
        functionArguments: [account.address.toString(), 1], // 1 is in Octas
      },
    });
    const response = await aptosClient(network).transaction.simulate.simple({
      signerPublicKey: account.publicKey,
      transaction,
    });
  };
```