### PR TITLE
Derived wallets implementation for Solana and Ethereum

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ coverage
 .next/
 out/
 build
+dist/
 
 # misc
 .DS_Store

--- a/apps/nextjs-example/package.json
+++ b/apps/nextjs-example/package.json
@@ -16,6 +16,8 @@
     "@aptos-labs/wallet-adapter-core": "workspace:*",
     "@aptos-labs/wallet-adapter-mui-design": "workspace:*",
     "@aptos-labs/wallet-adapter-react": "workspace:*",
+    "@aptos-labs/derived-wallet-ethereum": "workspace:^",
+    "@aptos-labs/derived-wallet-solana": "workspace:^",
     "@aptos-labs/wallet-standard": "^0.3.0",
     "@radix-ui/react-collapsible": "^1.0.3",
     "@radix-ui/react-dialog": "^1.0.5",

--- a/apps/nextjs-example/src/app/page.tsx
+++ b/apps/nextjs-example/src/app/page.tsx
@@ -171,8 +171,7 @@ function WalletConnection({
     return true;
   };
 
-  // TODO: Do a proper check for network change support
-  const isNetworkChangeSupported = wallet?.name === "Nightly";
+  const isNetworkChangeSupported = wallet?.features['aptos:changeNetwork'] !== undefined;
 
   return (
     <Card>

--- a/apps/nextjs-example/src/components/WalletProvider.tsx
+++ b/apps/nextjs-example/src/components/WalletProvider.tsx
@@ -1,11 +1,27 @@
 "use client";
 
 import { AptosWalletAdapterProvider } from "@aptos-labs/wallet-adapter-react";
+import { setupAutomaticEthereumWalletDerivation } from '@aptos-labs/derived-wallet-ethereum';
+import { setupAutomaticSolanaWalletDerivation } from '@aptos-labs/derived-wallet-solana';
 import { PropsWithChildren } from "react";
 import { Network } from "@aptos-labs/ts-sdk";
 import { useClaimSecretKey } from "@/hooks/useClaimSecretKey";
 import { useAutoConnect } from "./AutoConnectProvider";
 import { useToast } from "./ui/use-toast";
+
+const searchParams = typeof window !== "undefined" ? new URL(window.location.href).searchParams : undefined
+const deriveWalletsFrom = searchParams?.get('deriveWalletsFrom')?.split(',');
+if (deriveWalletsFrom?.includes('ethereum')) {
+  setupAutomaticEthereumWalletDerivation({ defaultNetwork: Network.TESTNET });
+}
+if (deriveWalletsFrom?.includes('solana')) {
+  setupAutomaticSolanaWalletDerivation({ defaultNetwork: Network.TESTNET });
+}
+
+let dappImageURI: string | undefined;
+if (typeof window !== 'undefined') {
+  dappImageURI = `${window.location.origin}${window.location.pathname}favicon.ico`;
+}
 
 export const WalletProvider = ({ children }: PropsWithChildren) => {
   const { autoConnect } = useAutoConnect();
@@ -26,6 +42,7 @@ export const WalletProvider = ({ children }: PropsWithChildren) => {
         aptosConnect: {
           claimSecretKey,
           dappId: "57fa42a9-29c6-4f1e-939c-4eefa36d9ff5",
+          dappImageURI,
         },
         mizuwallet: {
           manifestURL:

--- a/apps/nextjs-example/src/components/transactionFlows/SingleSigner.tsx
+++ b/apps/nextjs-example/src/components/transactionFlows/SingleSigner.tsx
@@ -9,6 +9,14 @@ import { TransactionHash } from "../TransactionHash";
 
 const APTOS_COIN = "0x1::aptos_coin::AptosCoin";
 
+/**
+ * Generate a nonce with alphanumeric characters only.
+ * This is a requirement for Sign in With Solana nonces
+ */
+function generateNonce() {
+  return crypto.randomUUID().replaceAll('-', '');
+}
+
 export function SingleSigner() {
   const { toast } = useToast();
   const {
@@ -25,7 +33,7 @@ export function SingleSigner() {
   const onSignMessageAndVerify = async () => {
     const payload = {
       message: "Hello from Aptos Wallet Adapter",
-      nonce: Math.random().toString(16),
+      nonce: generateNonce(),
     };
     const response = await signMessageAndVerify(payload);
     toast({
@@ -37,7 +45,7 @@ export function SingleSigner() {
   const onSignMessage = async () => {
     const payload = {
       message: "Hello from Aptos Wallet Adapter",
-      nonce: Math.random().toString(16),
+      nonce: generateNonce(),
     };
     const response = await signMessage(payload);
     toast({

--- a/packages/derived-wallet-base/.eslintrc.js
+++ b/packages/derived-wallet-base/.eslintrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+  root: true,
+  extends: ["@aptos-labs/eslint-config-adapter"],
+};

--- a/packages/derived-wallet-base/package.json
+++ b/packages/derived-wallet-base/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@aptos-labs/derived-wallet-base",
+  "version": "0.0.1",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/types/index.d.ts",
+  "license": "Apache-2.0",
+  "exports": {
+    "types": "./dist/types/index.d.ts",
+    "require": "./dist/index.js",
+    "import": "./dist/index.mjs"
+  },
+  "author": "aptoslabs.com",
+  "scripts": {
+    "build": "pnpm build:bundle && pnpm build:declarations",
+    "build:bundle": "tsup --sourcemap",
+    "build:declarations": "tsc --emitDeclarationOnly --declaration --declarationMap",
+    "test": "jest",
+    "lint": "TIMING=1 eslint \"src/**/*.ts*\""
+  },
+  "tsup": {
+    "entryPoints": ["src/index.ts"],
+    "format": ["cjs", "esm"]
+  },
+  "dependencies": {
+    "@aptos-labs/wallet-standard": "^0.3.0"
+  },
+  "peerDependencies": {
+    "@aptos-labs/ts-sdk": "^1.35.0"
+  },
+  "devDependencies": {
+    "@aptos-labs/eslint-config-adapter": "workspace:*",
+    "@aptos-labs/wallet-adapter-tsconfig": "workspace:*",
+    "@types/jest": "^29.2.4",
+    "@types/node": "^20.10.4",
+    "eslint": "^8.15.0",
+    "jest": "^29.3.1",
+    "ts-jest": "^29.0.3",
+    "tsup": "^8.3.6",
+    "typescript": "^5.4.5"
+  },
+  "files": [
+    "dist",
+    "src",
+    "!src/**.test.ts",
+    "!src/**/__tests__"
+  ]
+}

--- a/packages/derived-wallet-base/src/StructuredMessage.ts
+++ b/packages/derived-wallet-base/src/StructuredMessage.ts
@@ -1,0 +1,93 @@
+import { AccountAddressInput } from '@aptos-labs/ts-sdk';
+
+export const structuredMessagePrefix = 'APTOS' as const;
+
+export interface StructuredMessageInput {
+  message: string;
+  nonce: string;
+  application?: boolean;
+  chainId?: number | boolean;
+  address?: AccountAddressInput | boolean;
+}
+
+export interface StructuredMessage {
+  message: string;
+  nonce: string;
+  application?: string;
+  chainId?: number;
+  address?: string;
+}
+
+export function encodeStructuredMessage(structuredMessage: StructuredMessage): Uint8Array {
+  const { address, application, chainId, message, nonce } = structuredMessage;
+
+  const optionalParts: string[] = [];
+  if (address !== undefined) {
+    optionalParts.push(`address: ${address}`);
+  }
+  if (application !== undefined) {
+    optionalParts.push(`application: ${application}`);
+  }
+  if (chainId !== undefined) {
+    optionalParts.push(`chainId: ${chainId}`);
+  }
+
+  const parts = [
+    structuredMessagePrefix,
+    ...optionalParts,
+    `message: ${message}`,
+    `nonce: ${nonce}`,
+  ];
+
+  const input = parts.join('\n');
+  return new TextEncoder().encode(input);
+}
+
+function parsePart(part: string, name: string) {
+  const partPrefix = `${name}: `;
+  return part.startsWith(partPrefix) ? part.slice(partPrefix.length) : undefined;
+}
+
+export function decodeStructuredMessage(encoded: Uint8Array): StructuredMessage {
+  const utf8Decoded = new TextDecoder().decode(encoded);
+  const [prefix, ...parts] = utf8Decoded.split('\n');
+  if (prefix !== structuredMessagePrefix) {
+    throw new Error('Invalid message prefix');
+  }
+
+  let i = 0;
+
+  const address = parsePart(parts[i], 'address');
+  if (address !== undefined) {
+    i += 1;
+  }
+
+  const application = parsePart(parts[i], 'application');
+  if (application !== undefined) {
+    i += 1;
+  }
+
+  const chainIdStr = parsePart(parts[i], 'chainId');
+  if (chainIdStr !== undefined) {
+    i += 1;
+  }
+
+  const nonce = parsePart(parts[parts.length - 1], 'nonce');
+  if (!nonce) {
+    throw new Error('Expected nonce');
+  }
+
+  const messageParts = parts.slice(i, parts.length - 1).join('\n');
+  const message = parsePart(messageParts, 'message');
+  if (!message) {
+    throw new Error('Expected message');
+  }
+
+  return {
+    address,
+    application,
+    chainId: chainIdStr ? Number(chainIdStr) : undefined,
+    message,
+    nonce,
+  };
+}

--- a/packages/derived-wallet-base/src/UserResponse.ts
+++ b/packages/derived-wallet-base/src/UserResponse.ts
@@ -1,0 +1,31 @@
+import {
+  UserApproval,
+  UserRejection,
+  UserResponse,
+  UserResponseStatus,
+} from '@aptos-labs/wallet-standard';
+
+export function makeUserApproval<T>(args: T): UserApproval<T> {
+  return {
+    status: UserResponseStatus.APPROVED,
+    args,
+  };
+}
+
+export function makeUserRejection(): UserRejection {
+  return { status: UserResponseStatus.REJECTED };
+}
+
+export type MaybeAsync<T> = T | Promise<T>;
+
+export function mapUserResponse<Src, Dst>(response: UserResponse<Src>, mapFn: (src: Src) => Dst): UserResponse<Dst>
+export function mapUserResponse<Src, Dst>(response: UserResponse<Src>, mapFn: (src: Src) => Promise<Dst>): Promise<UserResponse<Dst>>
+export function mapUserResponse<Src, Dst>(response: UserResponse<Src>, mapFn: (src: Src) => MaybeAsync<Dst>): MaybeAsync<UserResponse<Dst>> {
+  if (response.status === UserResponseStatus.REJECTED) {
+    return makeUserRejection();
+  }
+  const mappedResponse = mapFn(response.args);
+  return mappedResponse instanceof Promise
+    ? mappedResponse.then((args) => makeUserApproval(args))
+    : makeUserApproval(mappedResponse);
+}

--- a/packages/derived-wallet-base/src/abstraction.ts
+++ b/packages/derived-wallet-base/src/abstraction.ts
@@ -1,0 +1,43 @@
+import { AccountAddress, AuthenticationKey, hashValues, isValidFunctionInfo, Serializer } from '@aptos-labs/ts-sdk';
+
+/**
+ * The domain separator used to calculate the DAA account address.
+ */
+export const ADDRESS_DOMAIN_SEPARATOR = 5;
+
+/**
+ * Compute the account address of the DAA
+ * The DAA account address is computed by hashing the function info and the account identity
+ * and appending the domain separator (5)
+ *
+ * @param functionInfo - The authentication function
+ * @param accountIdentifier - The account identity
+ * @returns The account address
+ */
+export function computeDomainAuthenticationKey(functionInfo: string, accountIdentifier: Uint8Array) {
+  if (!isValidFunctionInfo(functionInfo)) {
+    throw new Error(`Invalid authentication function ${functionInfo}`);
+  }
+  const [moduleAddress, moduleName, functionName] = functionInfo.split("::");
+
+  // Serialize and append the function info
+  const serializer = new Serializer();
+  AccountAddress.fromString(moduleAddress).serialize(serializer);
+  serializer.serializeStr(moduleName);
+  serializer.serializeStr(functionName);
+
+  // Serialize and append the account identity
+  const s2 = new Serializer();
+  s2.serializeBytes(accountIdentifier);
+
+  // Append the domain separator
+  const domainSeparator = new Uint8Array([ADDRESS_DOMAIN_SEPARATOR]);
+
+  const data = hashValues([
+    serializer.toUint8Array(),
+    s2.toUint8Array(),
+    domainSeparator,
+  ]);
+
+  return new AuthenticationKey({ data });
+}

--- a/packages/derived-wallet-base/src/index.ts
+++ b/packages/derived-wallet-base/src/index.ts
@@ -1,0 +1,5 @@
+export * from './abstraction';
+export * from './parseAptosSigningMessage';
+export * from './StructuredMessage';
+export * from './UserResponse';
+export * from './utils';

--- a/packages/derived-wallet-base/src/parseAptosSigningMessage.ts
+++ b/packages/derived-wallet-base/src/parseAptosSigningMessage.ts
@@ -1,0 +1,82 @@
+import {
+  AnyRawTransaction,
+  Deserializer, FeePayerRawTransaction,
+  hashValues, Hex, HexInput, MultiAgentRawTransaction, MultiAgentTransaction,
+  RAW_TRANSACTION_SALT,
+  RAW_TRANSACTION_WITH_DATA_SALT,
+  RawTransaction,
+  RawTransactionWithData, SimpleTransaction,
+} from '@aptos-labs/ts-sdk';
+import { decodeStructuredMessage, StructuredMessage } from './StructuredMessage';
+
+function bufferStartsWith(buffer: Uint8Array, search: Uint8Array) {
+  return buffer.slice(0, search.length) === search;
+}
+
+const transactionSigningMessagePrefix = hashValues([RAW_TRANSACTION_SALT]);
+const transactionWithDataSigningMessagePrefix = hashValues([RAW_TRANSACTION_WITH_DATA_SALT]);
+
+export function parseRawTransaction(message: Uint8Array) {
+  if (bufferStartsWith(message, transactionSigningMessagePrefix)) {
+    const serialized = message.slice(transactionSigningMessagePrefix.length);
+    const deserializer = new Deserializer(serialized);
+    return RawTransaction.deserialize(deserializer);
+  } else if (bufferStartsWith(message, transactionWithDataSigningMessagePrefix)) {
+    const serialized = message.slice(transactionWithDataSigningMessagePrefix.length);
+    const deserializer = new Deserializer(serialized);
+    return RawTransactionWithData.deserialize(deserializer);
+  }
+  return undefined;
+}
+
+export interface ParseSigningMessageTransactionResult {
+  type: 'transaction',
+  rawTransaction: AnyRawTransaction;
+}
+
+export interface ParseSigningMessageStructuredMessageResult {
+  type: 'structuredMessage',
+  structuredMessage: StructuredMessage;
+}
+
+export type ParseSigningMessageResult =
+  | ParseSigningMessageTransactionResult
+  | ParseSigningMessageStructuredMessageResult;
+
+export function parseAptosSigningMessage(message: HexInput): ParseSigningMessageResult | undefined {
+  const messageBytes = Hex.fromHexInput(message).toUint8Array();
+
+  const parsedRawTransaction = parseRawTransaction(messageBytes);
+  if (parsedRawTransaction) {
+    let rawTransaction: AnyRawTransaction;
+    if (parsedRawTransaction instanceof RawTransaction) {
+      rawTransaction = new SimpleTransaction(parsedRawTransaction);
+    } else if (parsedRawTransaction instanceof MultiAgentRawTransaction) {
+      rawTransaction = new MultiAgentTransaction(
+        parsedRawTransaction.raw_txn,
+        parsedRawTransaction.secondary_signer_addresses,
+      );
+    } else if (parsedRawTransaction instanceof FeePayerRawTransaction) {
+      const { raw_txn, secondary_signer_addresses, fee_payer_address } = parsedRawTransaction;
+      rawTransaction = secondary_signer_addresses.length > 0
+        ? new MultiAgentTransaction(raw_txn, secondary_signer_addresses, fee_payer_address)
+        : new SimpleTransaction(raw_txn, fee_payer_address);
+    } else {
+      throw new Error('Unsupported raw transaction');
+    }
+    return {
+      type: 'transaction',
+      rawTransaction
+    };
+  }
+
+  try {
+    const structuredMessage = decodeStructuredMessage(messageBytes);
+    return {
+      type: 'structuredMessage',
+      structuredMessage,
+    };
+  } catch (err) {
+    return undefined;
+  }
+}

--- a/packages/derived-wallet-base/src/utils.ts
+++ b/packages/derived-wallet-base/src/utils.ts
@@ -1,0 +1,22 @@
+import { AccountPublicKey, Network, NetworkToChainId } from '@aptos-labs/ts-sdk';
+import { AccountInfo } from '@aptos-labs/wallet-standard';
+
+export function accountInfoFromPublicKey(publicKey: AccountPublicKey) {
+  return new AccountInfo({
+    publicKey,
+    address: publicKey.authKey().derivedAddress(),
+  })
+}
+
+export function aptosChainIdToNetwork(chainId: number) {
+  for (const [network, otherChainId] of Object.entries(NetworkToChainId)) {
+    if (otherChainId === chainId) {
+      return network as Network;
+    }
+  }
+  return undefined;
+}
+
+export function isNullCallback(callback: Function) {
+  return '_isNull' in callback && callback._isNull === true;
+}

--- a/packages/derived-wallet-base/tsconfig.json
+++ b/packages/derived-wallet-base/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@aptos-labs/wallet-adapter-tsconfig/base.json",
+  "include": ["."],
+  "exclude": ["dist", "build", "node_modules"],
+  "compilerOptions": {
+    "target": "es2020",
+    "lib": ["es2021", "dom"],
+    "rootDir": "src",
+    "outDir": "dist/types"
+  }
+}

--- a/packages/derived-wallet-ethereum/.eslintrc.js
+++ b/packages/derived-wallet-ethereum/.eslintrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+  root: true,
+  extends: ["@aptos-labs/eslint-config-adapter"],
+};

--- a/packages/derived-wallet-ethereum/package.json
+++ b/packages/derived-wallet-ethereum/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@aptos-labs/derived-wallet-ethereum",
+  "version": "0.0.1",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/types/index.d.ts",
+  "license": "Apache-2.0",
+  "exports": {
+    "types": "./dist/types/index.d.ts",
+    "require": "./dist/index.js",
+    "import": "./dist/index.mjs"
+  },
+  "author": "aptoslabs.com",
+  "scripts": {
+    "build": "pnpm build:bundle && pnpm build:declarations",
+    "build:bundle": "tsup --sourcemap",
+    "build:declarations": "tsc --emitDeclarationOnly --declaration --declarationMap",
+    "test": "jest",
+    "lint": "TIMING=1 eslint \"src/**/*.ts*\""
+  },
+  "tsup": {
+    "entryPoints": ["src/index.ts"],
+    "format": ["cjs", "esm"]
+  },
+  "dependencies": {
+    "@aptos-labs/derived-wallet-base": "workspace:^",
+    "@aptos-labs/siwa": "^0.2.5",
+    "@aptos-labs/wallet-standard": "^0.3.0",
+    "@wallet-standard/app": "^1.1.0",
+    "ethers": "^6.13.5",
+    "mipd": "^0.0.7",
+    "viem": "^2.23.12"
+  },
+  "peerDependencies": {
+    "@aptos-labs/ts-sdk": "^1.35.0"
+  },
+  "devDependencies": {
+    "@aptos-labs/eslint-config-adapter": "workspace:*",
+    "@aptos-labs/wallet-adapter-tsconfig": "workspace:*",
+    "@types/jest": "^29.2.4",
+    "@types/node": "^20.10.4",
+    "eslint": "^8.15.0",
+    "jest": "^29.3.1",
+    "ts-jest": "^29.0.3",
+    "tsup": "^8.3.6",
+    "typescript": "^5.4.5"
+  },
+  "files": [
+    "dist",
+    "src",
+    "!src/**.test.ts",
+    "!src/**/__tests__"
+  ]
+}

--- a/packages/derived-wallet-ethereum/src/EIP1193DerivedPublicKey.ts
+++ b/packages/derived-wallet-ethereum/src/EIP1193DerivedPublicKey.ts
@@ -1,0 +1,99 @@
+import { computeDomainAuthenticationKey, parseAptosSigningMessage } from '@aptos-labs/derived-wallet-base';
+import {
+  AccountPublicKey,
+  AuthenticationKey,
+  Deserializer,
+  hashValues,
+  Hex,
+  Serializer,
+  VerifySignatureArgs,
+} from '@aptos-labs/ts-sdk';
+import { verifyMessage } from 'ethers';
+import { Address as EthereumAddress } from 'viem';
+import {
+  createSiweMessageFromAptosStructuredMessage,
+  createSiweMessageFromAptosTransaction,
+} from './createSiweMessageFromAptos';
+import { EIP1193DerivedSignature } from './EIP1193DerivedSignature';
+
+export interface EIP1193DerivedPublicKeyParams {
+  domain: string;
+  ethereumAddress: EthereumAddress;
+  authenticationFunction: string;
+}
+
+export class EIP1193DerivedPublicKey extends AccountPublicKey {
+  readonly domain: string;
+  readonly ethereumAddress: EthereumAddress;
+  readonly authenticationFunction: string;
+
+  private readonly _authKey: AuthenticationKey;
+
+  constructor({ domain, ethereumAddress, authenticationFunction }: EIP1193DerivedPublicKeyParams) {
+    super();
+    this.domain = domain;
+    this.ethereumAddress = ethereumAddress;
+    this.authenticationFunction = authenticationFunction;
+
+    const utf8EncodedDomain = new TextEncoder().encode(domain);
+    const ethereumAddressBytes = Hex.fromHexInput(ethereumAddress).toUint8Array();
+
+    const serializer = new Serializer();
+    serializer.serializeBytes(utf8EncodedDomain);
+    serializer.serializeBytes(ethereumAddressBytes);
+    const accountIdentifier = hashValues([serializer.toUint8Array()]);
+
+    this._authKey = computeDomainAuthenticationKey(
+      authenticationFunction,
+      accountIdentifier,
+    );
+  }
+
+  authKey(): AuthenticationKey {
+    return this._authKey;
+  }
+
+  verifySignature({ message, signature }: VerifySignatureArgs): boolean {
+    const parsed = parseAptosSigningMessage(message);
+    if (!parsed || !(signature instanceof EIP1193DerivedSignature)) {
+      return false;
+    }
+
+    const siweMessage = parsed.type === 'structuredMessage'
+      ? createSiweMessageFromAptosStructuredMessage({
+        ethereumAddress: this.ethereumAddress,
+        structuredMessage: parsed.structuredMessage,
+        issuedAt: signature.issuedAt,
+      })
+      : createSiweMessageFromAptosTransaction({
+        ethereumAddress: this.ethereumAddress,
+        aptosAddress: this._authKey.derivedAddress(),
+        rawTransaction: parsed.rawTransaction,
+        issuedAt: signature.issuedAt,
+      });
+
+    // This function is the only reason we have `ethers` as dependency, as `viem`
+    // unfortunately only provides an asynchronous `verifyMessage` that can't be used here.
+    // We might consider dropping `viem` and only using `ethers` but not worth it at this time.
+    const recoveredAddress = verifyMessage(siweMessage, signature.siweSignature);
+    return recoveredAddress === this.ethereumAddress;
+  }
+
+  // region Serialization
+
+  serialize(serializer: Serializer) {
+    serializer.serializeStr(this.domain);
+    serializer.serializeFixedBytes(Hex.fromHexInput(this.ethereumAddress).toUint8Array());
+    serializer.serializeStr(this.authenticationFunction);
+  }
+
+  static deserialize(deserializer: Deserializer) {
+    const domain = deserializer.deserializeStr();
+    const ethereumAddressBytes = deserializer.deserializeFixedBytes(20);
+    const ethereumAddress = Hex.fromHexInput(ethereumAddressBytes).toString() as EthereumAddress;
+    const authenticationFunction = deserializer.deserializeStr();
+    return new EIP1193DerivedPublicKey({ domain, ethereumAddress, authenticationFunction });
+  }
+
+  // endregion
+}

--- a/packages/derived-wallet-ethereum/src/EIP1193DerivedSignature.ts
+++ b/packages/derived-wallet-ethereum/src/EIP1193DerivedSignature.ts
@@ -1,0 +1,33 @@
+import { Deserializer, Hex, HexInput, Serializer, Signature } from '@aptos-labs/ts-sdk';
+
+export class EIP1193DerivedSignature extends Signature {
+  static readonly LENGTH = 65;
+
+  private readonly _siweSignature: Uint8Array;
+  readonly issuedAt: Date;
+
+  constructor(siweSignature: HexInput, issuedAt: Date) {
+    super();
+    this._siweSignature = Hex.fromHexInput(siweSignature).toUint8Array();
+    if (this._siweSignature.length !== EIP1193DerivedSignature.LENGTH) {
+      throw new Error('Expected signature length to be 65 bytes');
+    }
+    this.issuedAt = issuedAt;
+  }
+
+  get siweSignature() {
+    return Hex.fromHexInput(this._siweSignature).toString();
+  }
+
+  serialize(serializer: Serializer) {
+    serializer.serializeFixedBytes(this._siweSignature);
+    serializer.serializeU64(this.issuedAt.getTime());
+  }
+
+  static deserialize(deserializer: Deserializer) {
+    const siweSignature = deserializer.deserializeFixedBytes(EIP1193DerivedSignature.LENGTH);
+    // Number can safely contain a unix timestamp
+    const issuedAt = new Date(Number(deserializer.deserializeU64()));
+    return new EIP1193DerivedSignature(siweSignature, issuedAt);
+  }
+}

--- a/packages/derived-wallet-ethereum/src/EIP1193DerivedWallet.ts
+++ b/packages/derived-wallet-ethereum/src/EIP1193DerivedWallet.ts
@@ -1,0 +1,337 @@
+import {
+  encodeStructuredMessage,
+  isNullCallback,
+  makeUserApproval,
+  makeUserRejection,
+  mapUserResponse,
+} from '@aptos-labs/derived-wallet-base';
+import {
+  AccountAuthenticator,
+  AccountAuthenticatorAbstraction,
+  AnyRawTransaction,
+  Network,
+  NetworkToChainId,
+  NetworkToNodeAPI,
+} from '@aptos-labs/ts-sdk';
+import {
+  AccountInfo,
+  APTOS_CHAINS,
+  AptosChangeNetworkOutput,
+  AptosConnectOutput,
+  AptosFeatures,
+  AptosSignMessageInput,
+  AptosSignMessageOutput,
+  AptosWallet,
+  NetworkInfo,
+  UserResponse,
+  UserResponseStatus,
+  WalletIcon,
+} from "@aptos-labs/wallet-standard";
+import type { EIP6963ProviderDetail } from 'mipd';
+import {
+  Address as EthereumAddress,
+  createWalletClient,
+  custom,
+  CustomTransport,
+  EIP1193Provider,
+  UserRejectedRequestError,
+  WalletClient,
+} from 'viem'
+import {
+  createSiweMessageFromAptosStructuredMessage,
+  createSiweMessageFromAptosTransaction,
+} from './createSiweMessageFromAptos';
+import { EIP1193DerivedPublicKey } from './EIP1193DerivedPublicKey';
+import { EIP1193DerivedSignature } from './EIP1193DerivedSignature';
+
+const defaultAuthenticationFunction = '0x7::eip1193::authenticate';
+
+/**
+ * Adapt EIP1193 response into a UserResponse.
+ * `UserRejectedRequestError` will be converted into a rejection.
+ */
+async function wrapEIP1193UserResponse<TResponse>(promise: Promise<TResponse>): Promise<UserResponse<TResponse>> {
+  try {
+    const response = await promise;
+    return makeUserApproval(response);
+  } catch (err) {
+    if (err instanceof UserRejectedRequestError) {
+      return makeUserRejection();
+    }
+    throw err;
+  }
+}
+
+export interface EIP1193DerivedWalletOptions {
+  authenticationFunction?: string;
+  defaultNetwork?: Network;
+}
+
+export class EIP1193DerivedWallet implements AptosWallet {
+  readonly eip1193Provider: EIP1193Provider;
+  readonly eip1193Wallet: WalletClient<CustomTransport>;
+  readonly domain: string;
+  readonly authenticationFunction: string;
+  defaultNetwork: Network;
+
+  readonly version = "1.0.0";
+  readonly name: string;
+  readonly icon: WalletIcon;
+  readonly url: string;
+  readonly accounts = [];
+  readonly chains = APTOS_CHAINS;
+
+  constructor(providerDetail: EIP6963ProviderDetail, options: EIP1193DerivedWalletOptions = {}) {
+    const { info, provider } = providerDetail;
+    const {
+      authenticationFunction = defaultAuthenticationFunction,
+      defaultNetwork = Network.MAINNET,
+    } = options;
+
+    this.eip1193Provider = provider;
+    this.eip1193Wallet = createWalletClient({
+      transport: custom(this.eip1193Provider),
+    })
+
+    this.domain = window.location.origin;
+    this.authenticationFunction = authenticationFunction;
+    this.defaultNetwork = defaultNetwork;
+    this.name = `${info.name} (Ethereum)`;
+    // Phantom's icon is wrapped with new lines :shrug:
+    this.icon = info.icon.trim() as WalletIcon;
+    this.url = info.rdns;
+  }
+
+  readonly features: AptosFeatures = {
+    'aptos:connect': {
+      version: '1.0.0',
+      connect: () => this.connect(),
+    },
+    'aptos:disconnect': {
+      version: '1.0.0',
+      disconnect: () => this.disconnect(),
+    },
+    'aptos:account': {
+      version: '1.0.0',
+      account: () => this.getActiveAccount(),
+    },
+    'aptos:onAccountChange': {
+      version: '1.0.0',
+      onAccountChange: async (callback) => this.onActiveAccountChange(callback),
+    },
+    'aptos:network': {
+      version: '1.0.0',
+      network: () => this.getActiveNetwork(),
+    },
+    'aptos:changeNetwork': {
+      version: '1.0.0',
+      changeNetwork: (newNetwork) => this.changeNetwork(newNetwork),
+    },
+    'aptos:onNetworkChange': {
+      version: '1.0.0',
+      onNetworkChange: async (callback) => this.onActiveNetworkChange(callback),
+    },
+    "aptos:signMessage": {
+      version: '1.0.0',
+      signMessage: (args) => this.signMessage(args),
+    },
+    "aptos:signTransaction": {
+      version: '1.0.0',
+      signTransaction: (...args) => this.signTransaction(...args),
+    },
+  }
+
+  private derivePublicKey(ethereumAddress: EthereumAddress) {
+    return new EIP1193DerivedPublicKey({
+      domain: this.domain,
+      ethereumAddress,
+      authenticationFunction: this.authenticationFunction,
+    });
+  }
+
+  // region Connection
+
+  async connect(): Promise<UserResponse<AptosConnectOutput>> {
+    const response = await wrapEIP1193UserResponse(this.eip1193Wallet.requestAddresses());
+
+    return mapUserResponse(response, ([ethereumAddress]) => {
+      const publicKey = this.derivePublicKey(ethereumAddress);
+      const aptosAddress = publicKey.authKey().derivedAddress();
+      return new AccountInfo({ publicKey, address: aptosAddress });
+    });
+  }
+
+  async disconnect() {
+    // TODO: Eip1193 doesn't provide a "disconnect" method, so we have to keep track locally
+  }
+
+  // endregion
+
+  // region Accounts
+
+  private async getActiveAccountAddress(): Promise<EthereumAddress> {
+    const [activeAddress] = await this.eip1193Wallet.getAddresses();
+    if (!activeAddress) {
+      throw new Error('Account not connected');
+    }
+    return activeAddress;
+  }
+
+  async getActiveAccount() {
+    const ethereumAddress = await this.getActiveAccountAddress();
+    const publicKey = this.derivePublicKey(ethereumAddress);
+    const aptosAddress = publicKey.authKey().derivedAddress();
+    return new AccountInfo({ publicKey, address: aptosAddress });
+  }
+
+  private onAccountsChangedListeners: ((newAccounts: EthereumAddress[]) => void)[] = []
+
+  onActiveAccountChange(callback: (newAccount: AccountInfo) => void) {
+    if (isNullCallback(callback)) {
+      for (const listener of this.onAccountsChangedListeners) {
+        this.eip1193Provider.removeListener('accountsChanged', listener);
+      }
+      this.onAccountsChangedListeners = [];
+    } else {
+      const listener = ([ethereumAddress]: EthereumAddress[]) => {
+        if (!ethereumAddress) {
+          callback(undefined as any as AccountInfo);
+          return;
+        }
+        const publicKey = this.derivePublicKey(ethereumAddress);
+        const aptosAddress = publicKey.authKey().derivedAddress();
+        const account = new AccountInfo({ publicKey, address: aptosAddress });
+        callback(account);
+      };
+      this.onAccountsChangedListeners.push(listener);
+      this.eip1193Provider.on('accountsChanged', listener);
+    }
+  }
+
+  // endregion
+
+  // region Networks
+
+  private onActiveNetworkChangeListeners: ((newNetwork: NetworkInfo) => void)[] = [];
+
+  async getActiveNetwork(): Promise<NetworkInfo> {
+    const chainId = NetworkToChainId[this.defaultNetwork];
+    const url = NetworkToNodeAPI[this.defaultNetwork];
+    return {
+      name: this.defaultNetwork,
+      chainId,
+      url,
+    };
+  }
+
+  async changeNetwork(newNetwork: NetworkInfo): Promise<UserResponse<AptosChangeNetworkOutput>> {
+    const { name, chainId, url } = newNetwork;
+    if (name === Network.CUSTOM) {
+      throw new Error('Custom network not currently supported');
+    }
+    this.defaultNetwork = name;
+    for (const listener of this.onActiveNetworkChangeListeners) {
+      listener({
+        name,
+        chainId: chainId ?? NetworkToChainId[name],
+        url: url ?? NetworkToNodeAPI[name],
+      });
+    }
+    return {
+      status: UserResponseStatus.APPROVED,
+      args: { success: true },
+    };
+  }
+
+  onActiveNetworkChange(callback: (newNetwork: NetworkInfo) => void) {
+    if (isNullCallback(callback)) {
+      this.onActiveNetworkChangeListeners = [];
+    } else {
+      this.onActiveNetworkChangeListeners.push(callback);
+    }
+  }
+
+  // endregion
+
+  // region Signatures
+
+  async signMessage({
+    message,
+    nonce,
+    ...flags
+  }: AptosSignMessageInput): Promise<UserResponse<AptosSignMessageOutput>> {
+    const ethereumAddress = await this.getActiveAccountAddress();
+    const publicKey = this.derivePublicKey(ethereumAddress);
+
+    const aptosAddress = flags.address ? publicKey.authKey().derivedAddress() : undefined;
+    const application = flags.application ? this.domain : undefined;
+    const chainId = flags.chainId ? NetworkToChainId[this.defaultNetwork] : undefined;
+    const structuredMessage = {
+      address: aptosAddress?.toString(),
+      application,
+      chainId,
+      message,
+      nonce,
+    };
+
+    // We need to provide `issuedAt` externally so that we can match it with the signature
+    const issuedAt = new Date();
+    const siweMessage = createSiweMessageFromAptosStructuredMessage({
+      ethereumAddress,
+      structuredMessage,
+      issuedAt,
+    });
+
+    const response = await wrapEIP1193UserResponse(this.eip1193Wallet.signMessage({
+      account: ethereumAddress,
+      message: siweMessage,
+    }));
+
+    return mapUserResponse(response, (siweSignature) => {
+      const signature = new EIP1193DerivedSignature(siweSignature, issuedAt);
+      const fullMessageBytes = encodeStructuredMessage(structuredMessage);
+      const fullMessage = new TextDecoder().decode(fullMessageBytes);
+      return {
+        prefix: 'APTOS',
+        fullMessage,
+        message,
+        nonce,
+        signature,
+      };
+    });
+  }
+
+  async signTransaction(rawTransaction: AnyRawTransaction, asFeePayer?: boolean): Promise<UserResponse<AccountAuthenticator>> {
+    const ethereumAddress = await this.getActiveAccountAddress();
+    const publicKey = this.derivePublicKey(ethereumAddress);
+    const aptosAddress = publicKey.authKey().derivedAddress();
+
+    // We need to provide `issuedAt` externally so that we can match it with the signature
+    const issuedAt = new Date();
+    const siweMessage = createSiweMessageFromAptosTransaction({
+      aptosAddress,
+      ethereumAddress,
+      rawTransaction,
+      issuedAt,
+    });
+
+    const response = await wrapEIP1193UserResponse(this.eip1193Wallet.signMessage({
+      account: ethereumAddress,
+      message: siweMessage,
+    }));
+
+    return mapUserResponse(response, (siweSignature) => {
+      const utf8EncodedSiweMessage = new TextEncoder().encode(siweMessage);
+      const signature = new EIP1193DerivedSignature(siweSignature, issuedAt);
+      const authenticator: AccountAuthenticator = new AccountAuthenticatorAbstraction(
+        this.authenticationFunction,
+        // Not sure what the expected value is here
+        utf8EncodedSiweMessage,
+        signature.bcsToBytes(),
+      );
+      return authenticator;
+    });
+  }
+
+  // endregion
+}

--- a/packages/derived-wallet-ethereum/src/createSiweMessageFromAptos.ts
+++ b/packages/derived-wallet-ethereum/src/createSiweMessageFromAptos.ts
@@ -1,0 +1,107 @@
+import { aptosChainIdToNetwork, encodeStructuredMessage, StructuredMessage } from '@aptos-labs/derived-wallet-base';
+import {
+  AccountAddressInput,
+  AnyRawTransaction,
+  generateSigningMessageForTransaction,
+  hashValues,
+  Hex,
+} from '@aptos-labs/ts-sdk';
+import type { Address as EthereumAddress } from 'viem';
+import { createSiweMessage } from 'viem/siwe';
+
+// The Ethereum chainId is required for SIWE, although it shouldn't matter
+// for the purpose of signing Aptos messages. Using mainnet is a safe choice.
+const ethereumMainnetChainId = 1;
+
+export interface CreateSiweMessageFromAptosStructuredMessageInput {
+  ethereumAddress: EthereumAddress;
+  structuredMessage: StructuredMessage;
+  issuedAt: Date;
+}
+
+export function createSiweMessageFromAptosStructuredMessage(
+  input: CreateSiweMessageFromAptosStructuredMessageInput,
+) {
+  const { ethereumAddress, structuredMessage, issuedAt } = input;
+
+  const {
+    // display in the statement
+    address,
+    // automatically displayed as domain and URI
+    // application,
+    // displayed in the statement
+    chainId,
+    // escaped and displayed in the statement
+    message,
+    // displayed as nonce
+    nonce,
+  } = structuredMessage;
+
+  // `statement` does not allow newlines, so we escape them
+  const escapedMessage = message.replaceAll('\n', '\\n');
+
+  // Attempt to convert chainId into a human-readable identifier
+  const network = chainId ? aptosChainIdToNetwork(chainId) : undefined;
+  const networkId = network ?? (chainId ? `chainId: ${chainId}` : undefined);
+
+  const onAptosNetwork = networkId ? ` on Aptos (${networkId})` : " on Aptos";
+  const asAccount = address ? ` with account ${address}` : '';
+  const statement = `Sign the following message${onAptosNetwork}${asAccount}: ${escapedMessage}`;
+
+  const encodedMessage = encodeStructuredMessage(structuredMessage);
+  const messageHash = hashValues([encodedMessage]);
+  // TODO: consider using b58 or b64 instead
+  const requestId = Hex.fromHexInput(messageHash).toStringWithoutPrefix();
+
+  return createSiweMessage({
+    address: ethereumAddress,
+    domain: window.location.host,
+    uri: window.location.origin,
+    chainId: ethereumMainnetChainId,
+    nonce,
+    requestId,
+    statement,
+    version: '1',
+    issuedAt,
+  });
+}
+
+interface CreateSiweMessageFromAptosTransactionInput {
+  ethereumAddress: EthereumAddress;
+  aptosAddress: AccountAddressInput;
+  rawTransaction: AnyRawTransaction;
+  issuedAt: Date;
+}
+
+export function createSiweMessageFromAptosTransaction(input: CreateSiweMessageFromAptosTransactionInput) {
+  const { ethereumAddress, aptosAddress, rawTransaction, issuedAt } = input;
+  const signingMessage = generateSigningMessageForTransaction(rawTransaction);
+  const messageHash = hashValues([signingMessage]);
+  const messageHashHex = Hex.fromHexInput(messageHash).toStringWithoutPrefix();
+
+  // TODO: consider using b58 or b64 instead
+  const requestId = messageHashHex;
+  const nonce = messageHashHex;
+
+  const chainId = rawTransaction.rawTransaction.chain_id.chainId;
+
+  // Attempt to convert chainId into a human-readable identifier
+  const networkId = aptosChainIdToNetwork(chainId) ?? `chainId: ${chainId}`;
+
+  const onAptosNetwork = ` on Aptos (${networkId})`;
+  const asAccount = ` with account ${aptosAddress.toString()}`;
+  // TODO: define a good way to display the transaction
+  const statement = `Sign the following transaction${onAptosNetwork}${asAccount}: TODO`;
+
+  return createSiweMessage({
+    address: ethereumAddress,
+    domain: window.location.host,
+    uri: window.location.origin,
+    chainId: ethereumMainnetChainId,
+    nonce,
+    requestId,
+    statement,
+    version: '1',
+    issuedAt,
+  });
+}

--- a/packages/derived-wallet-ethereum/src/index.ts
+++ b/packages/derived-wallet-ethereum/src/index.ts
@@ -1,0 +1,4 @@
+export * from './EIP1193DerivedPublicKey';
+export * from './EIP1193DerivedSignature';
+export * from './EIP1193DerivedWallet';
+export * from './setupAutomaticDerivation';

--- a/packages/derived-wallet-ethereum/src/setupAutomaticDerivation.ts
+++ b/packages/derived-wallet-ethereum/src/setupAutomaticDerivation.ts
@@ -1,0 +1,35 @@
+import { getWallets } from '@wallet-standard/app';
+import { createStore } from 'mipd';
+import { EIP6963ProviderDetail } from 'mipd/src/types';
+import { EIP1193DerivedWallet, EIP1193DerivedWalletOptions } from './EIP1193DerivedWallet';
+
+export function setupAutomaticEthereumWalletDerivation(options: EIP1193DerivedWalletOptions = {}) {
+  const walletsApi = getWallets();
+  const eip6963Store = createStore();
+
+  type UnsubscribeCallback = () => void;
+  let registrations: { [name: string]: UnsubscribeCallback } = {};
+
+  const deriveAndRegisterWallet = (detail: EIP6963ProviderDetail) => {
+    const derivedWallet = new EIP1193DerivedWallet(detail, options);
+    registrations[detail.info.rdns] = walletsApi.register(derivedWallet);
+  };
+
+  const initialProviders = eip6963Store.getProviders();
+  for (const detail of initialProviders) {
+    deriveAndRegisterWallet(detail);
+  }
+
+  eip6963Store.subscribe((details) => {
+    for (const detail of details) {
+      deriveAndRegisterWallet(detail);
+    }
+  });
+
+  return () => {
+    eip6963Store.destroy();
+    for (const unregisterWallet of Object.values(registrations)) {
+      unregisterWallet();
+    }
+  };
+}

--- a/packages/derived-wallet-ethereum/tsconfig.json
+++ b/packages/derived-wallet-ethereum/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@aptos-labs/wallet-adapter-tsconfig/base.json",
+  "include": ["."],
+  "exclude": ["dist", "build", "node_modules"],
+  "compilerOptions": {
+    "target": "es2020",
+    "lib": ["es2021", "dom"],
+    "rootDir": "src",
+    "outDir": "dist/types"
+  }
+}

--- a/packages/derived-wallet-solana/.eslintrc.js
+++ b/packages/derived-wallet-solana/.eslintrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+  root: true,
+  extends: ["@aptos-labs/eslint-config-adapter"],
+};

--- a/packages/derived-wallet-solana/package.json
+++ b/packages/derived-wallet-solana/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@aptos-labs/derived-wallet-solana",
+  "version": "0.0.1",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/types/index.d.ts",
+  "license": "Apache-2.0",
+  "exports": {
+    "types": "./dist/types/index.d.ts",
+    "require": "./dist/index.js",
+    "import": "./dist/index.mjs"
+  },
+  "author": "aptoslabs.com",
+  "scripts": {
+    "build": "pnpm build:bundle && pnpm build:declarations",
+    "build:bundle": "tsup --sourcemap",
+    "build:declarations": "tsc --emitDeclarationOnly --declaration --declarationMap",
+    "test": "jest",
+    "lint": "TIMING=1 eslint \"src/**/*.ts*\""
+  },
+  "tsup": {
+    "entryPoints": ["src/index.ts"],
+    "format": ["cjs", "esm"]
+  },
+  "dependencies": {
+    "@aptos-labs/derived-wallet-base": "workspace:^",
+    "@aptos-labs/siwa": "^0.2.5",
+    "@aptos-labs/wallet-standard": "^0.3.0",
+    "@solana/wallet-adapter-base": "^0.9.23",
+    "@solana/wallet-standard-util": "^1.1.2",
+    "@solana/wallet-standard-wallet-adapter-base": "^1.1.4",
+    "@solana/web3.js": "^1.95.8",
+    "@wallet-standard/app": "^1.1.0"
+  },
+  "peerDependencies": {
+    "@aptos-labs/ts-sdk": "^1.35.0"
+  },
+  "devDependencies": {
+    "@aptos-labs/eslint-config-adapter": "workspace:*",
+    "@aptos-labs/wallet-adapter-tsconfig": "workspace:*",
+    "@types/jest": "^29.2.4",
+    "@types/node": "^20.10.4",
+    "eslint": "^8.15.0",
+    "jest": "^29.3.1",
+    "ts-jest": "^29.0.3",
+    "tsup": "^8.3.6",
+    "typescript": "^5.4.5"
+  },
+  "files": [
+    "dist",
+    "src",
+    "!src/**.test.ts",
+    "!src/**/__tests__"
+  ]
+}

--- a/packages/derived-wallet-solana/src/SolanaDerivedPublicKey.ts
+++ b/packages/derived-wallet-solana/src/SolanaDerivedPublicKey.ts
@@ -1,0 +1,92 @@
+import { computeDomainAuthenticationKey, parseAptosSigningMessage } from '@aptos-labs/derived-wallet-base';
+import {
+  AccountPublicKey,
+  AuthenticationKey,
+  Deserializer,
+  Ed25519PublicKey,
+  Ed25519Signature,
+  hashValues,
+  Serializer,
+  VerifySignatureArgs,
+} from '@aptos-labs/ts-sdk';
+import { createSignInMessage } from '@solana/wallet-standard-util';
+import { PublicKey as SolanaPublicKey } from '@solana/web3.js';
+import {
+  createSiwsInputFromAptosStructuredMessage,
+  createSiwsInputFromAptosTransaction,
+} from './createSiwsMessageFromAptos';
+
+export interface SolanaDerivedPublicKeyParams {
+  domain: string;
+  solanaPublicKey: SolanaPublicKey;
+  authenticationFunction: string;
+}
+
+export class SolanaDerivedPublicKey extends AccountPublicKey {
+  readonly domain: string;
+  readonly solanaPublicKey: SolanaPublicKey;
+  readonly authenticationFunction: string;
+
+  readonly _authKey: AuthenticationKey;
+
+  constructor(params: SolanaDerivedPublicKeyParams) {
+    super();
+    const { domain, solanaPublicKey, authenticationFunction } = params;
+    this.domain = domain;
+    this.solanaPublicKey = solanaPublicKey;
+    this.authenticationFunction = authenticationFunction;
+
+    const utf8EncodedDomain = new TextEncoder().encode(domain);
+    const solanaPublicKeyBytes = solanaPublicKey.toBytes();
+
+    const serializer = new Serializer();
+    serializer.serializeBytes(utf8EncodedDomain);
+    serializer.serializeFixedBytes(solanaPublicKeyBytes); // fixed length 32 bytes
+    const accountIdentifier = hashValues([serializer.toUint8Array()]);
+
+    this._authKey = computeDomainAuthenticationKey(
+      authenticationFunction,
+      accountIdentifier,
+    );
+  }
+
+  authKey(): AuthenticationKey {
+    return this._authKey;
+  }
+
+  verifySignature({ message, signature }: VerifySignatureArgs): boolean {
+    const parsed = parseAptosSigningMessage(message);
+    if (!parsed || !(signature instanceof Ed25519Signature)) {
+      return false;
+    }
+
+    const siwsInput = parsed.type === 'structuredMessage'
+      ? createSiwsInputFromAptosStructuredMessage({
+        solanaPublicKey: this.solanaPublicKey,
+        structuredMessage: parsed.structuredMessage,
+      })
+      : createSiwsInputFromAptosTransaction({
+        solanaPublicKey: this.solanaPublicKey,
+        aptosAddress: this._authKey.derivedAddress(),
+        rawTransaction: parsed.rawTransaction,
+      });
+
+    const signInMessage = createSignInMessage(siwsInput);
+    const ed25519PublicKey = new Ed25519PublicKey(this.solanaPublicKey.toBytes());
+    return ed25519PublicKey.verifySignature({ message: signInMessage, signature });
+  }
+
+  serialize(serializer: Serializer) {
+    serializer.serializeStr(this.domain);
+    serializer.serializeFixedBytes(this.solanaPublicKey.toBytes());
+    serializer.serializeStr(this.authenticationFunction);
+  }
+
+  static deserialize(deserializer: Deserializer) {
+    const domain = deserializer.deserializeStr();
+    const solanaPublicKeyBytes = deserializer.deserializeFixedBytes(32);
+    const solanaPublicKey = new SolanaPublicKey(solanaPublicKeyBytes)
+    const authenticationFunction = deserializer.deserializeStr();
+    return new SolanaDerivedPublicKey({ domain, solanaPublicKey, authenticationFunction });
+  }
+}

--- a/packages/derived-wallet-solana/src/createSiwsMessageFromAptos.ts
+++ b/packages/derived-wallet-solana/src/createSiwsMessageFromAptos.ts
@@ -1,0 +1,98 @@
+import { aptosChainIdToNetwork, encodeStructuredMessage, StructuredMessage } from '@aptos-labs/derived-wallet-base';
+import {
+  AccountAddressInput,
+  AnyRawTransaction,
+  generateSigningMessageForTransaction,
+  hashValues,
+  Hex,
+} from '@aptos-labs/ts-sdk';
+import { SolanaSignInInputWithRequiredFields } from '@solana/wallet-standard-util';
+import { PublicKey as SolanaPublicKey } from '@solana/web3.js';
+
+export interface CreateSiwsMessageFromAptosStructuredMessageInput {
+  solanaPublicKey: SolanaPublicKey;
+  structuredMessage: StructuredMessage;
+}
+
+export function createSiwsInputFromAptosStructuredMessage(
+  input: CreateSiwsMessageFromAptosStructuredMessageInput,
+): SolanaSignInInputWithRequiredFields {
+  const { solanaPublicKey, structuredMessage } = input;
+  const {
+    // display in the statement
+    address,
+    // automatically displayed as domain and URI
+    // application,
+    // displayed in the statement
+    chainId,
+    // escaped and displayed in the statement
+    message,
+    // displayed as nonce
+    nonce,
+  } = structuredMessage;
+
+  // `statement` does not allow newlines, so we escape them
+  const escapedMessage = message.replaceAll('\n', '\\n');
+
+  // Attempt to convert chainId into a human-readable identifier
+  const network = chainId ? aptosChainIdToNetwork(chainId) : undefined;
+  const networkId = network ?? (chainId ? `chainId: ${chainId}` : undefined);
+
+  const onAptosNetwork = networkId ? ` on Aptos (${networkId})` : " on Aptos";
+  const asAccount = address ? ` with account ${address}` : '';
+  const statement = `Sign the following message${onAptosNetwork}${asAccount}: ${escapedMessage}`;
+
+  const encodedMessage = encodeStructuredMessage(structuredMessage);
+  const messageHash = hashValues([encodedMessage]);
+  // TODO: consider using b58 or b64 instead
+  const requestId = Hex.fromHexInput(messageHash).toStringWithoutPrefix();
+
+  return {
+    address: solanaPublicKey.toString(),
+    domain: window.location.host,
+    uri: window.location.origin,
+    nonce,
+    requestId,
+    statement,
+    version: '1',
+  };
+}
+
+export interface CreateSiwsMessageFromAptosTransaction {
+  solanaPublicKey: SolanaPublicKey;
+  aptosAddress: AccountAddressInput;
+  rawTransaction: AnyRawTransaction;
+}
+
+export function createSiwsInputFromAptosTransaction(
+  input: CreateSiwsMessageFromAptosTransaction,
+): SolanaSignInInputWithRequiredFields {
+  const { solanaPublicKey, aptosAddress, rawTransaction } = input;
+  const signingMessage = generateSigningMessageForTransaction(rawTransaction);
+  const messageHash = hashValues([signingMessage]);
+  const messageHashHex = Hex.fromHexInput(messageHash).toStringWithoutPrefix();
+
+  // TODO: consider using b58 or b64 instead
+  const requestId = messageHashHex;
+  const nonce = messageHashHex;
+
+  const chainId = rawTransaction.rawTransaction.chain_id.chainId;
+
+  // Attempt to convert chainId into a human-readable identifier
+  const networkId = aptosChainIdToNetwork(chainId) ?? `chainId: ${chainId}`;
+
+  const onAptosNetwork = ` on Aptos (${networkId})`;
+  const asAccount = ` with account ${aptosAddress.toString()}`;
+  // TODO: define a good way to display the transaction
+  const statement = `Sign the following transaction${onAptosNetwork}${asAccount}: TODO`;
+
+  return {
+    address: solanaPublicKey.toString(),
+    domain: window.location.host,
+    uri: window.location.origin,
+    nonce,
+    requestId,
+    statement,
+    version: '1',
+  };
+}

--- a/packages/derived-wallet-solana/src/index.ts
+++ b/packages/derived-wallet-solana/src/index.ts
@@ -1,0 +1,3 @@
+export * from './setupAutomaticDerivation';
+export * from './SolanaDerivedPublicKey';
+export * from './SolanaDerivedWallet';

--- a/packages/derived-wallet-solana/src/setupAutomaticDerivation.ts
+++ b/packages/derived-wallet-solana/src/setupAutomaticDerivation.ts
@@ -1,0 +1,50 @@
+import {
+  isWalletAdapterCompatibleStandardWallet,
+  WalletAdapterCompatibleStandardWallet,
+} from "@solana/wallet-adapter-base";
+import { StandardWalletAdapter } from "@solana/wallet-standard-wallet-adapter-base";
+import { getWallets } from '@wallet-standard/app';
+import { SolanaDerivedWallet, SolanaDomainWalletOptions } from './SolanaDerivedWallet';
+
+export function setupAutomaticSolanaWalletDerivation(options: SolanaDomainWalletOptions = {}) {
+  const api = getWallets();
+
+  type UnsubscribeCallback = () => void;
+  let registrations: { [name: string]: UnsubscribeCallback } = {};
+
+  const deriveAndRegisterWallet = (wallet: WalletAdapterCompatibleStandardWallet) => {
+    const adapter = new StandardWalletAdapter({ wallet });
+    const derivedWallet = new SolanaDerivedWallet(adapter, options);
+    registrations[wallet.name] = api.register(derivedWallet);
+  };
+
+  for (const wallet of api.get()) {
+    if (isWalletAdapterCompatibleStandardWallet(wallet)) {
+      deriveAndRegisterWallet(wallet);
+    }
+  }
+
+  const offRegister = api.on('register', (wallet) => {
+    if (isWalletAdapterCompatibleStandardWallet(wallet)) {
+      deriveAndRegisterWallet(wallet);
+    }
+  });
+
+  const offUnregister = api.on('unregister', (wallet) => {
+    if (isWalletAdapterCompatibleStandardWallet(wallet)) {
+      const unregisterWallet = registrations[wallet.name];
+      if (unregisterWallet) {
+        unregisterWallet();
+        delete registrations[wallet.name];
+      }
+    }
+  });
+
+  return () => {
+    offRegister();
+    offUnregister();
+    for (const unregisterWallet of Object.values(registrations)) {
+      unregisterWallet();
+    }
+  };
+}

--- a/packages/derived-wallet-solana/tsconfig.json
+++ b/packages/derived-wallet-solana/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@aptos-labs/wallet-adapter-tsconfig/base.json",
+  "include": ["."],
+  "exclude": ["dist", "build", "node_modules"],
+  "compilerOptions": {
+    "target": "es2020",
+    "lib": ["es2021", "dom"],
+    "rootDir": "src",
+    "outDir": "dist/types"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,12 @@ importers:
 
   apps/nextjs-example:
     dependencies:
+      '@aptos-labs/derived-wallet-ethereum':
+        specifier: workspace:^
+        version: link:../../packages/derived-wallet-ethereum
+      '@aptos-labs/derived-wallet-solana':
+        specifier: workspace:^
+        version: link:../../packages/derived-wallet-solana
       '@aptos-labs/ts-sdk':
         specifier: ^1.35.0
         version: 1.35.0(axios@1.7.9)(got@11.8.6)
@@ -296,7 +302,7 @@ importers:
         version: 0.0.7(typescript@5.7.3)
       viem:
         specifier: ^2.23.12
-        version: 2.23.13(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)
+        version: 2.23.12(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)
     devDependencies:
       '@aptos-labs/eslint-config-adapter':
         specifier: workspace:*
@@ -8449,8 +8455,8 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
-  viem@2.23.13:
-    resolution: {integrity: sha512-f3RkcrzGhU79GfBb9GHUL0m3e3LUsNudXIQTFp4fit5hUGb0ew9KOYZ6cCY5d4Melj3noBy2zq0K2fV+mp+Cpg==}
+  viem@2.23.12:
+    resolution: {integrity: sha512-zq2mL4KcUfpVMLMaKjwzRG3akjjVUo9AhaNohrQ86ufltX1aUxapE+Z6YQ0U6F6MBQEMBgLiFTWgalgVDWqQyQ==}
     peerDependencies:
       typescript: '>=5.0.4'
     peerDependenciesMeta:
@@ -8790,18 +8796,6 @@ packages:
 
   ws@8.17.1:
     resolution: {integrity: sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
-  ws@8.18.0:
-    resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -10700,7 +10694,7 @@ snapshots:
       vite-plugin-inspect: 0.8.9(@nuxt/kit@3.15.4(magicast@0.3.5))(rollup@4.34.6)(vite@6.1.0(@types/node@22.7.5)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0))
       vite-plugin-vue-inspector: 5.3.1(vite@6.1.0(@types/node@22.7.5)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0))
       which: 3.0.1
-      ws: 8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      ws: 8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
       - rollup
@@ -17566,7 +17560,7 @@ snapshots:
     dependencies:
       eventemitter3: 4.0.7
       uuid: 8.3.2
-      ws: 8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      ws: 8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     optionalDependencies:
       bufferutil: 4.0.9
       utf-8-validate: 5.0.10
@@ -17579,7 +17573,7 @@ snapshots:
       buffer: 6.0.3
       eventemitter3: 5.0.1
       uuid: 8.3.2
-      ws: 8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      ws: 8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     optionalDependencies:
       bufferutil: 4.0.9
       utf-8-validate: 5.0.10
@@ -18646,7 +18640,7 @@ snapshots:
 
   vary@1.1.2: {}
 
-  viem@2.23.13(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10):
+  viem@2.23.12(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10):
     dependencies:
       '@noble/curves': 1.8.1
       '@noble/hashes': 1.7.1
@@ -19029,11 +19023,6 @@ snapshots:
       utf-8-validate: 5.0.10
 
   ws@8.17.1(bufferutil@4.0.9)(utf-8-validate@5.0.10):
-    optionalDependencies:
-      bufferutil: 4.0.9
-      utf-8-validate: 5.0.10
-
-  ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10):
     optionalDependencies:
       bufferutil: 4.0.9
       utf-8-validate: 5.0.10

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,7 +186,7 @@ importers:
         version: 0.396.0(vue@3.5.13(typescript@5.7.3))
       nuxt:
         specifier: ^3.15.4
-        version: 3.15.4(@parcel/watcher@2.5.1)(@types/node@20.17.17)(bufferutil@4.0.9)(db0@0.2.3)(eslint@8.57.1)(ioredis@5.5.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.34.6)(terser@5.38.1)(typescript@5.7.3)(utf-8-validate@5.0.10)(vite@6.1.0(@types/node@20.17.17)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0))(yaml@2.7.0)
+        version: 3.15.4(@parcel/watcher@2.5.1)(@types/node@22.7.5)(bufferutil@4.0.9)(db0@0.2.3)(eslint@8.57.1)(ioredis@5.5.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.34.6)(terser@5.38.1)(typescript@5.7.3)(utf-8-validate@5.0.10)(vite@6.1.0(@types/node@22.7.5)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0))(yaml@2.7.0)
       radix-vue:
         specifier: ^1.9.1
         version: 1.9.13(vue@3.5.13(typescript@5.7.3))
@@ -211,7 +211,7 @@ importers:
         version: 12.1.0(eslint@8.57.1)(typescript@5.7.3)
       '@nuxtjs/eslint-module':
         specifier: 4.1.0
-        version: 4.1.0(eslint@8.57.1)(magicast@0.3.5)(vite@6.1.0(@types/node@20.17.17)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0))(webpack@5.97.1)
+        version: 4.1.0(eslint@8.57.1)(magicast@0.3.5)(vite@6.1.0(@types/node@22.7.5)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0))(webpack@5.97.1)
       '@nuxtjs/tailwindcss':
         specifier: ^6.13.1
         version: 6.13.1(magicast@0.3.5)
@@ -233,6 +233,156 @@ importers:
       ufo:
         specifier: 1.5.3
         version: 1.5.3
+
+  packages/derived-wallet-base:
+    dependencies:
+      '@aptos-labs/ts-sdk':
+        specifier: ^1.35.0
+        version: 1.35.0(axios@1.7.9)(got@11.8.6)
+      '@aptos-labs/wallet-standard':
+        specifier: ^0.3.0
+        version: 0.3.0(@aptos-labs/ts-sdk@1.35.0(axios@1.7.9)(got@11.8.6))(@wallet-standard/core@1.1.0)
+    devDependencies:
+      '@aptos-labs/eslint-config-adapter':
+        specifier: workspace:*
+        version: link:../eslint-config-adapter
+      '@aptos-labs/wallet-adapter-tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+      '@types/jest':
+        specifier: ^29.2.4
+        version: 29.5.14
+      '@types/node':
+        specifier: ^20.10.4
+        version: 20.17.17
+      eslint:
+        specifier: ^8.15.0
+        version: 8.57.1
+      jest:
+        specifier: ^29.3.1
+        version: 29.7.0(@types/node@20.17.17)(babel-plugin-macros@3.1.0)
+      ts-jest:
+        specifier: ^29.0.3
+        version: 29.2.5(@babel/core@7.26.8)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.8))(esbuild@0.24.2)(jest@29.7.0(@types/node@20.17.17)(babel-plugin-macros@3.1.0))(typescript@5.7.3)
+      tsup:
+        specifier: ^8.3.6
+        version: 8.3.6(@microsoft/api-extractor@7.43.0(@types/node@20.17.17))(jiti@2.4.2)(postcss@8.5.1)(typescript@5.7.3)(yaml@2.7.0)
+      typescript:
+        specifier: ^5.4.5
+        version: 5.7.3
+
+  packages/derived-wallet-ethereum:
+    dependencies:
+      '@aptos-labs/derived-wallet-base':
+        specifier: workspace:^
+        version: link:../derived-wallet-base
+      '@aptos-labs/siwa':
+        specifier: ^0.2.5
+        version: 0.2.5(@aptos-labs/ts-sdk@1.35.0(axios@1.7.9)(got@11.8.6))(@wallet-standard/core@1.1.0)
+      '@aptos-labs/ts-sdk':
+        specifier: ^1.35.0
+        version: 1.35.0(axios@1.7.9)(got@11.8.6)
+      '@aptos-labs/wallet-standard':
+        specifier: ^0.3.0
+        version: 0.3.0(@aptos-labs/ts-sdk@1.35.0(axios@1.7.9)(got@11.8.6))(@wallet-standard/core@1.1.0)
+      '@wallet-standard/app':
+        specifier: ^1.1.0
+        version: 1.1.0
+      ethers:
+        specifier: ^6.13.5
+        version: 6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      mipd:
+        specifier: ^0.0.7
+        version: 0.0.7(typescript@5.7.3)
+      viem:
+        specifier: ^2.23.12
+        version: 2.23.13(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)
+    devDependencies:
+      '@aptos-labs/eslint-config-adapter':
+        specifier: workspace:*
+        version: link:../eslint-config-adapter
+      '@aptos-labs/wallet-adapter-tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+      '@types/jest':
+        specifier: ^29.2.4
+        version: 29.5.14
+      '@types/node':
+        specifier: ^20.10.4
+        version: 20.17.17
+      eslint:
+        specifier: ^8.15.0
+        version: 8.57.1
+      jest:
+        specifier: ^29.3.1
+        version: 29.7.0(@types/node@20.17.17)(babel-plugin-macros@3.1.0)
+      ts-jest:
+        specifier: ^29.0.3
+        version: 29.2.5(@babel/core@7.26.8)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.8))(esbuild@0.24.2)(jest@29.7.0(@types/node@20.17.17)(babel-plugin-macros@3.1.0))(typescript@5.7.3)
+      tsup:
+        specifier: ^8.3.6
+        version: 8.3.6(@microsoft/api-extractor@7.43.0(@types/node@20.17.17))(jiti@2.4.2)(postcss@8.5.1)(typescript@5.7.3)(yaml@2.7.0)
+      typescript:
+        specifier: ^5.4.5
+        version: 5.7.3
+
+  packages/derived-wallet-solana:
+    dependencies:
+      '@aptos-labs/derived-wallet-base':
+        specifier: workspace:^
+        version: link:../derived-wallet-base
+      '@aptos-labs/siwa':
+        specifier: ^0.2.5
+        version: 0.2.5(@aptos-labs/ts-sdk@1.35.0(axios@1.7.9)(got@11.8.6))(@wallet-standard/core@1.1.0)
+      '@aptos-labs/ts-sdk':
+        specifier: ^1.35.0
+        version: 1.35.0(axios@1.7.9)(got@11.8.6)
+      '@aptos-labs/wallet-standard':
+        specifier: ^0.3.0
+        version: 0.3.0(@aptos-labs/ts-sdk@1.35.0(axios@1.7.9)(got@11.8.6))(@wallet-standard/core@1.1.0)
+      '@solana/wallet-adapter-base':
+        specifier: ^0.9.23
+        version: 0.9.23(@solana/web3.js@1.98.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@solana/wallet-standard-util':
+        specifier: ^1.1.2
+        version: 1.1.2
+      '@solana/wallet-standard-wallet-adapter-base':
+        specifier: ^1.1.4
+        version: 1.1.4(@solana/web3.js@1.98.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(bs58@4.0.1)
+      '@solana/web3.js':
+        specifier: ^1.95.8
+        version: 1.98.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      '@wallet-standard/app':
+        specifier: ^1.1.0
+        version: 1.1.0
+    devDependencies:
+      '@aptos-labs/eslint-config-adapter':
+        specifier: workspace:*
+        version: link:../eslint-config-adapter
+      '@aptos-labs/wallet-adapter-tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+      '@types/jest':
+        specifier: ^29.2.4
+        version: 29.5.14
+      '@types/node':
+        specifier: ^20.10.4
+        version: 20.17.17
+      eslint:
+        specifier: ^8.15.0
+        version: 8.57.1
+      jest:
+        specifier: ^29.3.1
+        version: 29.7.0(@types/node@20.17.17)(babel-plugin-macros@3.1.0)
+      ts-jest:
+        specifier: ^29.0.3
+        version: 29.2.5(@babel/core@7.26.8)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.8))(esbuild@0.24.2)(jest@29.7.0(@types/node@20.17.17)(babel-plugin-macros@3.1.0))(typescript@5.7.3)
+      tsup:
+        specifier: ^8.3.6
+        version: 8.3.6(@microsoft/api-extractor@7.43.0(@types/node@20.17.17))(jiti@2.4.2)(postcss@8.5.1)(typescript@5.7.3)(yaml@2.7.0)
+      typescript:
+        specifier: ^5.4.5
+        version: 5.7.3
 
   packages/eslint-config-adapter:
     dependencies:
