### PR TITLE
Fix deeplink redirect on mobile view

### DIFF
--- a/.changeset/ninety-seas-thank.md
+++ b/.changeset/ninety-seas-thank.md
@@ -1,0 +1,6 @@
+---
+"@aptos-labs/wallet-adapter-core": minor
+"@aptos-labs/wallet-adapter-nextjs-example": minor
+---
+
+Fix deeplink redirect on mobile view

--- a/apps/nextjs-example/package.json
+++ b/apps/nextjs-example/package.json
@@ -21,7 +21,6 @@
     "@martianwallet/aptos-wallet-adapter": "^0.0.5",
     "@msafe/aptos-wallet-adapter": "^1.0.11",
     "@okwallet/aptos-wallet-adapter": "^0.0.3",
-    "@pontem/wallet-adapter-plugin": "^0.2.1",
     "@radix-ui/react-collapsible": "^1.0.3",
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-dropdown-menu": "^2.0.6",

--- a/apps/nextjs-example/src/components/WalletProvider.tsx
+++ b/apps/nextjs-example/src/components/WalletProvider.tsx
@@ -5,7 +5,6 @@ import { BitgetWallet } from "@bitget-wallet/aptos-wallet-adapter";
 import { MartianWallet } from "@martianwallet/aptos-wallet-adapter";
 import { MSafeWalletAdapter } from "@msafe/aptos-wallet-adapter";
 import { OKXWallet } from "@okwallet/aptos-wallet-adapter";
-import { PontemWallet } from "@pontem/wallet-adapter-plugin";
 import { TrustWallet } from "@trustwallet/aptos-wallet-adapter";
 import { FewchaWallet } from "fewcha-plugin-wallet-adapter";
 import { PropsWithChildren } from "react";
@@ -26,7 +25,6 @@ export const WalletProvider = ({ children }: PropsWithChildren) => {
     new FewchaWallet(),
     new MartianWallet(),
     new MSafeWalletAdapter(),
-    new PontemWallet(),
     new TrustWallet(),
     new OKXWallet(),
   ];

--- a/packages/wallet-adapter-core/src/AIP62StandardWallets/registry.ts
+++ b/packages/wallet-adapter-core/src/AIP62StandardWallets/registry.ts
@@ -8,11 +8,13 @@ import { AptosStandardSupportedWallet } from "./types";
  *
  * AIP-62 compatible wallets are required to add their wallet info here if they want to be detected by the adapter
  *
- * name - The name of your wallet cast to WalletName (Ex. "Petra" as WalletName<"Petra">)
- * url - TThe link to your chrome extension or main website where new users can create an account with your wallet.
- * icon - An icon for your wallet. Can be one of 4 data types. Be sure to follow the below format exactly (including the literal "," after base64).
+ * @param name - The name of your wallet cast to WalletName (Ex. "Petra" as WalletName<"Petra">)
+ * @param url - The link to your chrome extension or main website where new users can create an account with your wallet.
+ * @param icon - An icon for your wallet. Can be one of 4 data types. Be sure to follow the below format exactly (including the literal "," after base64).
  *        Format: `data:image/${"svg+xml" | "webp" | "png" | "gif"};base64,${string}`
  *        Note: ${...} data in the above format should be replaced. Other characters are literals (ex. ";")
