### PR TITLE
[react] Add support for async functions in autoConnect

### DIFF
--- a/.changeset/early-spiders-press.md
+++ b/.changeset/early-spiders-press.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/wallet-adapter-react": patch
+---
+
+Add support for async functions in `WalletProvider`'s `autoConnect` prop


### PR DESCRIPTION
### Description

Allow asynchronous functions to determine whether a `WalletProvider` should attempt to `autoConnect` this enable uses cases such as "Sign in with Aptos" which may not want to traditionally connect using the `connect` method.

### Tests

https://github.com/user-attachments/assets/9104086f-33ce-430e-b01b-307c5ca86a4d


