### PR TITLE
Change the signature type for EVM sign transaction

### DIFF
--- a/.changeset/mighty-jokes-unite.md
+++ b/.changeset/mighty-jokes-unite.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/derived-wallet-ethereum": patch
+---
+
+Change the signature type for signing a transaction message signature

--- a/packages/derived-wallet-ethereum/src/signAptosTransaction.ts
+++ b/packages/derived-wallet-ethereum/src/signAptosTransaction.ts
@@ -21,7 +21,7 @@ import { EthereumAddress, wrapEthersUserResponse } from "./shared";
  * authentication function on chain, and lets us identify the type of the message and to make
  * changes in the future if needed.
  */
-export const SIGNATURE_TYPE = 0;
+export const SIGNATURE_TYPE = 1;
 export interface SignAptosTransactionWithEthereumInput {
   eip1193Provider: Eip1193Provider | BrowserProvider;
   ethereumAddress?: EthereumAddress;
@@ -30,7 +30,7 @@ export interface SignAptosTransactionWithEthereumInput {
 }
 
 export async function signAptosTransactionWithEthereum(
-  input: SignAptosTransactionWithEthereumInput,
+  input: SignAptosTransactionWithEthereumInput
 ): Promise<UserResponse<AccountAuthenticator>> {
   const { authenticationFunction, rawTransaction } = input;
   const eip1193Provider =
@@ -64,7 +64,7 @@ export async function signAptosTransactionWithEthereum(
   });
 
   const response = await wrapEthersUserResponse(
-    ethereumAccount.signMessage(siweMessage),
+    ethereumAccount.signMessage(siweMessage)
   );
 
   return mapUserResponse(response, (siweSignature) => {
@@ -76,7 +76,7 @@ export async function signAptosTransactionWithEthereum(
     const signature = new EIP1193DerivedSignature(
       scheme,
       issuedAt,
-      siweSignature,
+      siweSignature
     );
     signature.serialize(serializer);
     const abstractSignature = serializer.toUint8Array();
@@ -84,14 +84,14 @@ export async function signAptosTransactionWithEthereum(
     // Serialize the abstract public key.
     const abstractPublicKey = new DerivableAbstractPublicKey(
       ethereumAddress,
-      window.location.host,
+      window.location.host
     );
 
     return new AccountAuthenticatorAbstraction(
       authenticationFunction,
       signingMessageDigest,
       abstractSignature,
-      abstractPublicKey.bcsToBytes(),
+      abstractPublicKey.bcsToBytes()
     );
   });
 }


### PR DESCRIPTION
Following https://github.com/aptos-labs/aptos-core/pull/16524 , changing the signature type to `1` to match the new `MessageV2` enum