@@ -438,7 +588,7 @@ importers:
     devDependencies:
       '@vitejs/plugin-vue':
         specifier: 5.0.5
-        version: 5.0.5(vite@5.3.6(@types/node@20.17.17)(terser@5.38.1))(vue@3.5.13(typescript@4.9.5))
+        version: 5.0.5(vite@5.3.6(@types/node@22.7.5)(terser@5.38.1))(vue@3.5.13(typescript@4.9.5))
       eslint:
         specifier: ^8.15.0
         version: 8.57.1
@@ -450,21 +600,27 @@ importers:
         version: 4.9.5
       vite:
         specifier: 5.3.6
-        version: 5.3.6(@types/node@20.17.17)(terser@5.38.1)
+        version: 5.3.6(@types/node@22.7.5)(terser@5.38.1)
       vite-plugin-compression:
         specifier: ^0.5.1
-        version: 0.5.1(vite@5.3.6(@types/node@20.17.17)(terser@5.38.1))
+        version: 0.5.1(vite@5.3.6(@types/node@22.7.5)(terser@5.38.1))
       vite-plugin-css-injected-by-js:
         specifier: ^3.5.1
-        version: 3.5.2(vite@5.3.6(@types/node@20.17.17)(terser@5.38.1))
+        version: 3.5.2(vite@5.3.6(@types/node@22.7.5)(terser@5.38.1))
       vite-plugin-dts:
         specifier: 3.9.1
