### PR TITLE
Fix the network validation in the demo dapp

### DIFF
--- a/apps/nextjs-example/src/app/page.tsx
+++ b/apps/nextjs-example/src/app/page.tsx
@@ -168,10 +168,16 @@ function WalletConnection({
     }
     // If the configured network is not an Aptos network, i.e is a custom network
     // we resolve it as a valid network name
-    return true;
+    if (network?.name === "custom") {
+      return true;
+    }
+
+    // Otherwise, the network is not valid
+    return false;
   };
 
-  const isNetworkChangeSupported = wallet?.features['aptos:changeNetwork'] !== undefined;
+  const isNetworkChangeSupported =
+    wallet?.features["aptos:changeNetwork"] !== undefined;
 
   return (
     <Card>


### PR DESCRIPTION
Network is considered as valid if it matches the expected network name. The network name should be all lowercase. For the cases the wallet uses an upper case name, i.e "Mainnet" it should be considered as invalid network. 

The demo dapp does not consider this case and displays the network as valid.

This PR changes the network validation to

- If it is an Aptos network (in the expected format), resolves as true
- If the network name is `custom` resolves as true
- Otherwise display an error

<img width="947" alt="Screenshot 2025-04-16 at 10 06 48 AM" src="https://github.com/user-attachments/assets/f0e0cf10-08d0-462b-826c-edf35168016b" />


