### PR TITLE
[core] Fix `connect` when not approved

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,6 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
+  "privatePackages": false,
   "ignore": []
 }

--- a/.changeset/six-roses-fail.md
+++ b/.changeset/six-roses-fail.md
@@ -1,0 +1,8 @@
+---
+"@aptos-labs/wallet-adapter-ant-design": patch
+"@aptos-labs/wallet-adapter-mui-design": patch
+"@aptos-labs/wallet-adapter-react": patch
+"@aptos-labs/wallet-adapter-core": patch
+---
+
+Allow users to perform connections when the wallet is `_connected` but `_account` is `null`

--- a/packages/wallet-adapter-core/src/WalletCore.ts
+++ b/packages/wallet-adapter-core/src/WalletCore.ts
@@ -516,7 +516,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
     if (!selectedWallet) return;
 
     // Check if wallet is already connected
-    if (this._connected) {
+    if (this._connected && this._account) {
       // if the selected wallet is already connected, we don't need to connect again
       if (this._wallet?.name === walletName)
         throw new WalletConnectionError(


### PR DESCRIPTION
### Description

Allow users to `connect` to the wallet whenever they are "connected" but "unapproved"

### Test

1. Connect with Account A and approve the dapp
2. Switch to Account B (should be unapproved)
3. Try to connect again with Account B (should show prompt)