### PR TITLE
Add Solana sign message fallback support + modify message format

### DIFF
--- a/.changeset/tender-kings-slide.md
+++ b/.changeset/tender-kings-slide.md
@@ -1,0 +1,6 @@
+---
+"@aptos-labs/derived-wallet-solana": patch
+"@aptos-labs/derived-wallet-base": patch
+---
+
+Add Solana sign message fallback support

--- a/packages/derived-wallet-base/src/envelope.ts
+++ b/packages/derived-wallet-base/src/envelope.ts
@@ -9,7 +9,7 @@ import { StructuredMessage } from './StructuredMessage';
 /**
  * Attempt to convert the specified chainId into a human-readable identifier.
  */
-export function getChainName(chainId: number) {
+function getChainName(chainId: number) {
   // Obtain the network name if available
   for (const [network, otherChainId] of Object.entries(NetworkToChainId)) {
     if (otherChainId === chainId) {

--- a/packages/derived-wallet-base/src/envelope.ts
+++ b/packages/derived-wallet-base/src/envelope.ts
@@ -59,5 +59,5 @@ export function createTransactionStatement(rawTransaction: AnyRawTransaction) {
   const chainName = getChainName(chainId);
   const onAptosChain = ` on Aptos blockchain (${chainName})`;
 
-  return `To execute transaction${humanReadableEntryFunction}${onAptosChain}.`;
+  return `Please confirm you explicitly initiated this request from ${window.location.host}. You are approving to execute transaction${humanReadableEntryFunction}${onAptosChain}.`;
 }

--- a/packages/derived-wallet-base/src/envelope.ts
+++ b/packages/derived-wallet-base/src/envelope.ts
@@ -9,7 +9,7 @@ import { StructuredMessage } from './StructuredMessage';
 /**
  * Attempt to convert the specified chainId into a human-readable identifier.
  */
-function getChainName(chainId: number) {
+export function getChainName(chainId: number) {
   // Obtain the network name if available
   for (const [network, otherChainId] of Object.entries(NetworkToChainId)) {
     if (otherChainId === chainId) {

--- a/packages/derived-wallet-solana/src/createSiwsEnvelope.ts
+++ b/packages/derived-wallet-solana/src/createSiwsEnvelope.ts
@@ -62,20 +62,18 @@ export function createSiwsEnvelopeForAptosTransaction(
  * <domain> wants you to sign in with your Solana account:
  * <base58_public_key>
  * 
- * To execute transaction <entry_function> on Aptos blockchain (<network_name>).
+ * Please confirm you explicitly initiated this request from <domain>. You are approving to execute transaction <entry_function> on Aptos blockchain (<network_name>).
  * 
  * Nonce: <aptos_txn_digest>
  */
 export function createSolanaSignMessageStatementForAptosTransaction(args:{accountAddress:string, signingMessageDigest: HexInput, rawTransaction: AnyRawTransaction  } ) {
   const {accountAddress, signingMessageDigest, rawTransaction} = args;
-  const entryFunctionName = getEntryFunctionName(rawTransaction.rawTransaction.payload);
-  const humanReadableEntryFunction = entryFunctionName ? `${entryFunctionName}` : '';
-
-  const chainId = rawTransaction.rawTransaction.chain_id.chainId;
-  const chainName = getChainName(chainId);
   
   const domain = window.location.host;
   const digestHex = Hex.fromHexInput(signingMessageDigest).toString();
 
-  return `${domain} wants you to sign in with your Solana account:\n${accountAddress}\n\nTo execute transaction ${humanReadableEntryFunction} on Aptos blockchain (${chainName}).\n\nNonce: ${digestHex}`
+  const messageStatementPrefix = `${domain} wants you to sign in with your Solana account:\n${accountAddress}`;
+  const messageStatementBody = createTransactionStatement(rawTransaction);
+
+  return `${messageStatementPrefix}\n\n${messageStatementBody}\n\nNonce: ${digestHex}`
 }

--- a/packages/derived-wallet-solana/src/createSiwsEnvelope.ts
+++ b/packages/derived-wallet-solana/src/createSiwsEnvelope.ts
@@ -1,6 +1,8 @@
 import {
   createStructuredMessageStatement,
   createTransactionStatement,
+  getChainName,
+  getEntryFunctionName,
   StructuredMessage,
 } from '@aptos-labs/derived-wallet-base';
 import { AnyRawTransaction, Hex, HexInput } from '@aptos-labs/ts-sdk';
@@ -50,4 +52,30 @@ export function createSiwsEnvelopeForAptosTransaction(
   const { rawTransaction, ...rest } = input;
   const statement = createTransactionStatement(rawTransaction);
   return createSiwsEnvelope({ ...rest, statement });
+}
+
+
+/**
+ * Create the message to be used with the wallet `signMessage` function.
+ * Note: this message format matches the SIWS message format, so it can be used with SIWS as well.
+ * 
+ * <domain> wants you to sign in with your Solana account:
+ * <base58_public_key>
+ * 
+ * To execute transaction <entry_function> on Aptos blockchain (<network_name>).
+ * 
+ * Nonce: <aptos_txn_digest>
+ */
+export function createSolanaSignMessageStatementForAptosTransaction(args:{accountAddress:string, signingMessageDigest: HexInput, rawTransaction: AnyRawTransaction  } ) {
+  const {accountAddress, signingMessageDigest, rawTransaction} = args;
+  const entryFunctionName = getEntryFunctionName(rawTransaction.rawTransaction.payload);
+  const humanReadableEntryFunction = entryFunctionName ? `${entryFunctionName}` : '';
+
+  const chainId = rawTransaction.rawTransaction.chain_id.chainId;
+  const chainName = getChainName(chainId);
+  
+  const domain = window.location.host;
+  const digestHex = Hex.fromHexInput(signingMessageDigest).toString();
+
+  return `${domain} wants you to sign in with your Solana account:\n${accountAddress}\n\nTo execute transaction ${humanReadableEntryFunction} on Aptos blockchain (${chainName}).\n\nNonce: ${digestHex}`
 }

--- a/packages/derived-wallet-solana/src/createSiwsEnvelope.ts
+++ b/packages/derived-wallet-solana/src/createSiwsEnvelope.ts
@@ -1,8 +1,6 @@
 import {
   createStructuredMessageStatement,
   createTransactionStatement,
-  getChainName,
-  getEntryFunctionName,
   StructuredMessage,
 } from '@aptos-labs/derived-wallet-base';
 import { AnyRawTransaction, Hex, HexInput } from '@aptos-labs/ts-sdk';
@@ -52,28 +50,4 @@ export function createSiwsEnvelopeForAptosTransaction(
   const { rawTransaction, ...rest } = input;
   const statement = createTransactionStatement(rawTransaction);
   return createSiwsEnvelope({ ...rest, statement });
-}
-
-
-/**
- * Create the message to be used with the wallet `signMessage` function.
- * Note: this message format matches the SIWS message format, so it can be used with SIWS as well.
- * 
- * <domain> wants you to sign in with your Solana account:
- * <base58_public_key>
- * 
- * Please confirm you explicitly initiated this request from <domain>. You are approving to execute transaction <entry_function> on Aptos blockchain (<network_name>).
- * 
- * Nonce: <aptos_txn_digest>
- */
-export function createSolanaSignMessageStatementForAptosTransaction(args:{accountAddress:string, signingMessageDigest: HexInput, rawTransaction: AnyRawTransaction  } ) {
-  const {accountAddress, signingMessageDigest, rawTransaction} = args;
-  
-  const domain = window.location.host;
-  const digestHex = Hex.fromHexInput(signingMessageDigest).toString();
-
-  const messageStatementPrefix = `${domain} wants you to sign in with your Solana account:\n${accountAddress}`;
-  const messageStatementBody = createTransactionStatement(rawTransaction);
-
-  return `${messageStatementPrefix}\n\n${messageStatementBody}\n\nNonce: ${digestHex}`
 }

--- a/packages/derived-wallet-solana/src/setupAutomaticDerivation.ts
+++ b/packages/derived-wallet-solana/src/setupAutomaticDerivation.ts
@@ -13,8 +13,8 @@ export function setupAutomaticSolanaWalletDerivation(options: SolanaDomainWallet
   let registrations: { [name: string]: UnsubscribeCallback } = {};
 
   const isWhitelisted = (wallet: WalletAdapterCompatibleStandardWallet) => {
-    // Using "Phantom" as only whitelisted by default, as it's the only one known to work well with SIWS
-    return wallet.name === 'Phantom';
+    // For now, we whitelist all wallets
+    return true;
   };
 
   const deriveAndRegisterWallet = (wallet: WalletAdapterCompatibleStandardWallet) => {

--- a/packages/derived-wallet-solana/src/shared.ts
+++ b/packages/derived-wallet-solana/src/shared.ts
@@ -2,7 +2,7 @@ import { makeUserApproval, makeUserRejection } from '@aptos-labs/derived-wallet-
 import { UserResponse } from '@aptos-labs/wallet-standard';
 import { WalletError } from '@solana/wallet-adapter-base';
 
-export const defaultAuthenticationFunction = '0x1::daa_siws::authenticate';
+export const defaultAuthenticationFunction = '0x1::solana_derivable_account::authenticate';
 
 /**
  * Adapt SolanaWalletAdapter response into a UserResponse.


### PR DESCRIPTION
Add support to fallback to the wallet `signMessage` function, if SIWS is not available. The message format is identical to the one is being used in SIWS so we maintain and support only one message format.

If the wallet supports SIWS, a domain verification will apply. In the case the wallet does not support SIWS the adapter uses `signMessage` function and therefore no domain verification will apply.

This is to balance the need to support many wallets, maintain a one message format in the adapter and on chain and secure users with domain verification when available.

Additionally, this PR modifies the message format to include a warning message, following https://github.com/aptos-labs/aptos-core/pull/16439