### PR TITLE
Add missing step id to build action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,7 @@ jobs:
         run: pnpm run build
 
       - name: Create Release Pull Request or Publish to npm
+        id: changesets
         uses: changesets/action@v1
         with:
           publish: pnpm run publish-packages

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "changeset": "changeset",
     "version-packages": "changeset version",
     "publish-packages": "changeset version && changeset publish",
-    "deploy:example": "pnpm run deploy:adapter-example && pnpm run deploy:cross-chain-example",
+    "deploy:example": "(pnpm run deploy:adapter-example) && (pnpm run deploy:cross-chain-example)",
     "deploy:adapter-example": "pnpm run adapter-example:build && pnpm run adapter-example:export && touch ./apps/nextjs-example/out/.nojekyll && gh-pages --dist apps/nextjs-example/out --dotfiles",
     "adapter-example:export": "pnpm run --filter {apps/nextjs-example} export",
     "adapter-example:build": "pnpm run --filter {apps/nextjs-example} build",


### PR DESCRIPTION
Publish step is not running, maybe because of this missing `id`
https://github.com/changesets/action?tab=readme-ov-file#with-publishing