-        version: 3.9.1(@types/node@20.17.17)(rollup@4.34.6)(typescript@4.9.5)(vite@5.3.6(@types/node@20.17.17)(terser@5.38.1))
+        version: 3.9.1(@types/node@22.7.5)(rollup@4.34.6)(typescript@4.9.5)(vite@5.3.6(@types/node@22.7.5)(terser@5.38.1))
       vue-tsc:
         specifier: ^2.0.26
         version: 2.2.0(typescript@4.9.5)
 
 packages:
+
+  '@adraffy/ens-normalize@1.10.1':
+    resolution: {integrity: sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==}
+
+  '@adraffy/ens-normalize@1.11.0':
+    resolution: {integrity: sha512-/3DDPKHqqIqxUULp8yP4zODUY1i+2xvVWsv8A79xGWdCAG+8sb0hRh0Rk2QyOJUnnbyPUAZYcpBuRe3nS2OIUg==}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -572,6 +728,11 @@ packages:
 
   '@aptos-labs/script-composer-pack@0.0.9':
     resolution: {integrity: sha512-Y3kA1rgF65HETgoTn2omDymsgO+fnZouPLrKJZ9sbxTGdOekIIHtGee3A2gk84eCqa02ZKBumZmP+IDCXRtU/g==}
+
+  '@aptos-labs/siwa@0.2.5':
+    resolution: {integrity: sha512-BDiZa5z8a1DRG95OO1e9EwAnjLUurwpAKcnmJcqYwNH+q5p3NsdPeEF071xmZNB9urPbOOJyGwGwHDH2TgUBCw==}
+    peerDependencies:
+      '@aptos-labs/ts-sdk': '>=1.33.2'
 
   '@aptos-labs/ts-sdk@1.35.0':
     resolution: {integrity: sha512-ChW2Lvi6lKfEb0AYo0HAa98bYf0+935nMdjl40wFMWsR+mxFhtNA4EYINXsHVTMPfE/WV9sXEvDInvscJFrALQ==}
