### PR TITLE
Use the default cross-chain wallet's signMessage API for when signing a regular message

### DIFF
--- a/.changeset/petite-hounds-stick.md
+++ b/.changeset/petite-hounds-stick.md
@@ -1,0 +1,7 @@
+---
+"@aptos-labs/derived-wallet-ethereum": minor
+"@aptos-labs/derived-wallet-solana": minor
+"@aptos-labs/derived-wallet-base": minor
+---
+
+Use the default cross-chain wallet's signMessage API for when signing a regular message

--- a/packages/derived-wallet-base/package.json
+++ b/packages/derived-wallet-base/package.json
@@ -15,6 +15,7 @@
     "build": "pnpm build:bundle && pnpm build:declarations",
     "build:bundle": "tsup --sourcemap",
     "build:declarations": "tsc --emitDeclarationOnly --declaration --declarationMap",
+    "dev": "tsup src/index.ts --format esm,cjs --watch",
     "test": "jest",
     "lint": "TIMING=1 eslint \"src/**/*.ts*\""
   },

--- a/packages/derived-wallet-base/src/StructuredMessage.ts
+++ b/packages/derived-wallet-base/src/StructuredMessage.ts
@@ -6,7 +6,7 @@ export interface StructuredMessageInput {
   message: string;
   nonce: string;
   application?: boolean;
-  chainId?: number | boolean;
+  chainId?: number;
   address?: AccountAddressInput | boolean;
 }
 

