### PR TITLE
chore: add Continue with Apple to the AvailableWallets type

### DIFF
--- a/.changeset/happy-worlds-carry.md
+++ b/.changeset/happy-worlds-carry.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/wallet-adapter-core": patch
+---
+
+include "Continue with Apple" in AvailableWallets type

--- a/packages/wallet-adapter-core/src/utils/types.ts
+++ b/packages/wallet-adapter-core/src/utils/types.ts
@@ -31,7 +31,8 @@ export type AvailableWallets =
   | "Pontem Wallet"
   | "Mizu Wallet"
   | "OKX Wallet"
-  | "Continue with Google";
+  | "Continue with Google"
+  | "Continue with Apple";
 
 export type InputTransactionData = {
   sender?: AccountAddressInput;


### PR DESCRIPTION
chore: Add Continue with Apple to AvailableWallets type

Hi team! 
I've added  the "Continue with Apple" option to the AvailableWallets type for Aptos Connect.

Thanks for reviewing!