### PR TITLE
[derived-wallet-solana] Return correctly-formed `AbstractAuthData`

### DIFF
--- a/packages/derived-wallet-solana/src/createSiwsEnvelopeForTransaction.ts
+++ b/packages/derived-wallet-solana/src/createSiwsEnvelopeForTransaction.ts
@@ -1,4 +1,4 @@
-import { aptosChainIdToNetwork, encodeStructuredMessage, StructuredMessage } from '@aptos-labs/derived-wallet-base';
+import { aptosChainIdToNetwork } from '@aptos-labs/derived-wallet-base';
 import {
   AccountAddressInput,
   AnyRawTransaction,
@@ -22,7 +22,7 @@ export interface CreateSiwsEnvelopeForAptosTransactionInput {
  */
 export function createSiwsEnvelopeForAptosTransaction(
   input: CreateSiwsEnvelopeForAptosTransactionInput,
-): SolanaSignInInputWithRequiredFields {
+): SolanaSignInInputWithRequiredFields & { requestId: string } {
   const { solanaPublicKey, aptosAddress, rawTransaction } = input;
   const signingMessage = generateSigningMessageForTransaction(rawTransaction);
   const messageHash = hashValues([signingMessage]);


### PR DESCRIPTION
In #504 I just defined a placeholder account authenticator when signing a transaction.
After some [more thinking / digging](https://aptos-org.slack.com/archives/C08DNU2PE9W/p1742609808632769), I came to the conclusion we need to pass the original signing message to the on-chain authentication function in order to perform authentication.

<img width="607" alt="Screenshot 2025-03-24 at 12 38 47 PM" src="https://github.com/user-attachments/assets/4caa8578-0226-499b-8f45-983f4b8fdf96" />