@@ -1732,9 +1893,16 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@noble/curves@1.2.0':
+    resolution: {integrity: sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==}
+
   '@noble/curves@1.8.1':
     resolution: {integrity: sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==}
     engines: {node: ^14.21.3 || >=16}
+
+  '@noble/hashes@1.3.2':
+    resolution: {integrity: sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==}
+    engines: {node: '>= 16'}
 
   '@noble/hashes@1.3.3':
     resolution: {integrity: sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==}
@@ -2593,6 +2761,38 @@ packages:
   '@sinonjs/fake-timers@10.3.0':
     resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
 
+  '@solana/buffer-layout@4.0.1':
+    resolution: {integrity: sha512-E1ImOIAD1tBZFRdjeM4/pzTiTApC0AOBGwyAMS4fwIodCWArzJ3DWdoh8cKxeFM2fElkxBh2Aqts1BPC373rHA==}
+    engines: {node: '>=5.10'}
+
+  '@solana/wallet-adapter-base@0.9.23':
+    resolution: {integrity: sha512-apqMuYwFp1jFi55NxDfvXUX2x1T0Zh07MxhZ/nCCTGys5raSfYUh82zen2BLv8BSDj/JxZ2P/s7jrQZGrX8uAw==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      '@solana/web3.js': ^1.77.3
+
+  '@solana/wallet-standard-chains@1.1.1':
+    resolution: {integrity: sha512-Us3TgL4eMVoVWhuC4UrePlYnpWN+lwteCBlhZDUhFZBJ5UMGh94mYPXno3Ho7+iHPYRtuCi/ePvPcYBqCGuBOw==}
+    engines: {node: '>=16'}
+
+  '@solana/wallet-standard-features@1.3.0':
+    resolution: {integrity: sha512-ZhpZtD+4VArf6RPitsVExvgkF+nGghd1rzPjd97GmBximpnt1rsUxMOEyoIEuH3XBxPyNB6Us7ha7RHWQR+abg==}
+    engines: {node: '>=16'}
+
+  '@solana/wallet-standard-util@1.1.2':
+    resolution: {integrity: sha512-rUXFNP4OY81Ddq7qOjQV4Kmkozx4wjYAxljvyrqPx8Ycz0FYChG/hQVWqvgpK3sPsEaO/7ABG1NOACsyAKWNOA==}
+    engines: {node: '>=16'}
+
+  '@solana/wallet-standard-wallet-adapter-base@1.1.4':
+    resolution: {integrity: sha512-Q2Rie9YaidyFA4UxcUIxUsvynW+/gE2noj/Wmk+IOwDwlVrJUAXCvFaCNsPDSyKoiYEKxkSnlG13OA1v08G4iw==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      '@solana/web3.js': ^1.98.0
+      bs58: ^6.0.0
+
+  '@solana/web3.js@1.98.0':
+    resolution: {integrity: sha512-nz3Q5OeyGFpFCR+erX2f6JPt3sKhzhYcSycBCSPkWjzSVDh/Rr1FqTVMRe58FKO16/ivTUcuJjeS5MyBvpkbzA==}
+
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
 
@@ -2734,6 +2934,9 @@ packages:
   '@types/node@20.17.17':
     resolution: {integrity: sha512-/WndGO4kIfMicEQLTi/mDANUu/iVUhT7KboZPdEqqHQ4aTS+3qT3U5gIqWDFV+XouorjfgGqvKILJeHhuQgFYg==}
 
+  '@types/node@22.7.5':
+    resolution: {integrity: sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==}
+
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
 
@@ -2771,11 +2974,17 @@ packages:
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
 
+  '@types/uuid@8.3.4':
+    resolution: {integrity: sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==}
+
   '@types/web-bluetooth@0.0.20':
     resolution: {integrity: sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow==}
 
   '@types/ws@7.4.7':
     resolution: {integrity: sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==}
+
+  '@types/ws@8.18.0':
+    resolution: {integrity: sha512-8svvI3hMyvN0kKCJMvTJP/x6Y/EoQbepff882wL+Sn5QsXb3etnamgrJq4isrBxSJj5L2AuXcI0+bgkoAXGUJw==}
 
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
@@ -3151,6 +3360,17 @@ packages:
     resolution: {integrity: sha512-+/kfrslGQ7TNV2ecmQwMJj/B65g5KVq1/L3SGVZ3tCYGqlzFuFCGBZJtMP99wH3NpEUyAjn0zPdPUg0D+DwrOA==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
+  abitype@1.0.8:
+    resolution: {integrity: sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+      zod: ^3 >=3.22.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+      zod:
+        optional: true
+
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
@@ -3179,9 +3399,16 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  aes-js@4.0.0-beta.5:
+    resolution: {integrity: sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==}
+
   agent-base@7.1.3:
     resolution: {integrity: sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==}
     engines: {node: '>= 14'}
+
+  agentkeepalive@4.6.0:
+    resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
+    engines: {node: '>= 8.0.0'}
 
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
@@ -3427,12 +3654,19 @@ packages:
   bare-events@2.5.4:
     resolution: {integrity: sha512-+gFfDkR8pj4/TrWCGUGWmJIkBwuxPS5F+a5yWjOHQt2hHvNZd5YLzadjmDUtFmMM4y429bnKLa8bYBMHcYdnQA==}
 
+  base-x@3.0.11:
+    resolution: {integrity: sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
+
+  bigint-buffer@1.1.5:
+    resolution: {integrity: sha512-trfYco6AoZ+rKhKnxA0hgX0HAbVP/s808/EuDSe2JDzUnCp/xAsli35Orvk67UrTEcwuxZqYZDmfA2RXJgxVvA==}
+    engines: {node: '>= 10.0.0'}
 
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
@@ -3449,6 +3683,9 @@ packages:
 
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
+  borsh@0.7.0:
+    resolution: {integrity: sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==}
 
   brace-expansion@1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
@@ -3468,6 +3705,9 @@ packages:
   bs-logger@0.2.6:
     resolution: {integrity: sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==}
     engines: {node: '>= 6'}
+
+  bs58@4.0.1:
+    resolution: {integrity: sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==}
 
   bser@2.1.1:
     resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}
@@ -3502,6 +3742,12 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     peerDependencies:
       esbuild: '>=0.13'
+
+  bundle-require@5.1.0:
+    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      esbuild: '>=0.18'
 
   busboy@1.6.0:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
@@ -4615,6 +4861,10 @@ packages:
   eth-rpc-errors@4.0.3:
     resolution: {integrity: sha512-Z3ymjopaoft7JDoxZcEb3pwdGh7yiYMhOwm2doUt6ASXlMavpNlK6Cre0+IMl2VSGyEU9rkiperQhp5iRxn5Pg==}
 
+  ethers@6.13.5:
+    resolution: {integrity: sha512-+knKNieu5EKRThQJWwqaJ10a6HE9sSehGeqWN65//wE7j47ZpFhKAnHB/JJFibwwg61I/koxaPsXbXpD/skNOQ==}
+    engines: {node: '>=14.0.0'}
+
   event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
@@ -4691,6 +4941,9 @@ packages:
 
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
+
+  fast-stable-stringify@1.0.0:
+    resolution: {integrity: sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==}
 
   fast-uri@3.0.6:
     resolution: {integrity: sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==}
@@ -5091,6 +5344,9 @@ packages:
     resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
     engines: {node: '>=16.17.0'}
 
+  humanize-ms@1.2.1:
+    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
+
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
     engines: {node: '>=0.10.0'}
@@ -5369,6 +5625,11 @@ packages:
     peerDependencies:
       ws: '*'
 
+  isows@1.0.6:
+    resolution: {integrity: sha512-lPHCayd40oW98/I0uvgaHKWCSvkzY27LjWLbtzOm64yQ+G3Q5npjjbdppU65iZXkK1Zt+kH9pfegli0AYfwYYw==}
+    peerDependencies:
+      ws: '*'
+
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
     engines: {node: '>=8'}
@@ -5411,6 +5672,11 @@ packages:
 
   jayson@3.7.0:
     resolution: {integrity: sha512-tfy39KJMrrXJ+mFcMpxwBvFDetS8LAID93+rycFglIQM4kl3uNR3W4lBLE/FFhsoUCEox5Dt2adVpDm/XtebbQ==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  jayson@4.1.3:
+    resolution: {integrity: sha512-LtXh5aYZodBZ9Fc3j6f2w+MTNcnxteMOrb+QgIouguGOulWi0lieEkOUg+HkjjFs0DGoWDds6bi4E9hpNFLulQ==}
     engines: {node: '>=8'}
     hasBin: true
 
@@ -5958,6 +6224,14 @@ packages:
     resolution: {integrity: sha512-umcy022ILvb5/3Djuu8LWeqUa8D68JaBzlttKeMWen48SjabqS3iY5w/vzeMzMUNhLDifyhbOwKDSznB1vvrwg==}
     engines: {node: '>= 18'}
 
+  mipd@0.0.7:
+    resolution: {integrity: sha512-aAPZPNDQ3uMTdKbuO2YmAw2TxLHO0moa4YKAyETM/DTj5FloZo+a+8tU+iv4GmW+sOxKLSRwcSFuczk+Cpt6fg==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   mitt@3.0.1:
     resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
 
@@ -6241,6 +6515,14 @@ packages:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
 
+  ox@0.6.9:
+    resolution: {integrity: sha512-wi5ShvzE4eOcTwQVsIPdFr+8ycyX+5le/96iAJutaZAvCes1J0+RvpEPg5QDPDiaR0XQQAvZVl7AwqQcINuUug==}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   p-cancelable@2.1.1:
     resolution: {integrity: sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==}
     engines: {node: '>=8'}
@@ -6484,6 +6766,24 @@ packages:
       postcss:
         optional: true
       ts-node:
+        optional: true
+
+  postcss-load-config@6.0.1:
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      jiti: '>=1.21.0'
+      postcss: '>=8.0.9'
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
         optional: true
 
   postcss-merge-longhand@7.0.4:
@@ -7178,6 +7478,9 @@ packages:
   rpc-websockets@7.11.2:
     resolution: {integrity: sha512-pL9r5N6AVHlMN/vT98+fcO+5+/UcPLf/4tq+WUaid/PPUGS/ttJ3y8e9IqmaWKtShNAysMSjkczuEA49NuV7UQ==}
 
+  rpc-websockets@9.1.1:
+    resolution: {integrity: sha512-1IXGM/TfPT6nfYMIXkJdzn+L4JEsmb0FL1O2OBjaH03V3yuUDdKFulGLMFG6ErV+8pZ5HVC0limve01RyO+saA==}
+
   run-applescript@7.0.0:
     resolution: {integrity: sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==}
     engines: {node: '>=18'}
@@ -7539,6 +7842,10 @@ packages:
     resolution: {integrity: sha512-5JRxVqC8I8NuOUjzBbvVJAKNM8qoVuH0O77h4WInc/qC2q5IreqKxYwgkga3PfA22OayK2ikceb/B26dztPl+Q==}
     engines: {node: '>=16'}
 
+  superstruct@2.0.2:
+    resolution: {integrity: sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A==}
+    engines: {node: '>=14.0.0'}
+
   supports-color@5.5.0:
     resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
     engines: {node: '>=4'}
@@ -7642,6 +7949,9 @@ packages:
   text-decoder@1.2.3:
     resolution: {integrity: sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==}
 
+  text-encoding-utf-8@1.0.2:
+    resolution: {integrity: sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg==}
+
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
 
@@ -7744,6 +8054,9 @@ packages:
   tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
 
+  tslib@2.7.0:
+    resolution: {integrity: sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -7759,6 +8072,25 @@ packages:
       postcss: ^8.4.12
       typescript: ^4.1.0
     peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
+        optional: true
+
+  tsup@8.3.6:
+    resolution: {integrity: sha512-XkVtlDV/58S9Ye0JxUUTcrQk4S+EqlOHKzg6Roa62rdjL1nGWNUstG0xgI4vanHdfIpjP448J8vlN0oK6XOJ5g==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
       '@swc/core':
         optional: true
       postcss:
@@ -8117,6 +8449,14 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
+  viem@2.23.13:
+    resolution: {integrity: sha512-f3RkcrzGhU79GfBb9GHUL0m3e3LUsNudXIQTFp4fit5hUGb0ew9KOYZ6cCY5d4Melj3noBy2zq0K2fV+mp+Cpg==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   vite-hot-client@0.2.4:
     resolution: {integrity: sha512-a1nzURqO7DDmnXqabFOliz908FRmIppkBKsJthS8rbe8hBEXwEwe4C3Pp33Z1JoFCYfVL4kTOMLKk0ZZxREIeA==}
     peerDependencies:
@@ -8448,8 +8788,32 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.17.1:
+    resolution: {integrity: sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   ws@8.18.0:
     resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  ws@8.18.1:
+    resolution: {integrity: sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -8519,6 +8883,10 @@ packages:
     engines: {node: '>= 14'}
 
 snapshots:
+
+  '@adraffy/ens-normalize@1.10.1': {}
+
+  '@adraffy/ens-normalize@1.11.0': {}
 
   '@alloc/quick-lru@5.2.0': {}
 
@@ -8686,6 +9054,14 @@ snapshots:
   '@aptos-labs/script-composer-pack@0.0.9':
     dependencies:
       '@aptos-labs/aptos-dynamic-transaction-composer': 0.1.3
+
+  '@aptos-labs/siwa@0.2.5(@aptos-labs/ts-sdk@1.35.0(axios@1.7.9)(got@11.8.6))(@wallet-standard/core@1.1.0)':
+    dependencies:
+      '@aptos-labs/ts-sdk': 1.35.0(axios@1.7.9)(got@11.8.6)
+      '@aptos-labs/wallet-standard': 0.3.0(@aptos-labs/ts-sdk@1.35.0(axios@1.7.9)(got@11.8.6))(@wallet-standard/core@1.1.0)
+      '@noble/hashes': 1.7.1
+    transitivePeerDependencies:
+      - '@wallet-standard/core'
 
   '@aptos-labs/ts-sdk@1.35.0(axios@1.7.9)(got@11.8.6)':
     dependencies:
@@ -9943,6 +10319,15 @@ snapshots:
       '@rushstack/node-core-library': 4.0.2(@types/node@20.17.17)
     transitivePeerDependencies:
       - '@types/node'
+    optional: true
+
+  '@microsoft/api-extractor-model@7.28.13(@types/node@22.7.5)':
+    dependencies:
+      '@microsoft/tsdoc': 0.14.2
+      '@microsoft/tsdoc-config': 0.16.2
+      '@rushstack/node-core-library': 4.0.2(@types/node@22.7.5)
+    transitivePeerDependencies:
+      - '@types/node'
 
   '@microsoft/api-extractor@7.43.0(@types/node@20.17.17)':
     dependencies:
@@ -9953,6 +10338,25 @@ snapshots:
       '@rushstack/rig-package': 0.5.2
       '@rushstack/terminal': 0.10.0(@types/node@20.17.17)
       '@rushstack/ts-command-line': 4.19.1(@types/node@20.17.17)
+      lodash: 4.17.21
+      minimatch: 3.0.8
+      resolve: 1.22.10
+      semver: 7.5.4
+      source-map: 0.6.1
+      typescript: 5.4.2
+    transitivePeerDependencies:
+      - '@types/node'
+    optional: true
+
+  '@microsoft/api-extractor@7.43.0(@types/node@22.7.5)':
+    dependencies:
+      '@microsoft/api-extractor-model': 7.28.13(@types/node@22.7.5)
+      '@microsoft/tsdoc': 0.14.2
+      '@microsoft/tsdoc-config': 0.16.2
+      '@rushstack/node-core-library': 4.0.2(@types/node@22.7.5)
+      '@rushstack/rig-package': 0.5.2
+      '@rushstack/terminal': 0.10.0(@types/node@22.7.5)
+      '@rushstack/ts-command-line': 4.19.1(@types/node@22.7.5)
       lodash: 4.17.21
       minimatch: 3.0.8
       resolve: 1.22.10
@@ -10174,9 +10578,15 @@ snapshots:
   '@next/swc-win32-x64-msvc@14.2.24':
     optional: true
 
+  '@noble/curves@1.2.0':
+    dependencies:
+      '@noble/hashes': 1.3.2
+
   '@noble/curves@1.8.1':
     dependencies:
       '@noble/hashes': 1.7.1
+
+  '@noble/hashes@1.3.2': {}
 
   '@noble/hashes@1.3.3': {}
 
@@ -10228,12 +10638,12 @@ snapshots:
 
   '@nuxt/devalue@2.0.2': {}
 
-  '@nuxt/devtools-kit@1.7.0(magicast@0.3.5)(vite@6.1.0(@types/node@20.17.17)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0))':
+  '@nuxt/devtools-kit@1.7.0(magicast@0.3.5)(vite@6.1.0(@types/node@22.7.5)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0))':
     dependencies:
       '@nuxt/kit': 3.15.4(magicast@0.3.5)
       '@nuxt/schema': 3.15.4
       execa: 7.2.0
-      vite: 6.1.0(@types/node@20.17.17)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0)
+      vite: 6.1.0(@types/node@22.7.5)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0)
     transitivePeerDependencies:
       - magicast
       - supports-color
@@ -10251,13 +10661,13 @@ snapshots:
       rc9: 2.1.2
       semver: 7.7.1
 
-  '@nuxt/devtools@1.7.0(bufferutil@4.0.9)(rollup@4.34.6)(utf-8-validate@5.0.10)(vite@6.1.0(@types/node@20.17.17)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0))(vue@3.5.13(typescript@5.7.3))':
+  '@nuxt/devtools@1.7.0(bufferutil@4.0.9)(rollup@4.34.6)(utf-8-validate@5.0.10)(vite@6.1.0(@types/node@22.7.5)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0))(vue@3.5.13(typescript@5.7.3))':
     dependencies:
       '@antfu/utils': 0.7.10
-      '@nuxt/devtools-kit': 1.7.0(magicast@0.3.5)(vite@6.1.0(@types/node@20.17.17)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0))
+      '@nuxt/devtools-kit': 1.7.0(magicast@0.3.5)(vite@6.1.0(@types/node@22.7.5)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0))
       '@nuxt/devtools-wizard': 1.7.0
       '@nuxt/kit': 3.15.4(magicast@0.3.5)
-      '@vue/devtools-core': 7.6.8(vite@6.1.0(@types/node@20.17.17)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0))(vue@3.5.13(typescript@5.7.3))
+      '@vue/devtools-core': 7.6.8(vite@6.1.0(@types/node@22.7.5)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0))(vue@3.5.13(typescript@5.7.3))
       '@vue/devtools-kit': 7.6.8
       birpc: 0.2.19
       consola: 3.4.0
@@ -10286,9 +10696,9 @@ snapshots:
       sirv: 3.0.0
       tinyglobby: 0.2.10
       unimport: 3.14.6(rollup@4.34.6)
-      vite: 6.1.0(@types/node@20.17.17)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0)
-      vite-plugin-inspect: 0.8.9(@nuxt/kit@3.15.4(magicast@0.3.5))(rollup@4.34.6)(vite@6.1.0(@types/node@20.17.17)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0))
-      vite-plugin-vue-inspector: 5.3.1(vite@6.1.0(@types/node@20.17.17)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0))
+      vite: 6.1.0(@types/node@22.7.5)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0)
+      vite-plugin-inspect: 0.8.9(@nuxt/kit@3.15.4(magicast@0.3.5))(rollup@4.34.6)(vite@6.1.0(@types/node@22.7.5)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0))
+      vite-plugin-vue-inspector: 5.3.1(vite@6.1.0(@types/node@22.7.5)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0))
       which: 3.0.1
       ws: 8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