+ * @param deeplinkProvider optional - An optional deeplink provider for the wallet. If the wallet is not installed, we can redirect the user to the wallet's deeplink provider
+ * @example "https://myWallet.app/explore?link="
  */
 export const aptosStandardSupportedWalletList: Array<AptosStandardSupportedWallet> =
   [
@@ -29,6 +31,7 @@ export const aptosStandardSupportedWalletList: Array<AptosStandardSupportedWalle
       icon: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAYAAADDPmHLAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAWbSURBVHgB7Z09c9NYFIaPlFSpUqQNK6rQhbSkWJghLZP9BesxfwAqytg1xe7+AY+3go5ACzObBkpwSqrVQkuRCiqkva8UZW1je22wpHPveZ8ZRU6wwwznueee+6FLJCuSdzrb7nZTNjaOJc9/ctdNiaJESPPkeeq+phLH5/L162k0HJ7JikTLvtEFPnFBf+D+0l/dt9tCNJK6xnjmZOg7GdJlPvC/AhQtPo5P3MsHQvwhiobLiLBQABf82y74z4Qt3ldSybKHToLTeW+I5/1B3u2euOD/JQy+zyRowEUs5zAzA1x+oCckJHrRYNCf/uE3AjD4QfONBBMC5PfvY2j3TEi4ZNmd8eHilQDFMK/s8xMhIXPhJLjuJLjAN/8VgRsbPWHwLbAtm5tXRWGRAS5b/99C7FBmgbTMAGXrJ5aIomJir8wA3S5afyLEEkUtEBezfQy+RYpFvdilgmMhNnGxRw2wL8QqScy1fMNE0T4yQCLEKkksxDQUwDj2BNjbK69pdndn/zxwNsUCCOyNGyJ374psbYkMBiLv30++59o1kW5X5NMnkdFI5OXL8nXghCsAAn10NL/Fz2NnpxQFFyR5/bq8BypDWAIg6AcHIoeH60nn4/K8e1deECIgwhAAQULQEXxIUAf43bju3ZvMDJ7jrwDT/XpToIvABeECqBf8EuB7+/W6CKBe0C/Auvv1uvC0XtArQBP9el14VC/oEqCtfr0uPKgX2hdAW79eF0rrhfYFQPCRKi1RyY4ZyZYF4GKQcSiAcSiAcSiAcSiAcSiAcSiAcSiAcSiAcSiAcSiAcSiAcSiAcShAm3z+LG1DAdqEAhjn40dpGwrQFtgIwgxgGAWtH1CAtsC2cQVQgLZQsk2cArSBoqeHKEAbKHpiiAI0DVq+kv4fUICmQetXMPyroABNgtb/5o1oggI0icJzBChAUyDwr16JNihAUzx+LBqhAE3w5InaU0MoQN08f64y9VdQgDrBkO/FC9EMBagLBB/P/yvHxlGxTYPh3tOn4gMUYN2g4FPc509DAdYFqvxZh1ArhwKsg6rSVzTHvywU4EeoqnyPTxKnAKuCVo4iD4s6ARwhTwGWoTrk8e3bIE4IH4cCVCDI1U6dL1/K73Eh4B727ctCASoQ6MBa9zJwJtA4FMA4FMA4FMA4FMA4FMA4FMA4FMA47Qtg4P/n1Uz7AgQ8zeoD7Qug5KQMq+joApgFWkNHEWhwEUYLFMA4OgRQdGCCNXQIUG28II2jZyKIWaAV9Aig7OgUK+gRAMH36ImaUNC1FoDt1swCjaJLAAQfT9mQxtC3GohugCOCxtC5HIyHLNkVNIJOATAv4Mnz9b6jd0MIhoWsB2pH944gPHmLkQGpDf1bwtAVUILa8GNPICRgd1AL/mwKRXfA0cHa8WtXMArDfp8bSdeIf9vCEfxHj8psQBF+GH/PB0A2wIzhrVsih4ciOztCVsfvAyKQAVAbYPr44EDk6Ehkd1fI8oRxQggKQ2QEXMgEe3ulELhvbQmZT3hHxFRn+1Tn/UAAZAWIUXUTHz4IKQn/jCBkB6Pn/ywDHw41DgUwDgRIhVgljSWKzoXYJM+dAFmWCrHKeewsOBViExd71AAjd10IsUYaDYdnsfty4Uz4U4g1zvClHAbm+e9CbJFlfdwKAVwWSJ0EfwixwrCIuYxPBOV5T1gLWCCtWj+4EqCoBbLsFyFhk2UPq9YPJqaCURW6W19IqPRdjCeG/dGsd+Xdbs/dToSERD8aDHrTP4zmvZsSBMXM4INo0afyTudY4vg39zIR4iNFXXfZtc9k4XJw0V9k2R1OFHkIhvVZdn1R8MHCDDDx+zqdxK0c9tz1szAjaKWc1XUTe+OV/iKWFmAcJ8NtJ8Kxe7kvkCGKEiHN45Zz3b/9yN3/uVzUGxXD+RX4F56985hsqA6SAAAAAElFTkSuQmCC",
       readyState: WalletReadyState.NotDetected,
       isAIP62Standard: true,
+      deeplinkProvider: "https://petra.app/explore?link=",
     },
     {
       name: "Pontem Wallet" as WalletName<"Pontem Wallet">,

--- a/packages/wallet-adapter-core/src/AIP62StandardWallets/types.ts
+++ b/packages/wallet-adapter-core/src/AIP62StandardWallets/types.ts
@@ -14,6 +14,9 @@ export interface AptosStandardSupportedWallet<Name extends string = string> {
   // A flag to indicate that this AptosStandardSupportedWallet implements the AIP-62 Wallet Standard.
   // See https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-62.md for more details.
   isAIP62Standard: true;
+  // An optional deeplink provider for the wallet. If the wallet is not installed, we can redirect the user to the wallet's deeplink provider
+  // @example "https://myWallet.app/explore?link="
+  deeplinkProvider?: string;
 }
 
 // Update this with the name of your wallet when you create a new wallet plugin.

--- a/packages/wallet-adapter-core/src/WalletCore.ts
+++ b/packages/wallet-adapter-core/src/WalletCore.ts
@@ -741,11 +741,24 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
       isRedirectable() &&
       selectedWallet.readyState !== WalletReadyState.Installed
     ) {
-      // use wallet deep link
-      if (selectedWallet.isAIP62Standard && selectedWallet.openInMobileApp) {
-        selectedWallet.openInMobileApp();
-        return;
+      // If wallet is AIP-62 compatible
+      if (selectedWallet.isAIP62Standard) {
+        // If wallet has a openInMobileApp method, use it
+        if (selectedWallet.openInMobileApp) {
+          selectedWallet.openInMobileApp();
+          return;
+        }
+        // If wallet has a deeplinkProvider property, i.e wallet is on the internal registry, use it
+        const uninstalledWallet =
+          selectedWallet as AptosStandardSupportedWallet;
+        if (uninstalledWallet.deeplinkProvider) {
+          const url = encodeURIComponent(window.location.href);
+          const location = uninstalledWallet.deeplinkProvider.concat(url);
+          window.location.href = location;
+          return;
+        }
       }
+      // Wallet is on the old standard, check if it has a deeplinkProvider method property
       if (selectedWallet.deeplinkProvider) {
         const url = encodeURIComponent(window.location.href);
         const location = selectedWallet.deeplinkProvider({ url });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,9 +57,6 @@ importers:
       '@okwallet/aptos-wallet-adapter':
         specifier: ^0.0.3
         version: 0.0.3
-      '@pontem/wallet-adapter-plugin':
-        specifier: ^0.2.1
-        version: 0.2.1
       '@radix-ui/react-collapsible':
         specifier: ^1.0.3
         version: 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.5)(react-dom@18.3.1)(react@18.3.1)
@@ -767,10 +764,10 @@ packages:
       - debug
     dev: false
 
-  /@aptos-labs/wallet-adapter-core@4.22.1(@aptos-labs/ts-sdk@1.27.1)(@mizuwallet-sdk/core@1.4.0)(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.2.1)(@wallet-standard/core@1.0.3)(aptos@1.21.0):
-    resolution: {integrity: sha512-OinSUf9rfubNTJROLCFrldMzX1cPsqbnEmEpFthOSgldhptNobOn06pQTiGOgMhRdre5xubhTyJXuA8OiUhc3A==}
+  /@aptos-labs/wallet-adapter-core@4.23.1(@aptos-labs/ts-sdk@1.27.1)(@mizuwallet-sdk/core@1.4.0)(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.2.1)(@wallet-standard/core@1.0.3)(aptos@1.21.0):
+    resolution: {integrity: sha512-GAT7bmKlpwPxXc/Lryl2hl2VKW6NHBsiEQ4fezCiOIsCfxT1tDSV3EgGURTFtPB+UOvZEBHo0dihS16T4S6yVw==}
     peerDependencies:
-      '@aptos-labs/ts-sdk': ^1.27.1
+      '@aptos-labs/ts-sdk': ^1.33.1
       aptos: ^1.21.0
     dependencies:
       '@aptos-connect/wallet-adapter-plugin': 2.3.2(@aptos-labs/ts-sdk@1.27.1)(@aptos-labs/wallet-standard@0.2.0)(@telegram-apps/bridge@1.2.1)(aptos@1.21.0)
@@ -790,10 +787,10 @@ packages:
       - debug
     dev: false
 
-  /@aptos-labs/wallet-adapter-core@4.22.1(@aptos-labs/ts-sdk@1.33.1)(@mizuwallet-sdk/core@1.4.0)(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.2.1)(@wallet-standard/core@1.0.3)(aptos@1.21.0):
-    resolution: {integrity: sha512-OinSUf9rfubNTJROLCFrldMzX1cPsqbnEmEpFthOSgldhptNobOn06pQTiGOgMhRdre5xubhTyJXuA8OiUhc3A==}
+  /@aptos-labs/wallet-adapter-core@4.23.1(@aptos-labs/ts-sdk@1.33.1)(@mizuwallet-sdk/core@1.4.0)(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.2.1)(@wallet-standard/core@1.0.3)(aptos@1.21.0):
+    resolution: {integrity: sha512-GAT7bmKlpwPxXc/Lryl2hl2VKW6NHBsiEQ4fezCiOIsCfxT1tDSV3EgGURTFtPB+UOvZEBHo0dihS16T4S6yVw==}
     peerDependencies:
-      '@aptos-labs/ts-sdk': ^1.27.1
+      '@aptos-labs/ts-sdk': ^1.33.1
       aptos: ^1.21.0
     dependencies:
       '@aptos-connect/wallet-adapter-plugin': 2.3.2(@aptos-labs/ts-sdk@1.33.1)(@aptos-labs/wallet-standard@0.2.0)(@telegram-apps/bridge@1.2.1)(aptos@1.21.0)
@@ -3404,7 +3401,7 @@ packages:
   /@msafe/aptos-wallet-adapter@1.1.3(@aptos-labs/ts-sdk@1.27.1)(@mizuwallet-sdk/core@1.4.0)(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.2.1)(@wallet-standard/core@1.0.3):
     resolution: {integrity: sha512-/5ftbNac9j2Vc6YOqET4IdkhiJnMzuy9LcnGP8ptLWHVuye5P/pAjIpv0A07gOM4/siUJQzlXkBxXdLYF9p8wQ==}
     dependencies:
-      '@aptos-labs/wallet-adapter-core': 4.22.1(@aptos-labs/ts-sdk@1.27.1)(@mizuwallet-sdk/core@1.4.0)(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.2.1)(@wallet-standard/core@1.0.3)(aptos@1.21.0)
+      '@aptos-labs/wallet-adapter-core': 4.23.1(@aptos-labs/ts-sdk@1.27.1)(@mizuwallet-sdk/core@1.4.0)(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.2.1)(@wallet-standard/core@1.0.3)(aptos@1.21.0)
       '@msafe/aptos-wallet': 6.1.1
       aptos: 1.21.0
     transitivePeerDependencies:
@@ -3419,7 +3416,7 @@ packages:
   /@msafe/aptos-wallet-adapter@1.1.3(@aptos-labs/ts-sdk@1.33.1)(@mizuwallet-sdk/core@1.4.0)(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.2.1)(@wallet-standard/core@1.0.3):
     resolution: {integrity: sha512-/5ftbNac9j2Vc6YOqET4IdkhiJnMzuy9LcnGP8ptLWHVuye5P/pAjIpv0A07gOM4/siUJQzlXkBxXdLYF9p8wQ==}
     dependencies:
-      '@aptos-labs/wallet-adapter-core': 4.22.1(@aptos-labs/ts-sdk@1.33.1)(@mizuwallet-sdk/core@1.4.0)(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.2.1)(@wallet-standard/core@1.0.3)(aptos@1.21.0)
+      '@aptos-labs/wallet-adapter-core': 4.23.1(@aptos-labs/ts-sdk@1.33.1)(@mizuwallet-sdk/core@1.4.0)(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.2.1)(@wallet-standard/core@1.0.3)(aptos@1.21.0)
       '@msafe/aptos-wallet': 6.1.1
       aptos: 1.21.0
     transitivePeerDependencies:


### PR DESCRIPTION
Following the AIP-62 standard, extension wallets are not visible in the mobile view due to the nature of the standard and Chrome extensions. As a result, users cannot use extension wallets on mobile. Previously, before AIP-62, the adapter supported a deepLink provider to redirect users to the native mobile app if it was installed on their device.

This PR adds a `deeplinkProvider` property to the adapter's wallet registry and handles redirection to the wallet's mobile app if the user is on a mobile device.

Each wallet should add its own `deeplinkProvider` property if supported.

Live example, tested with Petra on desktop and mobile views https://aptos-labs.github.io/aptos-wallet-adapter/nextjs-example-testing/