--- a/packages/derived-wallet-base/src/StructuredMessage.ts
+++ b/packages/derived-wallet-base/src/StructuredMessage.ts
@@ -19,7 +19,7 @@ export interface StructuredMessage {
 }
 
 export function encodeStructuredMessage(
-  structuredMessage: StructuredMessage,
+  structuredMessage: StructuredMessage
 ): Uint8Array {
   const { address, application, chainId, message, nonce } = structuredMessage;
 
@@ -36,9 +36,9 @@ export function encodeStructuredMessage(
 
   const parts = [
     structuredMessagePrefix,
-    ...optionalParts,
     `message: ${message}`,
     `nonce: ${nonce}`,
+    ...optionalParts,
   ];
 
   const input = parts.join("\n");
@@ -53,7 +53,7 @@ function parsePart(part: string, name: string) {
 }
 
 export function decodeStructuredMessage(
-  encoded: Uint8Array,
+  encoded: Uint8Array
 ): StructuredMessage {
   const utf8Decoded = new TextDecoder().decode(encoded);
   const [prefix, ...parts] = utf8Decoded.split("\n");

--- a/packages/derived-wallet-base/src/parseAptosSigningMessage.ts
+++ b/packages/derived-wallet-base/src/parseAptosSigningMessage.ts
@@ -36,7 +36,7 @@ export function parseRawTransaction(message: Uint8Array) {
     bufferStartsWith(message, transactionWithDataSigningMessagePrefix)
   ) {
     const serialized = message.slice(
-      transactionWithDataSigningMessagePrefix.length,
+      transactionWithDataSigningMessagePrefix.length
     );
     const deserializer = new Deserializer(serialized);
     return RawTransactionWithData.deserialize(deserializer);
@@ -59,7 +59,7 @@ export type ParseSigningMessageResult =
   | ParseSigningMessageStructuredMessageResult;
 
 export function parseAptosSigningMessage(
-  message: HexInput,
+  message: HexInput
 ): ParseSigningMessageResult | undefined {
   const messageBytes = Hex.fromHexInput(message).toUint8Array();
 
@@ -71,7 +71,7 @@ export function parseAptosSigningMessage(
     } else if (parsedRawTransaction instanceof MultiAgentRawTransaction) {
       rawTransaction = new MultiAgentTransaction(
         parsedRawTransaction.raw_txn,
-        parsedRawTransaction.secondary_signer_addresses,
+        parsedRawTransaction.secondary_signer_addresses
       );
     } else if (parsedRawTransaction instanceof FeePayerRawTransaction) {
       const { raw_txn, secondary_signer_addresses, fee_payer_address } =
@@ -81,7 +81,7 @@ export function parseAptosSigningMessage(
           ? new MultiAgentTransaction(
               raw_txn,
               secondary_signer_addresses,
-              fee_payer_address,
+              fee_payer_address
             )
           : new SimpleTransaction(raw_txn, fee_payer_address);
     } else {

--- a/packages/derived-wallet-ethereum/package.json
+++ b/packages/derived-wallet-ethereum/package.json
@@ -15,6 +15,7 @@
     "build": "pnpm build:bundle && pnpm build:declarations",
     "build:bundle": "tsup --sourcemap",
     "build:declarations": "tsc --emitDeclarationOnly --declaration --declarationMap",
+    "dev": "tsup src/index.ts --format esm,cjs --watch",
     "test": "jest",
     "lint": "TIMING=1 eslint \"src/**/*.ts*\""
   },

--- a/packages/derived-wallet-ethereum/src/EIP1193DerivedPublicKey.ts
+++ b/packages/derived-wallet-ethereum/src/EIP1193DerivedPublicKey.ts
@@ -18,8 +18,8 @@ import {
 import { verifyMessage as verifyEthereumMessage } from "ethers";
 import { createSiweEnvelopeForAptosTransaction } from "./createSiweEnvelope";
 import {
-  EIP1193DerivedSignature,
-  EIP1193Signature,
+  EIP1193SiweSignature,
+  EIP1193PersonalSignature,
 } from "./EIP1193DerivedSignature";
 import { EthereumAddress } from "./shared";
 
@@ -67,14 +67,14 @@ export class EIP1193DerivedPublicKey extends AccountPublicKey {
     let messageBytes: Uint8Array | string;
     // Handle structured message, i.e. a message signed withAptosSignMessageInput
     if (parsedSigningMessage.type === "structuredMessage") {
-      if (!(signature instanceof EIP1193Signature)) return false;
+      if (!(signature instanceof EIP1193PersonalSignature)) return false;
 
       messageBytes = encodeStructuredMessage(
         parsedSigningMessage.structuredMessage
       );
     } else {
       // Handle transaction
-      if (!(signature instanceof EIP1193DerivedSignature)) return false;
+      if (!(signature instanceof EIP1193SiweSignature)) return false;
       const { issuedAt } = signature;
       const signingMessageDigest = hashValues([message]);
       // Obtain SIWE envelope for the signing message

--- a/packages/derived-wallet-ethereum/src/EIP1193DerivedSignature.ts
+++ b/packages/derived-wallet-ethereum/src/EIP1193DerivedSignature.ts
@@ -6,26 +6,16 @@ import {
   Signature,
 } from "@aptos-labs/ts-sdk";
 
-export class EIP1193DerivedSignature extends Signature {
+/**
+ * A classs representing a signature of a message signed with EIP1193
+ */
+export class EIP1193Signature extends Signature {
   static readonly LENGTH = 65;
+  protected readonly _siweSignature: Uint8Array;
 
-  // The signature of the message
-  private readonly _siweSignature: Uint8Array;
-  // The date and time when the signature was issued
-  readonly issuedAt: Date;
-  // The scheme in the URI of the message, e.g. the scheme of the website that requested the signature (http, https, etc.)
-  readonly scheme: string;
-
-  constructor(scheme: string, issuedAt: Date, siweSignature: HexInput) {
+  constructor(siweSignature: HexInput) {
     super();
     this._siweSignature = Hex.fromHexInput(siweSignature).toUint8Array();
-    if (this._siweSignature.length !== EIP1193DerivedSignature.LENGTH) {
-      throw new Error(
-        `Expected signature length to be ${EIP1193DerivedSignature.LENGTH} bytes`,
-      );
-    }
-    this.issuedAt = issuedAt;
-    this.scheme = scheme;
   }
 
   get siweSignature() {
@@ -33,12 +23,37 @@ export class EIP1193DerivedSignature extends Signature {
   }
 
   serialize(serializer: Serializer) {
+    serializer.serializeBytes(this._siweSignature);
+  }
+
+  static deserialize(deserializer: Deserializer) {
+    const signature = deserializer.deserializeBytes();
+    return new EIP1193Signature(signature);
+  }
+}
+
+/**
+ * A class representing a signature of a message signed with EIP1193 and following the SIWE standard
+ */
+export class EIP1193DerivedSignature extends EIP1193Signature {
+  // The date and time when the signature was issued
+  readonly issuedAt: Date;
+  // The scheme in the URI of the message, e.g. the scheme of the website that requested the signature (http, https, etc.)
+  readonly scheme: string;
+
+  constructor(scheme: string, issuedAt: Date, siweSignature: HexInput) {
+    super(siweSignature);
+    this.issuedAt = issuedAt;
+    this.scheme = scheme;
+  }
+
+  override serialize(serializer: Serializer) {
     serializer.serializeStr(this.scheme);
     serializer.serializeStr(this.issuedAt.toISOString());
     serializer.serializeBytes(this._siweSignature);
   }
 
-  static deserialize(deserializer: Deserializer) {
+  static override deserialize(deserializer: Deserializer) {
     const scheme = deserializer.deserializeStr();
     const issuedAt = new Date(deserializer.deserializeStr());
     const siweSignature = deserializer.deserializeBytes();

--- a/packages/derived-wallet-ethereum/src/EIP1193DerivedSignature.ts
+++ b/packages/derived-wallet-ethereum/src/EIP1193DerivedSignature.ts
@@ -9,7 +9,7 @@ import {
 /**
  * A classs representing a signature of a message signed with EIP1193
  */
-export class EIP1193Signature extends Signature {
+export class EIP1193PersonalSignature extends Signature {
   static readonly LENGTH = 65;
   protected readonly _siweSignature: Uint8Array;
 
@@ -28,14 +28,14 @@ export class EIP1193Signature extends Signature {
 
   static deserialize(deserializer: Deserializer) {
     const signature = deserializer.deserializeBytes();
-    return new EIP1193Signature(signature);
+    return new EIP1193PersonalSignature(signature);
   }
 }
 
 /**
  * A class representing a signature of a message signed with EIP1193 and following the SIWE standard
  */
-export class EIP1193DerivedSignature extends EIP1193Signature {
+export class EIP1193SiweSignature extends EIP1193PersonalSignature {
   // The date and time when the signature was issued
   readonly issuedAt: Date;
   // The scheme in the URI of the message, e.g. the scheme of the website that requested the signature (http, https, etc.)
@@ -57,6 +57,6 @@ export class EIP1193DerivedSignature extends EIP1193Signature {
     const scheme = deserializer.deserializeStr();
     const issuedAt = new Date(deserializer.deserializeStr());
     const siweSignature = deserializer.deserializeBytes();
-    return new EIP1193DerivedSignature(scheme, issuedAt, siweSignature);
+    return new EIP1193SiweSignature(scheme, issuedAt, siweSignature);
   }
 }

--- a/packages/derived-wallet-ethereum/src/EIP1193DerivedWallet.ts
+++ b/packages/derived-wallet-ethereum/src/EIP1193DerivedWallet.ts
@@ -55,7 +55,7 @@ export class EIP1193DerivedWallet implements AptosWallet {
 
   constructor(
     providerDetail: EIP6963ProviderDetail,
-    options: EIP1193DerivedWalletOptions = {},
+    options: EIP1193DerivedWalletOptions = {}
   ) {
     const { info, provider } = providerDetail;
     const {
@@ -126,11 +126,11 @@ export class EIP1193DerivedWallet implements AptosWallet {
 
   async connect(): Promise<UserResponse<AptosConnectOutput>> {
     const response = await wrapEthersUserResponse(
-      this.eip1193Ethers.getSigner(),
+      this.eip1193Ethers.getSigner()
     );
     return mapUserResponse(response, (account) => {
       const publicKey = this.derivePublicKey(
-        account.address as EthereumAddress,
+        account.address as EthereumAddress
       );
       const aptosAddress = publicKey.authKey().derivedAddress();
       return new AccountInfo({ publicKey, address: aptosAddress });
@@ -151,14 +151,14 @@ export class EIP1193DerivedWallet implements AptosWallet {
       throw new Error("Account not connected");
     }
     const publicKey = this.derivePublicKey(
-      activeAccount.address as EthereumAddress,
+      activeAccount.address as EthereumAddress
     );
     const aptosAddress = publicKey.authKey().derivedAddress();
     return new AccountInfo({ publicKey, address: aptosAddress });
   }
 
   private onAccountsChangedListeners: ((
-    newAccounts: EthereumAddress[],
+    newAccounts: EthereumAddress[]
   ) => void)[] = [];
 
   onActiveAccountChange(callback: (newAccount: AccountInfo) => void) {
@@ -188,7 +188,7 @@ export class EIP1193DerivedWallet implements AptosWallet {
   // region Networks
 
   private onActiveNetworkChangeListeners: ((
-    newNetwork: NetworkInfo,
+    newNetwork: NetworkInfo
   ) => void)[] = [];
 
   async getActiveNetwork(): Promise<NetworkInfo> {
@@ -202,7 +202,7 @@ export class EIP1193DerivedWallet implements AptosWallet {
   }
 
   async changeNetwork(
-    newNetwork: NetworkInfo,
+    newNetwork: NetworkInfo
   ): Promise<UserResponse<AptosChangeNetworkOutput>> {
     const { name, chainId, url } = newNetwork;
     if (name === Network.CUSTOM) {
@@ -235,12 +235,13 @@ export class EIP1193DerivedWallet implements AptosWallet {
   // region Signatures
 
   async signMessage(
-    input: AptosSignMessageInput,
+    input: AptosSignMessageInput
   ): Promise<UserResponse<AptosSignMessageOutput>> {
-    const chainId =
-      this.defaultNetwork === Network.DEVNET
+    const chainId = input.chainId
+      ? this.defaultNetwork === Network.DEVNET
         ? await fetchDevnetChainId()
-        : NetworkToChainId[this.defaultNetwork];
+        : NetworkToChainId[this.defaultNetwork]
+      : undefined;
     return signAptosMessageWithEthereum({
       eip1193Provider: this.eip1193Provider,
       authenticationFunction: this.authenticationFunction,
@@ -253,7 +254,7 @@ export class EIP1193DerivedWallet implements AptosWallet {
 
   async signTransaction(
     rawTransaction: AnyRawTransaction,
-    _asFeePayer?: boolean,
+    _asFeePayer?: boolean
   ): Promise<UserResponse<AccountAuthenticator>> {
     return signAptosTransactionWithEthereum({
       eip1193Provider: this.eip1193Provider,

--- a/packages/derived-wallet-ethereum/src/signAptosMessage.ts
+++ b/packages/derived-wallet-ethereum/src/signAptosMessage.ts
@@ -13,16 +13,11 @@ import { EIP1193DerivedPublicKey } from "./EIP1193DerivedPublicKey";
 import { EIP1193Signature } from "./EIP1193DerivedSignature";
 import { EthereumAddress, wrapEthersUserResponse } from "./shared";
 
-export interface StructuredMessageInputWithChainId
-  extends StructuredMessageInput {
-  chainId?: number;
-}
-
 export interface SignAptosMessageWithEthereumInput {
   eip1193Provider: Eip1193Provider | BrowserProvider;
   ethereumAddress?: EthereumAddress;
   authenticationFunction: string;
-  messageInput: StructuredMessageInputWithChainId;
+  messageInput: StructuredMessageInput;
 }
 
 export async function signAptosMessageWithEthereum(

--- a/packages/derived-wallet-ethereum/src/signAptosMessage.ts
+++ b/packages/derived-wallet-ethereum/src/signAptosMessage.ts
@@ -10,7 +10,7 @@ import {
 } from "@aptos-labs/wallet-standard";
 import { BrowserProvider, Eip1193Provider } from "ethers";
 import { EIP1193DerivedPublicKey } from "./EIP1193DerivedPublicKey";
-import { EIP1193Signature } from "./EIP1193DerivedSignature";
+import { EIP1193PersonalSignature } from "./EIP1193DerivedSignature";
 import { EthereumAddress, wrapEthersUserResponse } from "./shared";
 
 export interface SignAptosMessageWithEthereumInput {
@@ -64,7 +64,7 @@ export async function signAptosMessageWithEthereum(
   );
 
   return mapUserResponse(response, (siweSignature) => {
-    const signature = new EIP1193Signature(siweSignature);
+    const signature = new EIP1193PersonalSignature(siweSignature);
     const fullMessage = new TextDecoder().decode(signingMessage);
     return {
       prefix: "APTOS",

--- a/packages/derived-wallet-ethereum/src/signAptosMessage.ts
+++ b/packages/derived-wallet-ethereum/src/signAptosMessage.ts
@@ -4,20 +4,18 @@ import {
   StructuredMessage,
   StructuredMessageInput,
 } from "@aptos-labs/derived-wallet-base";
-import { hashValues } from "@aptos-labs/ts-sdk";
 import {
   AptosSignMessageOutput,
   UserResponse,
 } from "@aptos-labs/wallet-standard";
 import { BrowserProvider, Eip1193Provider } from "ethers";
-import { createSiweEnvelopeForAptosStructuredMessage } from "./createSiweEnvelope";
 import { EIP1193DerivedPublicKey } from "./EIP1193DerivedPublicKey";
-import { EIP1193DerivedSignature } from "./EIP1193DerivedSignature";
+import { EIP1193Signature } from "./EIP1193DerivedSignature";
 import { EthereumAddress, wrapEthersUserResponse } from "./shared";
 
 export interface StructuredMessageInputWithChainId
   extends StructuredMessageInput {
-  chainId: number;
+  chainId?: number;
 }
 
 export interface SignAptosMessageWithEthereumInput {
@@ -28,7 +26,7 @@ export interface SignAptosMessageWithEthereumInput {
 }
 
 export async function signAptosMessageWithEthereum(
-  input: SignAptosMessageWithEthereumInput,
+  input: SignAptosMessageWithEthereumInput
 ): Promise<UserResponse<AptosSignMessageOutput>> {
   const { authenticationFunction, messageInput } = input;
   const eip1193Provider =
@@ -65,29 +63,13 @@ export async function signAptosMessageWithEthereum(
   };
 
   const signingMessage = encodeStructuredMessage(structuredMessage);
-  const signingMessageDigest = hashValues([signingMessage]);
-
-  // We need to provide `issuedAt` externally so that we can match it with the signature
-  const issuedAt = new Date();
-  const siweMessage = createSiweEnvelopeForAptosStructuredMessage({
-    ethereumAddress,
-    chainId,
-    structuredMessage,
-    signingMessageDigest,
-    issuedAt,
-  });
 
   const response = await wrapEthersUserResponse(
-    ethereumAccount.signMessage(siweMessage),
+    ethereumAccount.signMessage(signingMessage)
   );
 
   return mapUserResponse(response, (siweSignature) => {
-    const scheme = window.location.protocol.slice(0, -1);
-    const signature = new EIP1193DerivedSignature(
-      scheme,
-      issuedAt,
-      siweSignature,
-    );
+    const signature = new EIP1193Signature(siweSignature);
     const fullMessage = new TextDecoder().decode(signingMessage);
     return {
       prefix: "APTOS",

--- a/packages/derived-wallet-ethereum/src/signAptosTransaction.ts
+++ b/packages/derived-wallet-ethereum/src/signAptosTransaction.ts
@@ -13,7 +13,7 @@ import {
 import { UserResponse } from "@aptos-labs/wallet-standard";
 import { BrowserProvider, Eip1193Provider } from "ethers";
 import { createSiweEnvelopeForAptosTransaction } from "./createSiweEnvelope";
-import { EIP1193DerivedSignature } from "./EIP1193DerivedSignature";
+import { EIP1193SiweSignature } from "./EIP1193DerivedSignature";
 import { EthereumAddress, wrapEthersUserResponse } from "./shared";
 
 /**
@@ -73,11 +73,7 @@ export async function signAptosTransactionWithEthereum(
     serializer.serializeU8(SIGNATURE_TYPE);
     // Remove the trailing colon from the scheme
     const scheme = window.location.protocol.slice(0, -1);
-    const signature = new EIP1193DerivedSignature(
-      scheme,
-      issuedAt,
-      siweSignature
-    );
+    const signature = new EIP1193SiweSignature(scheme, issuedAt, siweSignature);
     signature.serialize(serializer);
     const abstractSignature = serializer.toUint8Array();
 

--- a/packages/derived-wallet-solana/package.json
+++ b/packages/derived-wallet-solana/package.json
@@ -15,6 +15,7 @@
     "build": "pnpm build:bundle && pnpm build:declarations",
     "build:bundle": "tsup --sourcemap",
     "build:declarations": "tsc --emitDeclarationOnly --declaration --declarationMap",
+    "dev": "tsup src/index.ts --format esm,cjs --watch",
     "test": "jest",
     "lint": "TIMING=1 eslint \"src/**/*.ts*\""
   },

--- a/packages/derived-wallet-solana/src/SolanaDerivedWallet.ts
+++ b/packages/derived-wallet-solana/src/SolanaDerivedWallet.ts
@@ -52,7 +52,7 @@ export class SolanaDerivedWallet implements AptosWallet {
 
   constructor(
     solanaWallet: SolanaWalletAdapter,
-    options: SolanaDomainWalletOptions = {},
+    options: SolanaDomainWalletOptions = {}
   ) {
     const {
       authenticationFunction = defaultAuthenticationFunction,
@@ -181,7 +181,7 @@ export class SolanaDerivedWallet implements AptosWallet {
   }
 
   async changeNetwork(
-    newNetwork: NetworkInfo,
+    newNetwork: NetworkInfo
   ): Promise<UserResponse<AptosChangeNetworkOutput>> {
     const { name, chainId, url } = newNetwork;
     if (name === Network.CUSTOM) {
@@ -214,7 +214,7 @@ export class SolanaDerivedWallet implements AptosWallet {
   // region Signatures
 
   async signMessage(
-    input: AptosSignMessageInput,
+    input: AptosSignMessageInput
   ): Promise<UserResponse<AptosSignMessageOutput>> {
     const chainId = input.chainId
       ? this.defaultNetwork === Network.DEVNET
@@ -234,7 +234,7 @@ export class SolanaDerivedWallet implements AptosWallet {
 
   async signTransaction(
     rawTransaction: AnyRawTransaction,
-    _asFeePayer?: boolean,
+    _asFeePayer?: boolean
   ): Promise<UserResponse<AccountAuthenticator>> {
     return signAptosTransactionWithSolana({
       solanaWallet: this.solanaWallet,

--- a/packages/derived-wallet-solana/src/extendSolanaWallet.ts
+++ b/packages/derived-wallet-solana/src/extendSolanaWallet.ts
@@ -15,13 +15,13 @@ import { SolanaDerivedPublicKey } from "./SolanaDerivedPublicKey";
 
 export type SolanaWalletAdapterWithAptosFeatures = SolanaWalletAdapter & {
   getAptosPublicKey: (
-    solanaPublicKey: SolanaPublicKey,
+    solanaPublicKey: SolanaPublicKey
   ) => SolanaDerivedPublicKey;
   signAptosTransaction: (
-    rawTransaction: AnyRawTransaction,
+    rawTransaction: AnyRawTransaction
   ) => Promise<UserResponse<AccountAuthenticator>>;
   signAptosMessage: (
-    input: StructuredMessageInputWithChainId,
+    input: StructuredMessageInputWithChainId
   ) => Promise<UserResponse<AptosSignMessageOutput>>;
 };
 
@@ -40,7 +40,7 @@ export type SolanaWalletAdapterWithAptosFeatures = SolanaWalletAdapter & {
  */
 export function extendSolanaWallet(
   solanaWallet: SolanaWalletAdapter,
-  authenticationFunction = defaultAuthenticationFunction,
+  authenticationFunction = defaultAuthenticationFunction
 ) {
   const extended = solanaWallet as SolanaWalletAdapterWithAptosFeatures;
   extended.getAptosPublicKey = (solanaPublicKey: SolanaPublicKey) =>

--- a/packages/derived-wallet-solana/src/signAptosMessage.ts
+++ b/packages/derived-wallet-solana/src/signAptosMessage.ts
@@ -4,10 +4,9 @@ import {
   StructuredMessage,
   StructuredMessageInput,
 } from "@aptos-labs/derived-wallet-base";
-import { Ed25519Signature, hashValues } from "@aptos-labs/ts-sdk";
+import { Ed25519Signature } from "@aptos-labs/ts-sdk";
 import { AptosSignMessageOutput } from "@aptos-labs/wallet-standard";
 import { StandardWalletAdapter as SolanaWalletAdapter } from "@solana/wallet-standard-wallet-adapter-base";
-import { createSiwsEnvelopeForAptosStructuredMessage } from "./createSiwsEnvelope";
 import { wrapSolanaUserResponse } from "./shared";
 import { SolanaDerivedPublicKey } from "./SolanaDerivedPublicKey";
 
@@ -24,12 +23,12 @@ export interface SignAptosMessageWithSolanaInput {
 }
 
 export async function signAptosMessageWithSolana(
-  input: SignAptosMessageWithSolanaInput,
+  input: SignAptosMessageWithSolanaInput
 ) {
   const { solanaWallet, authenticationFunction, messageInput, domain } = input;
 
-  if (!solanaWallet.signIn) {
-    throw new Error("solana:signIn not available");
+  if (!solanaWallet.signMessage) {
+    throw new Error("solana:signMessage not available");
   }
 
   const solanaPublicKey = solanaWallet.publicKey;
@@ -44,9 +43,11 @@ export async function signAptosMessageWithSolana(
   });
 
   const { message, nonce, chainId, ...flags } = messageInput;
+
   const aptosAddress = flags.address
     ? aptosPublicKey.authKey().derivedAddress()
     : undefined;
+
   const application = flags.application ? window.location.origin : undefined;
   const structuredMessage: StructuredMessage = {
     address: aptosAddress?.toString(),
@@ -57,26 +58,14 @@ export async function signAptosMessageWithSolana(
   };
 
   const signingMessage = encodeStructuredMessage(structuredMessage);
-  const signingMessageDigest = hashValues([signingMessage]);
 
-  const siwsInput = createSiwsEnvelopeForAptosStructuredMessage({
-    solanaPublicKey: aptosPublicKey.solanaPublicKey,
-    structuredMessage,
-    signingMessageDigest,
-    domain,
-  });
-
-  const response = await wrapSolanaUserResponse(solanaWallet.signIn(siwsInput));
+  const response = await wrapSolanaUserResponse(
+    solanaWallet.signMessage(signingMessage)
+  );
 
   return mapUserResponse(response, (output): AptosSignMessageOutput => {
-    if (output.signatureType && output.signatureType !== "ed25519") {
-      throw new Error("Unsupported signature type");
-    }
-
-    // The wallet might change some of the fields in the SIWS input, so we
-    // might need to include the finalized input in the signature.
-    // For now, we can assume the input is unchanged.
-    const signature = new Ed25519Signature(output.signature);
+    // Solana signMessage standard always returns a Ed25519 signature type
+    const signature = new Ed25519Signature(output);
     const fullMessage = new TextDecoder().decode(signingMessage);
 
     return {


### PR DESCRIPTION
- Update EVM wallets to use default `personal_sign` API when signing a regular message
- Update Solana wallets to use default `signMessage` API when signing a regular message


https://github.com/user-attachments/assets/bfcb518e-44dd-4e86-8676-9bd09cbba6cf