@@ -10350,12 +10760,12 @@ snapshots:
       - magicast
       - supports-color
 
-  '@nuxt/vite-builder@3.15.4(@types/node@20.17.17)(eslint@8.57.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.34.6)(terser@5.38.1)(typescript@5.7.3)(vue@3.5.13(typescript@5.7.3))(yaml@2.7.0)':
+  '@nuxt/vite-builder@3.15.4(@types/node@22.7.5)(eslint@8.57.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.34.6)(terser@5.38.1)(typescript@5.7.3)(vue@3.5.13(typescript@5.7.3))(yaml@2.7.0)':
     dependencies:
       '@nuxt/kit': 3.15.4(magicast@0.3.5)
       '@rollup/plugin-replace': 6.0.2(rollup@4.34.6)
-      '@vitejs/plugin-vue': 5.2.1(vite@6.1.0(@types/node@20.17.17)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0))(vue@3.5.13(typescript@5.7.3))
-      '@vitejs/plugin-vue-jsx': 4.1.1(vite@6.1.0(@types/node@20.17.17)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0))(vue@3.5.13(typescript@5.7.3))
+      '@vitejs/plugin-vue': 5.2.1(vite@6.1.0(@types/node@22.7.5)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0))(vue@3.5.13(typescript@5.7.3))
+      '@vitejs/plugin-vue-jsx': 4.1.1(vite@6.1.0(@types/node@22.7.5)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0))(vue@3.5.13(typescript@5.7.3))
       autoprefixer: 10.4.20(postcss@8.5.1)
       consola: 3.4.0
       cssnano: 7.0.6(postcss@8.5.1)
