### PR TITLE
Fix unexpected exceptions when submitting txn with a CUSTOM network

### DIFF
--- a/.changeset/tidy-shoes-exist.md
+++ b/.changeset/tidy-shoes-exist.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/wallet-adapter-core": patch
+---
+
+Fix unexpected exceptions when submitting transaction with a CUSTOM network

--- a/packages/wallet-adapter-core/src/utils/helpers.ts
+++ b/packages/wallet-adapter-core/src/utils/helpers.ts
@@ -80,25 +80,27 @@ export const getAptosConfig = (
   if (!networkInfo) {
     throw new Error("Undefined network");
   }
-  const currentNetwork = convertNetwork(networkInfo);
-
-  if (isAptosLiveNetwork(currentNetwork)) {
-    const apiKey = dappConfig?.aptosApiKeys;
-    return new AptosConfig({
-      network: currentNetwork,
-      clientConfig: { API_KEY: apiKey ? apiKey[currentNetwork] : undefined },
-    });
-  }
 
   if (isAptosNetwork(networkInfo)) {
+    const currentNetwork = convertNetwork(networkInfo);
+
+    if (isAptosLiveNetwork(currentNetwork)) {
+      const apiKey = dappConfig?.aptosApiKeys;
+      return new AptosConfig({
+        network: currentNetwork,
+        clientConfig: { API_KEY: apiKey ? apiKey[currentNetwork] : undefined },
+      });
+    }
+
     return new AptosConfig({
       network: currentNetwork,
     });
+  } else {
+    return new AptosConfig({
+      network: Network.CUSTOM,
+      fullnode: networkInfo.url,
+    });
   }
-  return new AptosConfig({
-    network: Network.CUSTOM,
-    fullnode: networkInfo.url,
-  });
 };
 
 /**

--- a/packages/wallet-adapter-core/src/utils/helpers.ts
+++ b/packages/wallet-adapter-core/src/utils/helpers.ts
@@ -95,12 +95,12 @@ export const getAptosConfig = (
     return new AptosConfig({
       network: currentNetwork,
     });
-  } else {
-    return new AptosConfig({
-      network: Network.CUSTOM,
-      fullnode: networkInfo.url,
-    });
   }
+
+  return new AptosConfig({
+    network: Network.CUSTOM,
+    fullnode: networkInfo.url,
+  });
 };
 
 /**


### PR DESCRIPTION
The `convertNetwork` cannot be called with CUSTOM network. So we change `getAptosConfig` to only called it when it's aptos netowrk.