### PR TITLE
[example] Fix nextjs example Sponsor txn error 

### DIFF
--- a/apps/nextjs-example/src/components/transactionFlows/Sponsor.tsx
+++ b/apps/nextjs-example/src/components/transactionFlows/Sponsor.tsx
@@ -42,7 +42,7 @@ export function Sponsor() {
       data: {
         function: "0x1::resource_account::create_resource_account",
         typeArguments: [],
-        functionArguments: ["My Resource Account", AccountAddress.from("0x0").toUint8Array()],
+        functionArguments: [account.address.toString(), AccountAddress.from("0x0").toUint8Array()],
       },
     });
     transactionToSign.feePayerAddress = account.address;
@@ -100,7 +100,6 @@ export function Sponsor() {
         senderAuthenticator: senderAuthenticator,
         feePayerAuthenticator: feepayerAuthenticator,
       });
-      console.log(response);
       toast({
         title: "Success",
         description: <TransactionHash hash={response.hash} network={network} />,


### PR DESCRIPTION
Original: Existing process uses multiple wallets to separately sign txn and feepayer transactions. However, due to adaptor and petra coordination issues, having both signatures simultaneously is difficult, leading to verification failures.

Current: Now using a local random account for on-chain operations, with the wallet paying gas and signing the feepayer transaction to complete the flow.