@@ -10379,9 +10789,9 @@ snapshots:
       ufo: 1.5.4
       unenv: 1.10.0
       unplugin: 2.1.2
-      vite: 6.1.0(@types/node@20.17.17)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0)
-      vite-node: 3.0.5(@types/node@20.17.17)(terser@5.38.1)
-      vite-plugin-checker: 0.8.0(eslint@8.57.1)(optionator@0.9.4)(typescript@5.7.3)(vite@6.1.0(@types/node@20.17.17)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0))
+      vite: 6.1.0(@types/node@22.7.5)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0)
+      vite-node: 3.0.5(@types/node@22.7.5)(terser@5.38.1)
+      vite-plugin-checker: 0.8.0(eslint@8.57.1)(optionator@0.9.4)(typescript@5.7.3)(vite@6.1.0(@types/node@22.7.5)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0))
       vue: 3.5.13(typescript@5.7.3)
       vue-bundle-renderer: 2.1.1
     transitivePeerDependencies:
@@ -10451,14 +10861,14 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  '@nuxtjs/eslint-module@4.1.0(eslint@8.57.1)(magicast@0.3.5)(vite@6.1.0(@types/node@20.17.17)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0))(webpack@5.97.1)':
+  '@nuxtjs/eslint-module@4.1.0(eslint@8.57.1)(magicast@0.3.5)(vite@6.1.0(@types/node@22.7.5)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0))(webpack@5.97.1)':
     dependencies:
       '@nuxt/kit': 3.15.4(magicast@0.3.5)
       chokidar: 3.6.0
       eslint: 8.57.1
       eslint-webpack-plugin: 4.2.0(eslint@8.57.1)(webpack@5.97.1)
       pathe: 1.1.2
