### PR TITLE
Cross chain wallet packages as an optional peer dependencies

### DIFF
--- a/.changeset/late-snails-stick.md
+++ b/.changeset/late-snails-stick.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/wallet-adapter-react": patch
+---
+
+Define cross chain wallet packages as an optional peer dependencies

--- a/packages/wallet-adapter-react/package.json
+++ b/packages/wallet-adapter-react/package.json
@@ -55,6 +55,14 @@
     "@aptos-labs/derived-wallet-solana": "workspace:*",
     "@aptos-labs/derived-wallet-ethereum": "workspace:*"
   },
+  "peerDependenciesMeta": {
+    "@aptos-labs/derived-wallet-solana": {
+      "optional": true
+    },
+    "@aptos-labs/derived-wallet-ethereum": {
+      "optional": true
+    }
+  },
   "files": [
     "dist",
     "src",


### PR DESCRIPTION
Define cross chain wallet packages as an optional peer dependencies in the `@aptos-labs/wallet-adapter-react` package