### PR TITLE
Fix mobile redirect logic

### DIFF
--- a/.changeset/two-kiwis-serve.md
+++ b/.changeset/two-kiwis-serve.md
@@ -1,0 +1,6 @@
+---
+"@aptos-labs/wallet-adapter-core": patch
+"@aptos-labs/wallet-adapter-nextjs-example": patch
+---
+
+Fix mobile redirect logic

--- a/apps/nextjs-example/next-env.d.ts
+++ b/apps/nextjs-example/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.


### PR DESCRIPTION
On mobile, extension wallets are not installed and are in `NotDetected` state. The adapter adds these wallets to the `_standard_not_detected_wallets`, so when users try to connect, we first need to check if we are on mobile view and look for the selected wallet in the `_standard_not_detected_wallets` array and handle the `deeplinkProvider` case. Otherwise, we continue to handle the rest of the wallets that are in "Installed" state, i.e SDK wallets.