-      vite-plugin-eslint: 1.8.1(eslint@8.57.1)(vite@6.1.0(@types/node@20.17.17)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0))
+      vite-plugin-eslint: 1.8.1(eslint@8.57.1)(vite@6.1.0(@types/node@22.7.5)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0))
     transitivePeerDependencies:
       - magicast
       - supports-color
@@ -11163,6 +11573,18 @@ snapshots:
       z-schema: 5.0.5
     optionalDependencies:
       '@types/node': 20.17.17
+    optional: true
+
+  '@rushstack/node-core-library@4.0.2(@types/node@22.7.5)':
+    dependencies:
+      fs-extra: 7.0.1
+      import-lazy: 4.0.0
+      jju: 1.4.0
+      resolve: 1.22.10
+      semver: 7.5.4
+      z-schema: 5.0.5
+    optionalDependencies:
+      '@types/node': 22.7.5
 
   '@rushstack/rig-package@0.5.2':
     dependencies:
@@ -11175,10 +11597,28 @@ snapshots:
       supports-color: 8.1.1
     optionalDependencies:
       '@types/node': 20.17.17
+    optional: true
+
+  '@rushstack/terminal@0.10.0(@types/node@22.7.5)':
+    dependencies:
+      '@rushstack/node-core-library': 4.0.2(@types/node@22.7.5)
+      supports-color: 8.1.1
+    optionalDependencies:
+      '@types/node': 22.7.5
 
   '@rushstack/ts-command-line@4.19.1(@types/node@20.17.17)':
     dependencies:
       '@rushstack/terminal': 0.10.0(@types/node@20.17.17)
+      '@types/argparse': 1.0.38
+      argparse: 1.0.10
+      string-argv: 0.3.2
+    transitivePeerDependencies:
+      - '@types/node'
+    optional: true
+
+  '@rushstack/ts-command-line@4.19.1(@types/node@22.7.5)':
+    dependencies:
+      '@rushstack/terminal': 0.10.0(@types/node@22.7.5)
       '@types/argparse': 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.2
@@ -11218,6 +11658,68 @@ snapshots:
   '@sinonjs/fake-timers@10.3.0':
     dependencies:
       '@sinonjs/commons': 3.0.1
+
+  '@solana/buffer-layout@4.0.1':
+    dependencies:
+      buffer: 6.0.3
+
+  '@solana/wallet-adapter-base@0.9.23(@solana/web3.js@1.98.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
+    dependencies:
+      '@solana/wallet-standard-features': 1.3.0
+      '@solana/web3.js': 1.98.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      '@wallet-standard/base': 1.1.0
+      '@wallet-standard/features': 1.1.0
+      eventemitter3: 4.0.7
+
+  '@solana/wallet-standard-chains@1.1.1':
+    dependencies:
+      '@wallet-standard/base': 1.1.0
+
+  '@solana/wallet-standard-features@1.3.0':
+    dependencies:
+      '@wallet-standard/base': 1.1.0
+      '@wallet-standard/features': 1.1.0
+
+  '@solana/wallet-standard-util@1.1.2':
+    dependencies:
+      '@noble/curves': 1.8.1
+      '@solana/wallet-standard-chains': 1.1.1
+      '@solana/wallet-standard-features': 1.3.0
+
+  '@solana/wallet-standard-wallet-adapter-base@1.1.4(@solana/web3.js@1.98.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(bs58@4.0.1)':
+    dependencies:
+      '@solana/wallet-adapter-base': 0.9.23(@solana/web3.js@1.98.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@solana/wallet-standard-chains': 1.1.1
+      '@solana/wallet-standard-features': 1.3.0
+      '@solana/wallet-standard-util': 1.1.2
+      '@solana/web3.js': 1.98.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      '@wallet-standard/app': 1.1.0
+      '@wallet-standard/base': 1.1.0
+      '@wallet-standard/features': 1.1.0
+      '@wallet-standard/wallet': 1.1.0
+      bs58: 4.0.1
+
+  '@solana/web3.js@1.98.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@babel/runtime': 7.26.7
+      '@noble/curves': 1.8.1
+      '@noble/hashes': 1.7.1
+      '@solana/buffer-layout': 4.0.1
+      agentkeepalive: 4.6.0
+      bigint-buffer: 1.1.5
+      bn.js: 5.2.1
+      borsh: 0.7.0
+      bs58: 4.0.1
+      buffer: 6.0.3
+      fast-stable-stringify: 1.0.0
+      jayson: 4.1.3(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      node-fetch: 2.7.0
+      rpc-websockets: 9.1.1
+      superstruct: 2.0.2
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - utf-8-validate
 
   '@swc/counter@0.1.3': {}
 
@@ -11394,6 +11896,10 @@ snapshots:
     dependencies:
       undici-types: 6.19.8
 
+  '@types/node@22.7.5':
+    dependencies:
+      undici-types: 6.19.8
+
   '@types/normalize-package-data@2.4.4': {}
 
   '@types/parse-json@4.0.2': {}
@@ -11425,9 +11931,15 @@ snapshots:
 
   '@types/stack-utils@2.0.3': {}
 
+  '@types/uuid@8.3.4': {}
+
   '@types/web-bluetooth@0.0.20': {}
 
   '@types/ws@7.4.7':
+    dependencies:
+      '@types/node': 20.17.17
+
+  '@types/ws@8.18.0':
     dependencies:
       '@types/node': 20.17.17
 
@@ -11650,24 +12162,24 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vitejs/plugin-vue-jsx@4.1.1(vite@6.1.0(@types/node@20.17.17)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0))(vue@3.5.13(typescript@5.7.3))':
+  '@vitejs/plugin-vue-jsx@4.1.1(vite@6.1.0(@types/node@22.7.5)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0))(vue@3.5.13(typescript@5.7.3))':
     dependencies:
       '@babel/core': 7.26.8
       '@babel/plugin-transform-typescript': 7.26.8(@babel/core@7.26.8)
       '@vue/babel-plugin-jsx': 1.2.5(@babel/core@7.26.8)
-      vite: 6.1.0(@types/node@20.17.17)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0)
+      vite: 6.1.0(@types/node@22.7.5)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0)
       vue: 3.5.13(typescript@5.7.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@5.0.5(vite@5.3.6(@types/node@20.17.17)(terser@5.38.1))(vue@3.5.13(typescript@4.9.5))':
+  '@vitejs/plugin-vue@5.0.5(vite@5.3.6(@types/node@22.7.5)(terser@5.38.1))(vue@3.5.13(typescript@4.9.5))':
     dependencies:
-      vite: 5.3.6(@types/node@20.17.17)(terser@5.38.1)
+      vite: 5.3.6(@types/node@22.7.5)(terser@5.38.1)
       vue: 3.5.13(typescript@4.9.5)
 
-  '@vitejs/plugin-vue@5.2.1(vite@6.1.0(@types/node@20.17.17)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0))(vue@3.5.13(typescript@5.7.3))':
+  '@vitejs/plugin-vue@5.2.1(vite@6.1.0(@types/node@22.7.5)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0))(vue@3.5.13(typescript@5.7.3))':
     dependencies:
-      vite: 6.1.0(@types/node@20.17.17)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0)
+      vite: 6.1.0(@types/node@22.7.5)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0)
       vue: 3.5.13(typescript@5.7.3)
 
   '@volar/language-core@1.11.1':
@@ -11773,14 +12285,14 @@ snapshots:
 
   '@vue/devtools-api@6.6.4': {}
 
-  '@vue/devtools-core@7.6.8(vite@6.1.0(@types/node@20.17.17)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0))(vue@3.5.13(typescript@5.7.3))':
+  '@vue/devtools-core@7.6.8(vite@6.1.0(@types/node@22.7.5)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0))(vue@3.5.13(typescript@5.7.3))':
     dependencies:
       '@vue/devtools-kit': 7.6.8
       '@vue/devtools-shared': 7.7.1
       mitt: 3.0.1
       nanoid: 5.0.9
       pathe: 1.1.2
-      vite-hot-client: 0.2.4(vite@6.1.0(@types/node@20.17.17)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0))
+      vite-hot-client: 0.2.4(vite@6.1.0(@types/node@22.7.5)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0))
       vue: 3.5.13(typescript@5.7.3)
     transitivePeerDependencies:
       - vite
@@ -11996,6 +12508,10 @@ snapshots:
 
   abbrev@3.0.0: {}
 
+  abitype@1.0.8(typescript@5.7.3):
+    optionalDependencies:
+      typescript: 5.7.3
+
   abort-controller@3.0.0:
     dependencies:
       event-target-shim: 5.0.1
@@ -12021,7 +12537,13 @@ snapshots:
 
   acorn@8.14.0: {}
 
+  aes-js@4.0.0-beta.5: {}
+
   agent-base@7.1.3: {}
+
+  agentkeepalive@4.6.0:
+    dependencies:
+      humanize-ms: 1.2.1
 
   ajv-formats@2.1.1(ajv@8.17.1):
     optionalDependencies:
@@ -12386,11 +12908,19 @@ snapshots:
   bare-events@2.5.4:
     optional: true
 
+  base-x@3.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
+
   base64-js@1.5.1: {}
 
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
+
+  bigint-buffer@1.1.5:
+    dependencies:
+      bindings: 1.5.0
 
   binary-extensions@2.3.0: {}
 
@@ -12403,6 +12933,12 @@ snapshots:
   bn.js@5.2.1: {}
 
   boolbase@1.0.0: {}
+
+  borsh@0.7.0:
+    dependencies:
+      bn.js: 5.2.1
+      bs58: 4.0.1
+      text-encoding-utf-8: 1.0.2
 
   brace-expansion@1.1.11:
     dependencies:
@@ -12427,6 +12963,10 @@ snapshots:
   bs-logger@0.2.6:
     dependencies:
       fast-json-stable-stringify: 2.1.0
+
+  bs58@4.0.1:
+    dependencies:
+      base-x: 3.0.11
 
   bser@2.1.1:
     dependencies:
@@ -12459,6 +12999,11 @@ snapshots:
   bundle-require@3.1.2(esbuild@0.14.54):
     dependencies:
       esbuild: 0.14.54
+      load-tsconfig: 0.2.5
+
+  bundle-require@5.1.0(esbuild@0.24.2):
+    dependencies:
+      esbuild: 0.24.2
       load-tsconfig: 0.2.5
 
   busboy@1.6.0:
@@ -13857,6 +14402,19 @@ snapshots:
     dependencies:
       fast-safe-stringify: 2.1.1
 
+  ethers@6.13.5(bufferutil@4.0.9)(utf-8-validate@5.0.10):
+    dependencies:
+      '@adraffy/ens-normalize': 1.10.1
+      '@noble/curves': 1.2.0
+      '@noble/hashes': 1.3.2
+      '@types/node': 22.7.5
+      aes-js: 4.0.0-beta.5
+      tslib: 2.7.0
+      ws: 8.17.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   event-target-shim@5.0.1: {}
 
   eventemitter3@4.0.7: {}
@@ -13953,6 +14511,8 @@ snapshots:
   fast-npm-meta@0.2.2: {}
 
   fast-safe-stringify@2.1.1: {}
+
+  fast-stable-stringify@1.0.0: {}
 
   fast-uri@3.0.6: {}
 
@@ -14418,6 +14978,10 @@ snapshots:
 
   human-signals@5.0.0: {}
 
+  humanize-ms@1.2.1:
+    dependencies:
+      ms: 2.1.3
+
   iconv-lite@0.4.24:
     dependencies:
       safer-buffer: 2.1.2
@@ -14679,6 +15243,10 @@ snapshots:
     dependencies:
       ws: 7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)
 
+  isows@1.0.6(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)):
+    dependencies:
+      ws: 8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+
   istanbul-lib-coverage@3.2.2: {}
 
   istanbul-lib-instrument@5.2.1:
@@ -14761,6 +15329,24 @@ snapshots:
       isomorphic-ws: 4.0.1(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       json-stringify-safe: 5.0.1
       lodash: 4.17.21
+      uuid: 8.3.2
+      ws: 7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  jayson@4.1.3(bufferutil@4.0.9)(utf-8-validate@5.0.10):
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/node': 12.20.55
+      '@types/ws': 7.4.7
+      JSONStream: 1.3.5
+      commander: 2.20.3
+      delay: 5.0.0
+      es6-promisify: 5.0.0
+      eyes: 0.1.8
+      isomorphic-ws: 4.0.1(ws@7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      json-stringify-safe: 5.0.1
       uuid: 8.3.2
       ws: 7.5.10(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
@@ -15463,6 +16049,10 @@ snapshots:
       minipass: 7.1.2
       rimraf: 5.0.10
 
+  mipd@0.0.7(typescript@5.7.3):
+    optionalDependencies:
+      typescript: 5.7.3
+
   mitt@3.0.1: {}
 
   mkdirp@0.5.6:
@@ -15685,15 +16275,15 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  nuxt@3.15.4(@parcel/watcher@2.5.1)(@types/node@20.17.17)(bufferutil@4.0.9)(db0@0.2.3)(eslint@8.57.1)(ioredis@5.5.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.34.6)(terser@5.38.1)(typescript@5.7.3)(utf-8-validate@5.0.10)(vite@6.1.0(@types/node@20.17.17)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0))(yaml@2.7.0):
+  nuxt@3.15.4(@parcel/watcher@2.5.1)(@types/node@22.7.5)(bufferutil@4.0.9)(db0@0.2.3)(eslint@8.57.1)(ioredis@5.5.0)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.34.6)(terser@5.38.1)(typescript@5.7.3)(utf-8-validate@5.0.10)(vite@6.1.0(@types/node@22.7.5)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0))(yaml@2.7.0):
     dependencies:
       '@nuxt/cli': 3.21.1(magicast@0.3.5)
       '@nuxt/devalue': 2.0.2
-      '@nuxt/devtools': 1.7.0(bufferutil@4.0.9)(rollup@4.34.6)(utf-8-validate@5.0.10)(vite@6.1.0(@types/node@20.17.17)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0))(vue@3.5.13(typescript@5.7.3))
+      '@nuxt/devtools': 1.7.0(bufferutil@4.0.9)(rollup@4.34.6)(utf-8-validate@5.0.10)(vite@6.1.0(@types/node@22.7.5)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0))(vue@3.5.13(typescript@5.7.3))
       '@nuxt/kit': 3.15.4(magicast@0.3.5)
       '@nuxt/schema': 3.15.4
       '@nuxt/telemetry': 2.6.4(magicast@0.3.5)
-      '@nuxt/vite-builder': 3.15.4(@types/node@20.17.17)(eslint@8.57.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.34.6)(terser@5.38.1)(typescript@5.7.3)(vue@3.5.13(typescript@5.7.3))(yaml@2.7.0)
+      '@nuxt/vite-builder': 3.15.4(@types/node@22.7.5)(eslint@8.57.1)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.34.6)(terser@5.38.1)(typescript@5.7.3)(vue@3.5.13(typescript@5.7.3))(yaml@2.7.0)
       '@unhead/dom': 1.11.18
       '@unhead/shared': 1.11.18
       '@unhead/ssr': 1.11.18
@@ -15753,7 +16343,7 @@ snapshots:
       vue-router: 4.5.0(vue@3.5.13(typescript@5.7.3))
     optionalDependencies:
       '@parcel/watcher': 2.5.1
