### PR TITLE
[derived-wallet-solana] Improvements and modularization

### DIFF
--- a/.changeset/large-plums-jog.md
+++ b/.changeset/large-plums-jog.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/derived-wallet-solana": patch
+---
+
+Extracted `signAptosTransactionWithSolana` and `signAptosStructuredMessageWithSolana`

--- a/packages/derived-wallet-solana/src/SolanaDerivedPublicKey.ts
+++ b/packages/derived-wallet-solana/src/SolanaDerivedPublicKey.ts
@@ -11,10 +11,9 @@ import {
 } from '@aptos-labs/ts-sdk';
 import { createSignInMessage } from '@solana/wallet-standard-util';
 import { PublicKey as SolanaPublicKey } from '@solana/web3.js';
-import {
-  createSiwsInputFromAptosStructuredMessage,
-  createSiwsInputFromAptosTransaction,
-} from './createSiwsMessageFromAptos';
+import { createSiwsEnvelopeForAptosStructuredMessage } from './createSiwsEnvelopeForStructuredMessage';
+import { createSiwsEnvelopeForAptosTransaction } from './createSiwsEnvelopeForTransaction';
+
 
 export interface SolanaDerivedPublicKeyParams {
   domain: string;
@@ -61,11 +60,11 @@ export class SolanaDerivedPublicKey extends AccountPublicKey {
     }
 
     const siwsInput = parsed.type === 'structuredMessage'
-      ? createSiwsInputFromAptosStructuredMessage({
+      ? createSiwsEnvelopeForAptosStructuredMessage({
         solanaPublicKey: this.solanaPublicKey,
         structuredMessage: parsed.structuredMessage,
       })
-      : createSiwsInputFromAptosTransaction({
+      : createSiwsEnvelopeForAptosTransaction({
         solanaPublicKey: this.solanaPublicKey,
         aptosAddress: this._authKey.derivedAddress(),
         rawTransaction: parsed.rawTransaction,

--- a/packages/derived-wallet-solana/src/createSiwsEnvelopeForStructuredMessage.ts
+++ b/packages/derived-wallet-solana/src/createSiwsEnvelopeForStructuredMessage.ts
@@ -1,21 +1,20 @@
 import { aptosChainIdToNetwork, encodeStructuredMessage, StructuredMessage } from '@aptos-labs/derived-wallet-base';
-import {
-  AccountAddressInput,
-  AnyRawTransaction,
-  generateSigningMessageForTransaction,
-  hashValues,
-  Hex,
-} from '@aptos-labs/ts-sdk';
+import { hashValues, Hex } from '@aptos-labs/ts-sdk';
 import { SolanaSignInInputWithRequiredFields } from '@solana/wallet-standard-util';
 import { PublicKey as SolanaPublicKey } from '@solana/web3.js';
 
-export interface CreateSiwsMessageFromAptosStructuredMessageInput {
+export interface CreateSiwsEnvelopeForAptosStructuredMessageInput {
   solanaPublicKey: SolanaPublicKey;
   structuredMessage: StructuredMessage;
 }
 
-export function createSiwsInputFromAptosStructuredMessage(
-  input: CreateSiwsMessageFromAptosStructuredMessageInput,
+/**
+ * Create a SIWS envelope for an Aptos structured message.
+ * A signature on the Solana blockchain by `solanaPublicKey` will be
+ * considered as valid signature on the Aptos blockchain for the provided message.
+ */
+export function createSiwsEnvelopeForAptosStructuredMessage(
+  input: CreateSiwsEnvelopeForAptosStructuredMessageInput,
 ): SolanaSignInInputWithRequiredFields {
   const { solanaPublicKey, structuredMessage } = input;
   const {
@@ -46,45 +45,6 @@ export function createSiwsInputFromAptosStructuredMessage(
   const messageHash = hashValues([encodedMessage]);
   // TODO: consider using b58 or b64 instead
   const requestId = Hex.fromHexInput(messageHash).toStringWithoutPrefix();
-
-  return {
-    address: solanaPublicKey.toString(),
-    domain: window.location.host,
-    uri: window.location.origin,
-    nonce,
-    requestId,
-    statement,
-    version: '1',
-  };
-}
-
-export interface CreateSiwsMessageFromAptosTransaction {
-  solanaPublicKey: SolanaPublicKey;
-  aptosAddress: AccountAddressInput;
-  rawTransaction: AnyRawTransaction;
-}
-
-export function createSiwsInputFromAptosTransaction(
-  input: CreateSiwsMessageFromAptosTransaction,
-): SolanaSignInInputWithRequiredFields {
-  const { solanaPublicKey, aptosAddress, rawTransaction } = input;
-  const signingMessage = generateSigningMessageForTransaction(rawTransaction);
-  const messageHash = hashValues([signingMessage]);
-  const messageHashHex = Hex.fromHexInput(messageHash).toStringWithoutPrefix();
-
-  // TODO: consider using b58 or b64 instead
-  const requestId = messageHashHex;
-  const nonce = messageHashHex;
-
-  const chainId = rawTransaction.rawTransaction.chain_id.chainId;
-
-  // Attempt to convert chainId into a human-readable identifier
-  const networkId = aptosChainIdToNetwork(chainId) ?? `chainId: ${chainId}`;
-
-  const onAptosNetwork = ` on Aptos (${networkId})`;
-  const asAccount = ` with account ${aptosAddress.toString()}`;
-  // TODO: define a good way to display the transaction
-  const statement = `Sign the following transaction${onAptosNetwork}${asAccount}: TODO`;
 
   return {
     address: solanaPublicKey.toString(),

--- a/packages/derived-wallet-solana/src/createSiwsEnvelopeForTransaction.ts
+++ b/packages/derived-wallet-solana/src/createSiwsEnvelopeForTransaction.ts
@@ -1,0 +1,54 @@
+import { aptosChainIdToNetwork, encodeStructuredMessage, StructuredMessage } from '@aptos-labs/derived-wallet-base';
+import {
+  AccountAddressInput,
+  AnyRawTransaction,
+  generateSigningMessageForTransaction,
+  hashValues,
+  Hex,
+} from '@aptos-labs/ts-sdk';
+import { SolanaSignInInputWithRequiredFields } from '@solana/wallet-standard-util';
+import { PublicKey as SolanaPublicKey } from '@solana/web3.js';
+
+export interface CreateSiwsEnvelopeForAptosTransactionInput {
+  solanaPublicKey: SolanaPublicKey;
+  aptosAddress: AccountAddressInput;
+  rawTransaction: AnyRawTransaction;
+}
+
+/**
+ * Create a SIWS envelope for an Aptos transaction.
+ * A signature on the Solana blockchain by `solanaPublicKey` will be
+ * considered as valid signature on the Aptos blockchain for the provided transaction.
+ */
+export function createSiwsEnvelopeForAptosTransaction(
+  input: CreateSiwsEnvelopeForAptosTransactionInput,
+): SolanaSignInInputWithRequiredFields {
+  const { solanaPublicKey, aptosAddress, rawTransaction } = input;
+  const signingMessage = generateSigningMessageForTransaction(rawTransaction);
+  const messageHash = hashValues([signingMessage]);
+  const messageHashHex = Hex.fromHexInput(messageHash).toStringWithoutPrefix();
+
+  // TODO: consider using b58 or b64 instead
+  const requestId = messageHashHex;
+  const nonce = messageHashHex;
+
+  const chainId = rawTransaction.rawTransaction.chain_id.chainId;
+
+  // Attempt to convert chainId into a human-readable identifier
+  const networkId = aptosChainIdToNetwork(chainId) ?? `chainId: ${chainId}`;
+
+  const onAptosNetwork = ` on Aptos (${networkId})`;
+  const asAccount = ` with account ${aptosAddress.toString()}`;
+  // TODO: define a good way to display the transaction
+  const statement = `Sign the following transaction${onAptosNetwork}${asAccount}: TODO`;
+
+  return {
+    address: solanaPublicKey.toString(),
+    domain: window.location.host,
+    uri: window.location.origin,
+    nonce,
+    requestId,
+    statement,
+    version: '1',
+  };
+}

--- a/packages/derived-wallet-solana/src/extendSolanaWallet.ts
+++ b/packages/derived-wallet-solana/src/extendSolanaWallet.ts
@@ -1,0 +1,52 @@
+import { AccountAuthenticator, AnyRawTransaction } from '@aptos-labs/ts-sdk';
+import { AptosSignMessageOutput, UserResponse } from '@aptos-labs/wallet-standard';
+import { StandardWalletAdapter as SolanaWalletAdapter } from "@solana/wallet-standard-wallet-adapter-base";
+import { PublicKey as SolanaPublicKey } from '@solana/web3.js';
+import { defaultAuthenticationFunction } from './shared';
+import { signAptosMessageWithSolana, StructuredMessageInputWithChainId } from './signAptosMessage';
+import { signAptosTransactionWithSolana } from './signAptosTransaction';
+import { SolanaDerivedPublicKey } from './SolanaDerivedPublicKey';
+
+export type SolanaWalletAdapterWithAptosFeatures = SolanaWalletAdapter & {
+  getAptosPublicKey: (solanaPublicKey: SolanaPublicKey) => SolanaDerivedPublicKey;
+  signAptosTransaction: (rawTransaction: AnyRawTransaction) => Promise<UserResponse<AccountAuthenticator>>;
+  signAptosMessage: (input: StructuredMessageInputWithChainId) => Promise<UserResponse<AptosSignMessageOutput>>;
+};
+
+/**
+ * Utility function for extending a SolanaWalletAdapter with Aptos features.
+ * @param solanaWallet the source wallet adapter
+ * @param authenticationFunction authentication function required for DAA
+ *
+ * @example
+ * ```typescript
+ * const extendedWallet = extendSolanaWallet(solanaWallet, authenticationFunction);
+ *
+ * const solanaSignature = await extendedWallet.signTransaction(solanaTransaction);
+ * const aptosSignature = await extendedWallet.signAptosTransaction(aptosRawTransaction);
+ * ```
+ */
+export function extendSolanaWallet(
+  solanaWallet: SolanaWalletAdapter,
+  authenticationFunction = defaultAuthenticationFunction,
+) {
+  const extended = solanaWallet as SolanaWalletAdapterWithAptosFeatures;
+  extended.getAptosPublicKey = (solanaPublicKey: SolanaPublicKey) => new SolanaDerivedPublicKey({
+    solanaPublicKey,
+    domain: window.location.origin,
+    authenticationFunction,
+  });
+  extended.signAptosTransaction = (rawTransaction: AnyRawTransaction) => signAptosTransactionWithSolana({
+    solanaWallet,
+    authenticationFunction,
+    rawTransaction,
+  });
+  extended.signAptosMessage = (messageInput) => {
+    return signAptosMessageWithSolana({
+      solanaWallet,
+      authenticationFunction,
+      messageInput,
+    });
+  }
+  return extended;
+}

--- a/packages/derived-wallet-solana/src/index.ts
+++ b/packages/derived-wallet-solana/src/index.ts
@@ -1,3 +1,5 @@
 export * from './setupAutomaticDerivation';
+export * from './signAptosMessage';
+export * from './signAptosTransaction';
 export * from './SolanaDerivedPublicKey';
 export * from './SolanaDerivedWallet';

--- a/packages/derived-wallet-solana/src/shared.ts
+++ b/packages/derived-wallet-solana/src/shared.ts
@@ -1,0 +1,21 @@
+import { makeUserApproval, makeUserRejection } from '@aptos-labs/derived-wallet-base';
+import { UserResponse } from '@aptos-labs/wallet-standard';
+import { WalletError } from '@solana/wallet-adapter-base';
+
+export const defaultAuthenticationFunction = '0x7::solana::authenticate';
+
+/**
+ * Adapt SolanaWalletAdapter response into a UserResponse.
+ * `WalletError` will be converted into a rejection.
+ */
+export async function wrapSolanaUserResponse<TResponse>(promise: Promise<TResponse>): Promise<UserResponse<TResponse>> {
+  try {
+    const response = await promise;
+    return makeUserApproval(response);
+  } catch (err) {
+    if (err instanceof WalletError && err.message === 'User rejected the request.') {
+      return makeUserRejection();
+    }
+    throw err;
+  }
+}

--- a/packages/derived-wallet-solana/src/signAptosMessage.ts
+++ b/packages/derived-wallet-solana/src/signAptosMessage.ts
@@ -1,0 +1,80 @@
+import {
+  encodeStructuredMessage,
+  mapUserResponse,
+  StructuredMessage,
+  StructuredMessageInput,
+} from '@aptos-labs/derived-wallet-base';
+import { Ed25519Signature } from '@aptos-labs/ts-sdk';
+import { AptosSignMessageOutput } from '@aptos-labs/wallet-standard';
+import { StandardWalletAdapter as SolanaWalletAdapter } from "@solana/wallet-standard-wallet-adapter-base";
+import { createSiwsEnvelopeForAptosStructuredMessage } from './createSiwsEnvelopeForStructuredMessage';
+import { wrapSolanaUserResponse } from './shared';
+import { SolanaDerivedPublicKey } from './SolanaDerivedPublicKey';
+
+export interface StructuredMessageInputWithChainId extends StructuredMessageInput {
+  chainId?: number;
+}
+
+export interface SignAptosMessageWithSolanaInput {
+  solanaWallet: SolanaWalletAdapter;
+  authenticationFunction: string;
+  messageInput: StructuredMessageInputWithChainId;
+}
+
+export async function signAptosMessageWithSolana(input: SignAptosMessageWithSolanaInput) {
+  const { solanaWallet, authenticationFunction, messageInput } = input;
+
+  if (!solanaWallet.signIn) {
+    throw new Error('solana:signIn not available');
+  }
+
+  const solanaPublicKey = solanaWallet.publicKey;
+  if (!solanaPublicKey) {
+    throw new Error('Account not connected');
+  }
+
+  const aptosPublicKey = new SolanaDerivedPublicKey({
+    domain: window.location.origin,
+    solanaPublicKey,
+    authenticationFunction,
+  });
+
+  const { message, nonce, chainId, ...flags } = messageInput;
+  const aptosAddress = flags.address ? aptosPublicKey.authKey().derivedAddress() : undefined;
+  const application = flags.application ? window.location.origin : undefined;
+  const structuredMessage: StructuredMessage = {
+    address: aptosAddress?.toString(),
+    application,
+    chainId,
+    message,
+    nonce,
+  };
+
+  const siwsInput = createSiwsEnvelopeForAptosStructuredMessage({
+    solanaPublicKey: aptosPublicKey.solanaPublicKey,
+    structuredMessage,
+  })
+
+  const response = await wrapSolanaUserResponse(solanaWallet.signIn(siwsInput));
+
+  return mapUserResponse(response, (output): AptosSignMessageOutput => {
+    if (output.signatureType && output.signatureType !== 'ed25519') {
+      throw new Error('Unsupported signature type');
+    }
+
+    // The wallet might change some of the fields in the SIWS input, so we
+    // might need to include the finalized input in the signature.
+    // For now, we can assume the input is unchanged.
+    const signature = new Ed25519Signature(output.signature);
+    const fullMessageBytes = encodeStructuredMessage(structuredMessage);
+    const fullMessage = new TextDecoder().decode(fullMessageBytes);
+
+    return {
+      prefix: 'APTOS',
+      fullMessage,
+      message,
+      nonce,
+      signature,
+    };
+  });
+}

--- a/packages/derived-wallet-solana/src/signAptosTransaction.ts
+++ b/packages/derived-wallet-solana/src/signAptosTransaction.ts
@@ -1,0 +1,61 @@
+import { mapUserResponse } from '@aptos-labs/derived-wallet-base';
+import {
+  AccountAuthenticator,
+  AccountAuthenticatorAbstraction,
+  AnyRawTransaction,
+  Ed25519Signature,
+} from '@aptos-labs/ts-sdk';
+import { StandardWalletAdapter as SolanaWalletAdapter } from "@solana/wallet-standard-wallet-adapter-base";
+import { createSiwsEnvelopeForAptosTransaction } from './createSiwsEnvelopeForTransaction';
+import { wrapSolanaUserResponse } from './shared';
+import { SolanaDerivedPublicKey } from './SolanaDerivedPublicKey';
+
+export interface SignAptosTransactionWithSolanaInput {
+  solanaWallet: SolanaWalletAdapter,
+  authenticationFunction: string,
+  rawTransaction: AnyRawTransaction,
+}
+
+export async function signAptosTransactionWithSolana(input: SignAptosTransactionWithSolanaInput) {
+  const { solanaWallet, authenticationFunction, rawTransaction } = input;
+  if (!solanaWallet.signIn) {
+    throw new Error('solana:signIn not available');
+  }
+
+  const solanaPublicKey = solanaWallet.publicKey;
+  if (!solanaPublicKey) {
+    throw new Error('Account not connected');
+  }
+
+  const aptosPublicKey = new SolanaDerivedPublicKey({
+    domain: window.location.origin,
+    solanaPublicKey,
+    authenticationFunction,
+  });
+  const aptosAddress = aptosPublicKey.authKey().derivedAddress();
+
+  const siwsInput = createSiwsEnvelopeForAptosTransaction({
+    solanaPublicKey,
+    aptosAddress,
+    rawTransaction,
+  });
+
+  const response = await wrapSolanaUserResponse(solanaWallet.signIn!(siwsInput));
+
+  return mapUserResponse(response, (output): AccountAuthenticator => {
+    if (output.signatureType && output.signatureType !== 'ed25519') {
+      throw new Error('Unsupported signature type');
+    }
+
+    // The wallet might change some of the fields in the SIWS input, so we
+    // might need to include the finalized input in the signature.
+    // For now, we can assume the input is unchanged.
+    const signature = new Ed25519Signature(output.signature);
+    return new AccountAuthenticatorAbstraction(
+      authenticationFunction,
+      // Not sure what the expected value is here
+      output.signedMessage,
+      signature.bcsToBytes(),
+    );
+  });
+}


### PR DESCRIPTION
Added some minor changes to the Solana package:

- renamed `createSiwsMessageFrom*` to `createSiwsEnvelopeFor*` and added comments to make it more obvious what the purpose of using SIWS is
- extracted `signAptosMessage` and `signAptosTransaction` from the derived wallet code, so that they can be used independently from the full-featured derived `AptosWallet`
- implemented `extendSolanaWallet` as proof-of-concept (if we don't like it we can just remove, but giving us options)

The rationale behind the last two points is that, if the end goal is to have a single wallet "instance" that can sign both solana and aptos messages, this code makes it much easier to do so

### Example 1:

Cleaner and more modular, but we have to pass `authenticationFunction` every time we sign.
This should work well for Wormhole CCTP, since we have to create a "signer" for both chains.

```typescript
// From a hypothetical solana wallet adapter
const solanaWallet = useSolanaWallet();

const authenticationFunction = '0x7::solana::authenticate';

await solanaWallet.connect();
const solanaSignature = await solanaWallet.signTransaction(solanaTransaction);
const aptosSignature = await signAptosTransactionWithSolana({
  solanaWallet,
  authenticationFunction,
  rawTransaction: aptosTransaction,
});

```

### Example 2:
I don't love this, if feels like a bit hacky, but could be convenient

```typescript
// From a hypothetical solana wallet adapter
const solanaWallet = useSolanaWallet();

const solanaAuthenticationFunction = '0x7::solana::authenticate';
const extendedSolanaWallet = extendSolanaWallet(solanaWallet, solanaAuthenticationFunction);

await extendedSolanaWallet.connect();
const solanaSignature = await extendedSolanaWallet.signTransaction(solanaTransaction);
const aptosSignature = await extendedSolanaWallet.signAptosTransaction(aptosTransaction);
```
