### PR TITLE
[wallet-adapter-react] Fix wallet provider autoConnect setting isLoading to false prematurely

### DIFF
--- a/.changeset/silly-shirts-whisper.md
+++ b/.changeset/silly-shirts-whisper.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/wallet-adapter-react": patch
+---
+
+Fix WalletProvider setting `isLoading` to `false` prematurely when `autoConnect` is enabled

--- a/packages/wallet-adapter-react/src/WalletProvider.tsx
+++ b/packages/wallet-adapter-react/src/WalletProvider.tsx
@@ -129,7 +129,7 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
             shouldConnect = autoConnect;
           }
 
-          if (shouldConnect) connect(walletName);
+          if (shouldConnect) await connect(walletName);
         } catch (error) {
           if (onError) onError(error);
           return Promise.reject(error);


### PR DESCRIPTION
### Description

Fix wallet provider setting `isLoading` to `false` prematurely whenever `autoConnect` is enabled by awaiting the connection response.

### Test Plan

- [x] Locally tested to make sure `isLoading` is `false` whenever the connect attempt is done.