-      '@types/node': 20.17.17
+      '@types/node': 22.7.5
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -15946,6 +16536,20 @@ snapshots:
       get-intrinsic: 1.2.7
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
+
+  ox@0.6.9(typescript@5.7.3):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.0
+      '@noble/curves': 1.8.1
+      '@noble/hashes': 1.7.1
+      '@scure/bip32': 1.6.2
+      '@scure/bip39': 1.5.4
+      abitype: 1.0.8(typescript@5.7.3)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - zod
 
   p-cancelable@2.1.1: {}
 
@@ -16145,6 +16749,14 @@ snapshots:
       yaml: 2.7.0
     optionalDependencies:
       postcss: 8.5.1
+
+  postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.1)(yaml@2.7.0):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      jiti: 2.4.2
+      postcss: 8.5.1
+      yaml: 2.7.0
 
   postcss-merge-longhand@7.0.4(postcss@8.5.1):
     dependencies:
@@ -16959,6 +17571,19 @@ snapshots:
       bufferutil: 4.0.9
       utf-8-validate: 5.0.10
 
+  rpc-websockets@9.1.1:
+    dependencies:
+      '@swc/helpers': 0.5.15
+      '@types/uuid': 8.3.4
+      '@types/ws': 8.18.0
+      buffer: 6.0.3
+      eventemitter3: 5.0.1
+      uuid: 8.3.2
+      ws: 8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+    optionalDependencies:
+      bufferutil: 4.0.9
+      utf-8-validate: 5.0.10
+
   run-applescript@7.0.0: {}
 
   run-parallel@1.2.0:
@@ -17374,6 +17999,8 @@ snapshots:
     dependencies:
       copy-anything: 3.0.5
 
+  superstruct@2.0.2: {}
+
   supports-color@5.5.0:
     dependencies:
       has-flag: 3.0.0
@@ -17513,6 +18140,8 @@ snapshots:
     dependencies:
       b4a: 1.6.7
 
+  text-encoding-utf-8@1.0.2: {}
+
   text-table@0.2.0: {}
 
   thenify-all@1.6.0:
@@ -17570,6 +18199,26 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
+  ts-jest@29.2.5(@babel/core@7.26.8)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.8))(esbuild@0.24.2)(jest@29.7.0(@types/node@20.17.17)(babel-plugin-macros@3.1.0))(typescript@5.7.3):
+    dependencies:
+      bs-logger: 0.2.6
+      ejs: 3.1.10
+      fast-json-stable-stringify: 2.1.0
+      jest: 29.7.0(@types/node@20.17.17)(babel-plugin-macros@3.1.0)
+      jest-util: 29.7.0
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.7.1
+      typescript: 5.7.3
+      yargs-parser: 21.1.1
+    optionalDependencies:
+      '@babel/core': 7.26.8
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.26.8)
+      esbuild: 0.24.2
+
   ts-jest@29.2.5(@babel/core@7.26.8)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.8))(jest@29.7.0(@types/node@20.17.17)(babel-plugin-macros@3.1.0))(typescript@4.9.5):
     dependencies:
       bs-logger: 0.2.6
@@ -17598,6 +18247,8 @@ snapshots:
 
   tslib@1.14.1: {}
 
+  tslib@2.7.0: {}
+
   tslib@2.8.1: {}
 
   tsscmp@1.0.6: {}
@@ -17624,6 +18275,34 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - ts-node
+
+  tsup@8.3.6(@microsoft/api-extractor@7.43.0(@types/node@20.17.17))(jiti@2.4.2)(postcss@8.5.1)(typescript@5.7.3)(yaml@2.7.0):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.24.2)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.0
+      debug: 4.4.0(supports-color@9.4.0)
+      esbuild: 0.24.2
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(jiti@2.4.2)(postcss@8.5.1)(yaml@2.7.0)
+      resolve-from: 5.0.0
+      rollup: 4.34.6
+      source-map: 0.8.0-beta.0
+      sucrase: 3.35.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.10
+      tree-kill: 1.2.2
+    optionalDependencies:
+      '@microsoft/api-extractor': 7.43.0(@types/node@20.17.17)
+      postcss: 8.5.1
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
 
   tsutils@3.21.0(typescript@4.9.5):
     dependencies:
@@ -17967,17 +18646,34 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite-hot-client@0.2.4(vite@6.1.0(@types/node@20.17.17)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0)):
+  viem@2.23.13(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10):
     dependencies:
-      vite: 6.1.0(@types/node@20.17.17)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0)
+      '@noble/curves': 1.8.1
+      '@noble/hashes': 1.7.1
+      '@scure/bip32': 1.6.2
+      '@scure/bip39': 1.5.4
+      abitype: 1.0.8(typescript@5.7.3)
+      isows: 1.0.6(ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      ox: 0.6.9(typescript@5.7.3)
+      ws: 8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+    optionalDependencies:
+      typescript: 5.7.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
 
-  vite-node@3.0.5(@types/node@20.17.17)(terser@5.38.1):
+  vite-hot-client@0.2.4(vite@6.1.0(@types/node@22.7.5)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0)):
+    dependencies:
+      vite: 6.1.0(@types/node@22.7.5)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0)
+
+  vite-node@3.0.5(@types/node@22.7.5)(terser@5.38.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0(supports-color@9.4.0)
       es-module-lexer: 1.6.0
       pathe: 2.0.2
-      vite: 5.3.6(@types/node@20.17.17)(terser@5.38.1)
+      vite: 5.3.6(@types/node@22.7.5)(terser@5.38.1)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -17988,7 +18684,7 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-checker@0.8.0(eslint@8.57.1)(optionator@0.9.4)(typescript@5.7.3)(vite@6.1.0(@types/node@20.17.17)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0)):
+  vite-plugin-checker@0.8.0(eslint@8.57.1)(optionator@0.9.4)(typescript@5.7.3)(vite@6.1.0(@types/node@22.7.5)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0)):
     dependencies:
       '@babel/code-frame': 7.26.2
       ansi-escapes: 4.3.2
@@ -18000,7 +18696,7 @@ snapshots:
       npm-run-path: 4.0.1
       strip-ansi: 6.0.1
       tiny-invariant: 1.3.3
-      vite: 6.1.0(@types/node@20.17.17)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0)
+      vite: 6.1.0(@types/node@22.7.5)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0)
       vscode-languageclient: 7.0.0
       vscode-languageserver: 7.0.0
       vscode-languageserver-textdocument: 1.0.12
@@ -18010,22 +18706,22 @@ snapshots:
       optionator: 0.9.4
       typescript: 5.7.3
 
-  vite-plugin-compression@0.5.1(vite@5.3.6(@types/node@20.17.17)(terser@5.38.1)):
+  vite-plugin-compression@0.5.1(vite@5.3.6(@types/node@22.7.5)(terser@5.38.1)):
     dependencies:
       chalk: 4.1.2
       debug: 4.4.0(supports-color@9.4.0)
       fs-extra: 10.1.0
-      vite: 5.3.6(@types/node@20.17.17)(terser@5.38.1)
+      vite: 5.3.6(@types/node@22.7.5)(terser@5.38.1)
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-css-injected-by-js@3.5.2(vite@5.3.6(@types/node@20.17.17)(terser@5.38.1)):
+  vite-plugin-css-injected-by-js@3.5.2(vite@5.3.6(@types/node@22.7.5)(terser@5.38.1)):
     dependencies:
-      vite: 5.3.6(@types/node@20.17.17)(terser@5.38.1)
+      vite: 5.3.6(@types/node@22.7.5)(terser@5.38.1)
 
-  vite-plugin-dts@3.9.1(@types/node@20.17.17)(rollup@4.34.6)(typescript@4.9.5)(vite@5.3.6(@types/node@20.17.17)(terser@5.38.1)):
+  vite-plugin-dts@3.9.1(@types/node@22.7.5)(rollup@4.34.6)(typescript@4.9.5)(vite@5.3.6(@types/node@22.7.5)(terser@5.38.1)):
     dependencies:
-      '@microsoft/api-extractor': 7.43.0(@types/node@20.17.17)
+      '@microsoft/api-extractor': 7.43.0(@types/node@22.7.5)
       '@rollup/pluginutils': 5.1.4(rollup@4.34.6)
       '@vue/language-core': 1.8.27(typescript@4.9.5)
       debug: 4.4.0(supports-color@9.4.0)
@@ -18034,21 +18730,21 @@ snapshots:
       typescript: 4.9.5
       vue-tsc: 1.8.27(typescript@4.9.5)
     optionalDependencies:
-      vite: 5.3.6(@types/node@20.17.17)(terser@5.38.1)
+      vite: 5.3.6(@types/node@22.7.5)(terser@5.38.1)
     transitivePeerDependencies:
       - '@types/node'
       - rollup
       - supports-color
 
-  vite-plugin-eslint@1.8.1(eslint@8.57.1)(vite@6.1.0(@types/node@20.17.17)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0)):
+  vite-plugin-eslint@1.8.1(eslint@8.57.1)(vite@6.1.0(@types/node@22.7.5)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0)):
     dependencies:
       '@rollup/pluginutils': 4.2.1
       '@types/eslint': 8.56.12
       eslint: 8.57.1
       rollup: 2.79.2
-      vite: 6.1.0(@types/node@20.17.17)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0)
+      vite: 6.1.0(@types/node@22.7.5)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0)
 
-  vite-plugin-inspect@0.8.9(@nuxt/kit@3.15.4(magicast@0.3.5))(rollup@4.34.6)(vite@6.1.0(@types/node@20.17.17)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0)):
+  vite-plugin-inspect@0.8.9(@nuxt/kit@3.15.4(magicast@0.3.5))(rollup@4.34.6)(vite@6.1.0(@types/node@22.7.5)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0)):
     dependencies:
       '@antfu/utils': 0.7.10
       '@rollup/pluginutils': 5.1.4(rollup@4.34.6)
@@ -18059,14 +18755,14 @@ snapshots:
       perfect-debounce: 1.0.0
       picocolors: 1.1.1
       sirv: 3.0.0
-      vite: 6.1.0(@types/node@20.17.17)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0)
+      vite: 6.1.0(@types/node@22.7.5)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0)
     optionalDependencies:
       '@nuxt/kit': 3.15.4(magicast@0.3.5)
     transitivePeerDependencies:
       - rollup
       - supports-color
 
-  vite-plugin-vue-inspector@5.3.1(vite@6.1.0(@types/node@20.17.17)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0)):
+  vite-plugin-vue-inspector@5.3.1(vite@6.1.0(@types/node@22.7.5)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0)):
     dependencies:
       '@babel/core': 7.26.8
       '@babel/plugin-proposal-decorators': 7.25.9(@babel/core@7.26.8)
@@ -18077,27 +18773,27 @@ snapshots:
       '@vue/compiler-dom': 3.5.13
       kolorist: 1.8.0
       magic-string: 0.30.17
-      vite: 6.1.0(@types/node@20.17.17)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0)
+      vite: 6.1.0(@types/node@22.7.5)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0)
     transitivePeerDependencies:
       - supports-color
 
-  vite@5.3.6(@types/node@20.17.17)(terser@5.38.1):
+  vite@5.3.6(@types/node@22.7.5)(terser@5.38.1):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.1
       rollup: 4.34.6
     optionalDependencies:
-      '@types/node': 20.17.17
+      '@types/node': 22.7.5
       fsevents: 2.3.3
       terser: 5.38.1
 
-  vite@6.1.0(@types/node@20.17.17)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0):
+  vite@6.1.0(@types/node@22.7.5)(jiti@2.4.2)(terser@5.38.1)(yaml@2.7.0):
     dependencies:
       esbuild: 0.24.2
       postcss: 8.5.1
       rollup: 4.34.6
     optionalDependencies:
-      '@types/node': 20.17.17
+      '@types/node': 22.7.5
       fsevents: 2.3.3
       jiti: 2.4.2
       terser: 5.38.1
@@ -18332,7 +19028,17 @@ snapshots:
       bufferutil: 4.0.9
       utf-8-validate: 5.0.10
 
+  ws@8.17.1(bufferutil@4.0.9)(utf-8-validate@5.0.10):
+    optionalDependencies:
+      bufferutil: 4.0.9
+      utf-8-validate: 5.0.10
+
   ws@8.18.0(bufferutil@4.0.9)(utf-8-validate@5.0.10):
+    optionalDependencies:
+      bufferutil: 4.0.9
+      utf-8-validate: 5.0.10
+
+  ws@8.18.1(bufferutil@4.0.9)(utf-8-validate@5.0.10):
     optionalDependencies:
       bufferutil: 4.0.9
       utf-8-validate: 5.0.10


### PR DESCRIPTION
Implementation of `SolanaDerivedWallet` and `EIP1193DerivedWallet` (Ethereum).

## `derived-wallet-base`
Contains common code used in all derived wallets packages:
- parsing of Aptos signing messages (useful for veryfing messages with abstract public keys)
- format definition and encoding/decoding of StructuredMessage

some of this code could be moved in the wallet-standard repo.

## `derived-wallet-ethereum`
Contains an `EIP1193DerivedWallet` that adapts an `EIP6963ProviderDetail` into a fully functional `AptosWallet`.

See [EIP-1193](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1193.md) (wallet provider) and [EIP-6963](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-6963.md) (wallet discovery) for more information.

It also exports `setupAutomaticEthereumWalletDerivation` that leverages EIP-6963 and the [mipd library](https://github.com/wevm/mipd) for wallet discovery, and registers an `EIP1193DerivedWallet` whenever a new EIP1193-compatible wallet is discovered.

We use [Sign In with Ethereum](https://docs.login.xyz/) (SIWE) for signing messages and transactions, as other message signature methods are not verified by the wallet. We can't show simulations for Aptos transactions on non-Aptos wallets, at the very least we want the dapp's domain and other details to be verified.
A module called `createSiweMessageFromAptos` provides ways to convert a structured message or transaction into a SIWE message that contains human-readable information about the signature input.

## `derived-wallet-solana`
Contains `SolanaDerivedWallet` that adapts a `SolanaWalletAdapter` from `@solana/wallet-standard-wallet-adapter-base` into a fully functional `AptosWallet`.

It also exports `setupAutomaticSolanaWalletDerivation` function that leverages solana's wallet discovery and registers a `SolanaDerivedWallet` whenever a new wallet is detected.

Just like mentioned above for Ethereum, we are using Sign in with Solana (SIWS) for signatures to provide signature input verification, that would otherwise not be possible with the basic `signMessage`. 
A module called `createSiwsMessageFromAptos` provides ways to convert aptos signature inputs to SIWS messages that include human-readable information about the input.

## Some notes

Things that could be improved:
- Nightly doesn't handle line breaks in the message. The displayed message is not very nice.
- Phantom does handle line breaks, but there's no automatic wrapping, so the overflow is just hidden and we need to expand the prompt

## Todos (upcoming PRs)
- [ ] Decide on a good format for displaying transaction info in human-readable but also concise way.
- [ ] Write example on how to use derived wallets for cross-chain needs

## Demos

Phantom (Solana):
- Fully functional
- Message is formatted as expected
- Does not emit events when switching active account

https://github.com/user-attachments/assets/17a885fa-4866-4141-9cca-738c61080a1f

Nightly (Solana):
- `solana:signIn` not implemented, can't sign with derived wallet
- Emits events when the active account is switched
- Doesn't emit when account is disconnected from the wallet

https://github.com/user-attachments/assets/49da51a1-f5e3-4135-90c4-da8a5fc0ed35

Metamask (Ethereum):
- Fully functional
- Emits events when connected accounts are changed (including full disconnect)
- No native concept of "active account", we consider the first connected account as active

https://github.com/user-attachments/assets/58b99de1-a7e2-4ac5-950a-b8aa65ebd16e

Nightly (Ethereum):
- Fully functional
- Emits events when the active account is switched
- Doesn't emit when account is disconnected from the wallet
- Newlines are skipped in the message, formatting is not great

https://github.com/user-attachments/assets/9f2bdc62-d1c0-4da2-938c-b73d77576908




