### PR TITLE
Support network based api keys

### DIFF
--- a/.changeset/five-lies-float.md
+++ b/.changeset/five-lies-float.md
@@ -1,0 +1,6 @@
+---
+"@aptos-labs/wallet-adapter-core": minor
+"@aptos-labs/wallet-adapter-nextjs-example": minor
+---
+
+Support network based API key

--- a/apps/nextjs-example/src/components/WalletProvider.tsx
+++ b/apps/nextjs-example/src/components/WalletProvider.tsx
@@ -10,7 +10,7 @@ import { TrustWallet } from "@trustwallet/aptos-wallet-adapter";
 import { FewchaWallet } from "fewcha-plugin-wallet-adapter";
 import { PropsWithChildren } from "react";
 import { Network } from "@aptos-labs/ts-sdk";
-import { useClaimSecretKey } from '@/hooks/useClaimSecretKey';
+import { useClaimSecretKey } from "@/hooks/useClaimSecretKey";
 import { useAutoConnect } from "./AutoConnectProvider";
 import { useToast } from "./ui/use-toast";
 
@@ -37,7 +37,10 @@ export const WalletProvider = ({ children }: PropsWithChildren) => {
       autoConnect={autoConnect}
       dappConfig={{
         network: Network.TESTNET,
-        aptosApiKey: process.env.NEXT_PUBLIC_APTOS_API_KEY,
+        aptosApiKeys: {
+          testnet: process.env.NEXT_PUBLIC_APTOS_API_KEY_TESNET,
+          devnet: process.env.NEXT_PUBLIC_APTOS_API_KEY_DEVNET,
+        },
         aptosConnect: {
           claimSecretKey,
           dappId: "57fa42a9-29c6-4f1e-939c-4eefa36d9ff5",

--- a/packages/wallet-adapter-core/src/WalletCore.ts
+++ b/packages/wallet-adapter-core/src/WalletCore.ts
@@ -92,12 +92,14 @@ export type IAptosWallet = AptosStandardWallet & Wallet;
  * Interface for dapp configuration
  *
  * @network The network the dapp is working with
- * @aptosApiKey An Api Key generated with {@link https://developers.aptoslabs.com/docs/api-access}
+ * @aptosApiKeys A map of Network<>Api Key generated with {@link https://developers.aptoslabs.com/docs/api-access}
  * @aptosConnect Config used to initialize the AptosConnect wallet provider
  * @mizuwallet Config used to initialize the Mizu wallet provider
  */
 export interface DappConfig {
   network: Network;
+  aptosApiKeys?: Partial<Record<Network, string>>;
+  /** @deprecated */
   aptosApiKey?: string;
   /** @deprecated */
   aptosConnectDappId?: string;

--- a/packages/wallet-adapter-core/src/utils/helpers.ts
+++ b/packages/wallet-adapter-core/src/utils/helpers.ts
@@ -80,16 +80,24 @@ export const getAptosConfig = (
   if (!networkInfo) {
     throw new Error("Undefined network");
   }
+  const currentNetwork = convertNetwork(networkInfo);
+
+  if (isAptosLiveNetwork(currentNetwork)) {
+    const apiKey = dappConfig?.aptosApiKeys;
+    return new AptosConfig({
+      network: currentNetwork,
+      clientConfig: { API_KEY: apiKey ? apiKey[currentNetwork] : undefined },
+    });
+  }
+
   if (isAptosNetwork(networkInfo)) {
     return new AptosConfig({
-      network: convertNetwork(networkInfo),
-      clientConfig: { API_KEY: dappConfig?.aptosApiKey },
+      network: currentNetwork,
     });
   }
   return new AptosConfig({
     network: Network.CUSTOM,
     fullnode: networkInfo.url,
-    clientConfig: { API_KEY: dappConfig?.aptosApiKey },
   });
 };
 
@@ -106,6 +114,14 @@ export const isAptosNetwork = (
     throw new Error("Undefined network");
   }
   return NetworkToNodeAPI[networkInfo.name] !== undefined;
+};
+
+export const isAptosLiveNetwork = (networkInfo: Network): boolean => {
+  return (
+    networkInfo === "devnet" ||
+    networkInfo === "testnet" ||
+    networkInfo === "mainnet"
+  );
 };
 
 /**

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,10 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "globalEnv": ["GAID", "NEXT_PUBLIC_APTOS_API_KEY"],
+  "globalEnv": [
+    "GAID",
+    "NEXT_PUBLIC_APTOS_API_KEY_TESNET",
+    "NEXT_PUBLIC_APTOS_API_KEY_DEVNET"
+  ],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
We recently added API Key support to the adapter, but an API key is a network based, so supporting only 1 api key doesnt make sense when the user connects their wallet to different networks.

This PR adds support for a network based API Key so the adapter uses the correct API Key based on the network the wallet is connected to
