### PR TITLE
fix wallet names

### DIFF
--- a/.changeset/curvy-shoes-drum.md
+++ b/.changeset/curvy-shoes-drum.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/wallet-adapter-core": patch
+---
+
+Rename Msafe wallet to MSafe in AvailableWallets + Add Rimosafe

--- a/packages/wallet-adapter-core/src/utils/types.ts
+++ b/packages/wallet-adapter-core/src/utils/types.ts
@@ -25,15 +25,17 @@ export interface AptosStandardSupportedWallet {
 
 // Update this with the name of your wallet when you create a new wallet plugin.
 export type AvailableWallets =
-  | "Nightly"
-  | "Petra"
-  | "T wallet"
-  | "Pontem Wallet"
-  | "Mizu Wallet"
-  | "OKX Wallet"
-  | "Continue with Google"
   | "Continue with Apple"
-  | "MSafe Wallet";
+  | "Continue with Google"
+  | "Leap Wallet"
+  | "MSafe"
+  | "Mizu Wallet"
+  | "Nightly"
+  | "OKX Wallet"
+  | "Petra"
+  | "Pontem Wallet"
+  | "Rimosafe"
+  | "T wallet";
 
 export type InputTransactionData = {
   sender?: AccountAddressInput;

--- a/packages/wallet-adapter-core/src/utils/types.ts
+++ b/packages/wallet-adapter-core/src/utils/types.ts
@@ -27,7 +27,6 @@ export interface AptosStandardSupportedWallet {
 export type AvailableWallets =
   | "Continue with Apple"
   | "Continue with Google"
-  | "Leap Wallet"
   | "MSafe"
   | "Mizu Wallet"
   | "Nightly"


### PR DESCRIPTION
There is a type mismatch in the wallet names

I believe this is the cause of https://github.com/aptos-labs/aptos-wallet-adapter/issues/501


## Overview

- Order alphabetically
- Rename `MSafe Wallet` -> `MSafe`
- Add `Rimosafe`

