### PR TITLE
Keep only minimum required fields for SIWE and SIWS

### DIFF
--- a/packages/derived-wallet-ethereum/src/EIP1193DerivedPublicKey.ts
+++ b/packages/derived-wallet-ethereum/src/EIP1193DerivedPublicKey.ts
@@ -62,13 +62,13 @@ export class EIP1193DerivedPublicKey extends AccountPublicKey {
       return false;
     }
 
-    const { ethereumChainId, issuedAt, siweSignature } = signature;
+    const { chainId, issuedAt, siweSignature } = signature;
     const signingMessageDigest = hashValues([message]);
 
     // Obtain SIWE envelope for the signing message
     const envelopeInput = {
       ethereumAddress: this.ethereumAddress,
-      ethereumChainId,
+      chainId,
       signingMessageDigest,
       issuedAt,
     };

--- a/packages/derived-wallet-ethereum/src/EIP1193DerivedSignature.ts
+++ b/packages/derived-wallet-ethereum/src/EIP1193DerivedSignature.ts
@@ -4,16 +4,16 @@ export class EIP1193DerivedSignature extends Signature {
   static readonly LENGTH = 65;
 
   private readonly _siweSignature: Uint8Array;
-  readonly ethereumChainId: number;
+  readonly chainId: number;
   readonly issuedAt: Date;
 
-  constructor(siweSignature: HexInput, ethereumChainId: number, issuedAt: Date) {
+  constructor(siweSignature: HexInput, chainId: number, issuedAt: Date) {
     super();
     this._siweSignature = Hex.fromHexInput(siweSignature).toUint8Array();
     if (this._siweSignature.length !== EIP1193DerivedSignature.LENGTH) {
       throw new Error('Expected signature length to be 65 bytes');
     }
-    this.ethereumChainId = ethereumChainId;
+    this.chainId = chainId;
     this.issuedAt = issuedAt;
   }
 
@@ -23,15 +23,15 @@ export class EIP1193DerivedSignature extends Signature {
 
   serialize(serializer: Serializer) {
     serializer.serializeFixedBytes(this._siweSignature);
-    serializer.serializeU32AsUleb128(this.ethereumChainId);
+    serializer.serializeU32AsUleb128(this.chainId);
     serializer.serializeU64(this.issuedAt.getTime());
   }
 
   static deserialize(deserializer: Deserializer) {
     const siweSignature = deserializer.deserializeFixedBytes(EIP1193DerivedSignature.LENGTH);
-    const ethereumChainId = deserializer.deserializeUleb128AsU32();
+    const chainId = deserializer.deserializeUleb128AsU32();
     // Number can safely contain a unix timestamp
     const issuedAt = new Date(Number(deserializer.deserializeU64()));
-    return new EIP1193DerivedSignature(siweSignature, ethereumChainId, issuedAt);
+    return new EIP1193DerivedSignature(siweSignature, chainId, issuedAt);
   }
 }

--- a/packages/derived-wallet-ethereum/src/EIP1193DerivedWallet.ts
+++ b/packages/derived-wallet-ethereum/src/EIP1193DerivedWallet.ts
@@ -219,6 +219,7 @@ export class EIP1193DerivedWallet implements AptosWallet {
     return signAptosMessageWithEthereum({
       eip1193Provider: this.eip1193Provider,
       authenticationFunction: this.authenticationFunction,
+      aptosChainId: NetworkToChainId[this.defaultNetwork],
       messageInput: {
         ...input,
         chainId,
@@ -233,6 +234,7 @@ export class EIP1193DerivedWallet implements AptosWallet {
     return signAptosTransactionWithEthereum({
       eip1193Provider: this.eip1193Provider,
       authenticationFunction: this.authenticationFunction,
+      aptosChainId: NetworkToChainId[this.defaultNetwork],
       rawTransaction,
     })
   }

--- a/packages/derived-wallet-ethereum/src/EIP1193DerivedWallet.ts
+++ b/packages/derived-wallet-ethereum/src/EIP1193DerivedWallet.ts
@@ -215,11 +215,10 @@ export class EIP1193DerivedWallet implements AptosWallet {
   // region Signatures
 
   async signMessage(input: AptosSignMessageInput): Promise<UserResponse<AptosSignMessageOutput>> {
-    const chainId = input.chainId ? NetworkToChainId[this.defaultNetwork] : undefined;
+    const chainId = NetworkToChainId[this.defaultNetwork];
     return signAptosMessageWithEthereum({
       eip1193Provider: this.eip1193Provider,
       authenticationFunction: this.authenticationFunction,
-      aptosChainId: NetworkToChainId[this.defaultNetwork],
       messageInput: {
         ...input,
         chainId,
@@ -234,7 +233,6 @@ export class EIP1193DerivedWallet implements AptosWallet {
     return signAptosTransactionWithEthereum({
       eip1193Provider: this.eip1193Provider,
       authenticationFunction: this.authenticationFunction,
-      aptosChainId: NetworkToChainId[this.defaultNetwork],
       rawTransaction,
     })
   }

--- a/packages/derived-wallet-ethereum/src/createSiweEnvelope.ts
+++ b/packages/derived-wallet-ethereum/src/createSiweEnvelope.ts
@@ -9,19 +9,19 @@ import { EthereumAddress } from './shared';
 
 export interface CreateSiweEnvelopeInput {
   ethereumAddress: EthereumAddress;
-  ethereumChainId: number;
+  chainId: number;
   signingMessageDigest: HexInput;
   issuedAt: Date;
 }
 
 function createSiweEnvelope(input: CreateSiweEnvelopeInput & { statement: string }) {
-  const { ethereumAddress, ethereumChainId, signingMessageDigest, issuedAt, statement } = input;
+  const { ethereumAddress, chainId, signingMessageDigest, issuedAt, statement } = input;
   const digestHex = Hex.fromHexInput(signingMessageDigest).toString();
   return createSiweMessage({
     address: ethereumAddress,
     domain: window.location.host,
     uri: window.location.origin,
-    chainId: ethereumChainId,
+    chainId,
     nonce: digestHex,
     statement,
     version: '1',

--- a/packages/derived-wallet-ethereum/src/signAptosMessage.ts
+++ b/packages/derived-wallet-ethereum/src/signAptosMessage.ts
@@ -13,19 +13,18 @@ import { EIP1193DerivedSignature } from './EIP1193DerivedSignature';
 import { EthereumAddress, wrapEthersUserResponse } from './shared';
 
 export interface StructuredMessageInputWithChainId extends StructuredMessageInput {
-  chainId?: number;
+  chainId: number;
 }
 
 export interface SignAptosMessageWithEthereumInput {
   eip1193Provider: Eip1193Provider | BrowserProvider;
   ethereumAddress?: EthereumAddress;
-  aptosChainId: number;
   authenticationFunction: string;
   messageInput: StructuredMessageInputWithChainId;
 }
 
 export async function signAptosMessageWithEthereum(input: SignAptosMessageWithEthereumInput): Promise<UserResponse<AptosSignMessageOutput>> {
-  const { authenticationFunction, messageInput, aptosChainId } = input;
+  const { authenticationFunction, messageInput } = input;
   const eip1193Provider = input.eip1193Provider instanceof BrowserProvider
     ? input.eip1193Provider
     : new BrowserProvider(input.eip1193Provider);
@@ -64,7 +63,7 @@ export async function signAptosMessageWithEthereum(input: SignAptosMessageWithEt
   const issuedAt = new Date();
   const siweMessage = createSiweEnvelopeForAptosStructuredMessage({
     ethereumAddress,
-    chainId: aptosChainId,
+    chainId,
     structuredMessage,
     signingMessageDigest,
     issuedAt,
@@ -73,7 +72,7 @@ export async function signAptosMessageWithEthereum(input: SignAptosMessageWithEt
   const response = await wrapEthersUserResponse(ethereumAccount.signMessage(siweMessage));
 
   return mapUserResponse(response, (siweSignature) => {
-    const signature = new EIP1193DerivedSignature(siweSignature, aptosChainId, issuedAt);
+    const signature = new EIP1193DerivedSignature(siweSignature, chainId, issuedAt);
     const fullMessage = new TextDecoder().decode(signingMessage);
     return {
       prefix: 'APTOS',

--- a/packages/derived-wallet-solana/src/createSiwsEnvelope.ts
+++ b/packages/derived-wallet-solana/src/createSiwsEnvelope.ts
@@ -20,10 +20,8 @@ function createSiwsEnvelope(input: CreateSiwsEnvelopeInput & {
   return {
     address: solanaPublicKey.toString(),
     domain: window.location.host,
-    uri: window.location.origin,
     nonce: digestHex,
     statement,
-    version: '1',
   };
 }
 


### PR DESCRIPTION
This PR uses the bare minimum required fields for both SIWS and SIWE.
In addition, for SIWE we use the current Aptos chain id instead of the Ethereum chain id in the message

Note:
- While SIWE minimum required fields are `chainId, domain, nonce, uri, version (default to 1)` Metamask adds `issued, network` to the UI message. Network is the `chainId` in `hex` format, so if `chainId : 2` network is `0x2`

Deployed to https://aptos-labs.github.io/aptos-wallet-adapter/nextjs-cross-chain-example/