### PR TITLE
Add the URI scheme to the message URI field and EIP1193DerivedSignature

### DIFF
--- a/.changeset/tangy-pens-win.md
+++ b/.changeset/tangy-pens-win.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/derived-wallet-ethereum": patch
+---
+
+Add the URI scheme to the message URI field and EIP1193DerivedSignature

--- a/packages/derived-wallet-ethereum/src/EIP1193DerivedSignature.ts
+++ b/packages/derived-wallet-ethereum/src/EIP1193DerivedSignature.ts
@@ -7,17 +7,17 @@ export class EIP1193DerivedSignature extends Signature {
   private readonly _siweSignature: Uint8Array;
   // The date and time when the signature was issued
   readonly issuedAt: Date;
-  // The origin of the message, e.g. the domain of the website that requested the signature
-  readonly origin: string;
+  // The scheme in the URI of the message, e.g. the scheme of the website that requested the signature (http, https, etc.)
+  readonly scheme: string;
 
-  constructor(origin: string, issuedAt: Date, siweSignature: HexInput) {
+  constructor(scheme: string, issuedAt: Date, siweSignature: HexInput) {
     super();
     this._siweSignature = Hex.fromHexInput(siweSignature).toUint8Array();
     if (this._siweSignature.length !== EIP1193DerivedSignature.LENGTH) {
-      throw new Error('Expected signature length to be 65 bytes');
+      throw new Error(`Expected signature length to be ${EIP1193DerivedSignature.LENGTH} bytes`);
     }
     this.issuedAt = issuedAt;
-    this.origin = origin;
+    this.scheme = scheme;
   }
 
   get siweSignature() {
@@ -25,15 +25,15 @@ export class EIP1193DerivedSignature extends Signature {
   }
 
   serialize(serializer: Serializer) {
-    serializer.serializeStr(this.origin);
+    serializer.serializeStr(this.scheme);
     serializer.serializeStr(this.issuedAt.toISOString());
     serializer.serializeBytes(this._siweSignature);
   }
 
   static deserialize(deserializer: Deserializer) {
-    const origin = deserializer.deserializeStr();
+    const scheme = deserializer.deserializeStr();
     const issuedAt = new Date(deserializer.deserializeStr());
     const siweSignature = deserializer.deserializeBytes();
-    return new EIP1193DerivedSignature(origin, issuedAt, siweSignature);
+    return new EIP1193DerivedSignature(scheme, issuedAt, siweSignature);
   }
 }

--- a/packages/derived-wallet-ethereum/src/EIP1193DerivedSignature.ts
+++ b/packages/derived-wallet-ethereum/src/EIP1193DerivedSignature.ts
@@ -3,16 +3,21 @@ import { Deserializer, Hex, HexInput, Serializer, Signature } from '@aptos-labs/
 export class EIP1193DerivedSignature extends Signature {
   static readonly LENGTH = 65;
 
+  // The signature of the message
   private readonly _siweSignature: Uint8Array;
+  // The date and time when the signature was issued
   readonly issuedAt: Date;
+  // The origin of the message, e.g. the domain of the website that requested the signature
+  readonly origin: string;
 
-  constructor(issuedAt: Date, siweSignature: HexInput) {
+  constructor(origin: string, issuedAt: Date, siweSignature: HexInput) {
     super();
     this._siweSignature = Hex.fromHexInput(siweSignature).toUint8Array();
     if (this._siweSignature.length !== EIP1193DerivedSignature.LENGTH) {
       throw new Error('Expected signature length to be 65 bytes');
     }
     this.issuedAt = issuedAt;
+    this.origin = origin;
   }
 
   get siweSignature() {
@@ -20,13 +25,15 @@ export class EIP1193DerivedSignature extends Signature {
   }
 
   serialize(serializer: Serializer) {
+    serializer.serializeStr(this.origin);
     serializer.serializeStr(this.issuedAt.toISOString());
     serializer.serializeBytes(this._siweSignature);
   }
 
   static deserialize(deserializer: Deserializer) {
+    const origin = deserializer.deserializeStr();
     const issuedAt = new Date(deserializer.deserializeStr());
     const siweSignature = deserializer.deserializeBytes();
-    return new EIP1193DerivedSignature(issuedAt, siweSignature);
+    return new EIP1193DerivedSignature(origin, issuedAt, siweSignature);
   }
 }

--- a/packages/derived-wallet-ethereum/src/createSiweEnvelope.ts
+++ b/packages/derived-wallet-ethereum/src/createSiweEnvelope.ts
@@ -20,7 +20,7 @@ function createSiweEnvelope(input: CreateSiweEnvelopeInput & { statement: string
   return createSiweMessage({
     address: ethereumAddress,
     domain: window.location.host,
-    uri: window.location.host,
+    uri: window.location.origin,
     chainId,
     nonce: digestHex,
     statement,

--- a/packages/derived-wallet-ethereum/src/signAptosMessage.ts
+++ b/packages/derived-wallet-ethereum/src/signAptosMessage.ts
@@ -72,7 +72,8 @@ export async function signAptosMessageWithEthereum(input: SignAptosMessageWithEt
   const response = await wrapEthersUserResponse(ethereumAccount.signMessage(siweMessage));
 
   return mapUserResponse(response, (siweSignature) => {
-    const signature = new EIP1193DerivedSignature(window.location.origin, issuedAt, siweSignature);
+    const scheme = window.location.protocol.slice(0, -1);
+    const signature = new EIP1193DerivedSignature(scheme, issuedAt, siweSignature);
     const fullMessage = new TextDecoder().decode(signingMessage);
     return {
       prefix: 'APTOS',

--- a/packages/derived-wallet-ethereum/src/signAptosMessage.ts
+++ b/packages/derived-wallet-ethereum/src/signAptosMessage.ts
@@ -72,7 +72,7 @@ export async function signAptosMessageWithEthereum(input: SignAptosMessageWithEt
   const response = await wrapEthersUserResponse(ethereumAccount.signMessage(siweMessage));
 
   return mapUserResponse(response, (siweSignature) => {
-    const signature = new EIP1193DerivedSignature(issuedAt, siweSignature);
+    const signature = new EIP1193DerivedSignature(window.location.origin, issuedAt, siweSignature);
     const fullMessage = new TextDecoder().decode(signingMessage);
     return {
       prefix: 'APTOS',

--- a/packages/derived-wallet-ethereum/src/signAptosTransaction.ts
+++ b/packages/derived-wallet-ethereum/src/signAptosTransaction.ts
@@ -13,6 +13,12 @@ import { createSiweEnvelopeForAptosTransaction } from './createSiweEnvelope';
 import { EIP1193DerivedSignature } from './EIP1193DerivedSignature';
 import { EthereumAddress, wrapEthersUserResponse } from './shared';
 
+/**
+ * A first byte of the signature that indicates the "message type", this is defined in the
+ * authentication function on chain, and lets us identify the type of the message and to make
+ * changes in the future if needed.
+ */
+export const SIGNATURE_TYPE = 0;
 export interface SignAptosTransactionWithEthereumInput {
   eip1193Provider: Eip1193Provider | BrowserProvider;
   ethereumAddress?: EthereumAddress;
@@ -57,8 +63,8 @@ export async function signAptosTransactionWithEthereum(input: SignAptosTransacti
 
     // Serialize the signature with the signature type as the first byte.
     const serializer = new Serializer();
-    serializer.serializeU8(0);
-    const signature = new EIP1193DerivedSignature(issuedAt, siweSignature);
+    serializer.serializeU8(SIGNATURE_TYPE);
+    const signature = new EIP1193DerivedSignature(window.location.origin, issuedAt, siweSignature);
     signature.serialize(serializer)
     const abstractSignature = serializer.toUint8Array();
 

--- a/packages/derived-wallet-ethereum/src/signAptosTransaction.ts
+++ b/packages/derived-wallet-ethereum/src/signAptosTransaction.ts
@@ -64,7 +64,9 @@ export async function signAptosTransactionWithEthereum(input: SignAptosTransacti
     // Serialize the signature with the signature type as the first byte.
     const serializer = new Serializer();
     serializer.serializeU8(SIGNATURE_TYPE);
-    const signature = new EIP1193DerivedSignature(window.location.origin, issuedAt, siweSignature);
+    // Remove the trailing colon from the scheme
+    const scheme = window.location.protocol.slice(0, -1);
+    const signature = new EIP1193DerivedSignature(scheme, issuedAt, siweSignature);
     signature.serialize(serializer)
     const abstractSignature = serializer.toUint8Array();
 


### PR DESCRIPTION
We use the `domain` as the `uri` in the message for the EVM dAA, but while it works locally (i.e `localhost:3001`) it is misleading since in production (i.e `aptos-labs.github.io`) it fails on the wallet verification because it does not follow the uri format which is `<scheme>:<path>`.

Since we need to construct the message the user signed on on-chain, and need to include the `scheme`, we add it to the abstract signature so we can extract it from there and use it in the message we build on chain.

on chain PR https://github.com/aptos-labs/aptos-core/pull/16524

<img width="403" alt="image" src="https://github.com/user-attachments/assets/3581e204-b573-44c4-8dea-fd5046f897d2" />
