### PR TITLE
Remove derived wallet packages peer dependencies from the `@aptos-labs/wallet-adapter-react` package

### DIFF
--- a/.changeset/legal-bees-ring.md
+++ b/.changeset/legal-bees-ring.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/wallet-adapter-react": minor
+---
+
+Remove derived wallet packages peer dependecies

--- a/apps/nextjs-x-chain/src/app/components/CCTPTransfer.tsx
+++ b/apps/nextjs-x-chain/src/app/components/CCTPTransfer.tsx
@@ -31,6 +31,8 @@ import {
   OriginWalletDetails,
   useWallet,
 } from "@aptos-labs/wallet-adapter-react";
+import { isEIP1193DerivedWallet } from "@/utils/derivedWallet";
+import { isSolanaDerivedWallet } from "@/utils/derivedWallet";
 
 const dappNetwork: Network.MAINNET | Network.TESTNET = Network.TESTNET;
 
@@ -97,9 +99,10 @@ export function CCTPTransfer({
   const [sourceChain, setSourceChain] = useState<Chain | null>(null);
 
   useEffect(() => {
-    if (wallet instanceof SolanaDerivedWallet) {
+    if (!wallet) return;
+    if (isSolanaDerivedWallet(wallet)) {
       setSourceChain("Solana");
-    } else if (wallet instanceof EIP1193DerivedWallet) {
+    } else if (isEIP1193DerivedWallet(wallet)) {
       setSourceChain("Sepolia");
     } else {
       setSourceChain("Aptos");

--- a/apps/nextjs-x-chain/src/app/components/CCTPTransfer.tsx
+++ b/apps/nextjs-x-chain/src/app/components/CCTPTransfer.tsx
@@ -21,17 +21,15 @@ import {
   WormholeInitiateTransferResponse,
   WormholeQuoteResponse,
 } from "@aptos-labs/cross-chain-core";
-import { SolanaDerivedWallet } from "@aptos-labs/derived-wallet-solana";
 import { AdapterWallet } from "@aptos-labs/wallet-adapter-core";
 import { Loader2, MoveDown } from "lucide-react";
 import USDC from "@/app/icons/USDC";
 import { chainToIcon } from "@/app/icons";
-import { EIP1193DerivedWallet } from "@aptos-labs/derived-wallet-ethereum";
+import { useWallet } from "@aptos-labs/wallet-adapter-react";
 import {
+  isEIP1193DerivedWallet,
   OriginWalletDetails,
-  useWallet,
-} from "@aptos-labs/wallet-adapter-react";
-import { isEIP1193DerivedWallet } from "@/utils/derivedWallet";
+} from "@/utils/derivedWallet";
 import { isSolanaDerivedWallet } from "@/utils/derivedWallet";
 
 const dappNetwork: Network.MAINNET | Network.TESTNET = Network.TESTNET;

--- a/apps/nextjs-x-chain/src/app/components/WalletConnection.tsx
+++ b/apps/nextjs-x-chain/src/app/components/WalletConnection.tsx
@@ -2,7 +2,10 @@ import { DisplayValue, LabelValueGrid } from "@/components/LabelValueGrid";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
-import { isSolanaDerivedWallet } from "@/utils/derivedWallet";
+import {
+  isSolanaDerivedWallet,
+  OriginWalletDetails,
+} from "@/utils/derivedWallet";
 import { isEIP1193DerivedWallet } from "@/utils/derivedWallet";
 import { Network } from "@aptos-labs/ts-sdk";
 import {
@@ -11,8 +14,6 @@ import {
   AptosChangeNetworkOutput,
   isAptosNetwork,
   NetworkInfo,
-  OriginWalletDetails,
-  useWallet,
 } from "@aptos-labs/wallet-adapter-react";
 import Image from "next/image";
 

--- a/apps/nextjs-x-chain/src/app/components/WalletConnection.tsx
+++ b/apps/nextjs-x-chain/src/app/components/WalletConnection.tsx
@@ -2,6 +2,8 @@ import { DisplayValue, LabelValueGrid } from "@/components/LabelValueGrid";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { isSolanaDerivedWallet } from "@/utils/derivedWallet";
+import { isEIP1193DerivedWallet } from "@/utils/derivedWallet";
 import { Network } from "@aptos-labs/ts-sdk";
 import {
   AccountInfo,
@@ -29,8 +31,6 @@ export function WalletConnection({
   changeNetwork,
   originWalletDetails,
 }: WalletConnectionProps) {
-  const { isSolanaDerivedWallet, isEIP1193DerivedWallet } = useWallet();
-
   const isValidNetworkName = () => {
     if (isAptosNetwork(network)) {
       return Object.values<string | undefined>(Network).includes(network?.name);

--- a/apps/nextjs-x-chain/src/app/page.tsx
+++ b/apps/nextjs-x-chain/src/app/page.tsx
@@ -21,6 +21,7 @@ import {
   WalletConnection,
   WalletSelection,
 } from "./components";
+import { getOriginWalletDetails } from "@/utils/derivedWallet";
 
 // Example of how to register a browser extension wallet plugin.
 // Browser extension wallets should call registerWallet once on page load.
@@ -39,14 +40,7 @@ if (isTelegramMiniApp) {
 }
 
 export default function Home() {
-  const {
-    account,
-    connected,
-    network,
-    wallet,
-    changeNetwork,
-    getOriginWalletDetails,
-  } = useWallet();
+  const { account, connected, network, wallet, changeNetwork } = useWallet();
 
   const [originWalletDetails, setOriginWalletDetails] = useState<
     OriginWalletDetails | undefined

--- a/apps/nextjs-x-chain/src/app/page.tsx
+++ b/apps/nextjs-x-chain/src/app/page.tsx
@@ -6,10 +6,7 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 // Imports for registering a browser extension wallet plugin on page load
 import { MyWallet } from "@/utils/standardWallet";
 import { Network } from "@aptos-labs/ts-sdk";
-import {
-  OriginWalletDetails,
-  useWallet,
-} from "@aptos-labs/wallet-adapter-react";
+import { useWallet } from "@aptos-labs/wallet-adapter-react";
 import { registerWallet } from "@aptos-labs/wallet-standard";
 import { init as initTelegram } from "@telegram-apps/sdk";
 import { AlertCircle } from "lucide-react";
@@ -21,7 +18,10 @@ import {
   WalletConnection,
   WalletSelection,
 } from "./components";
-import { getOriginWalletDetails } from "@/utils/derivedWallet";
+import {
+  getOriginWalletDetails,
+  OriginWalletDetails,
+} from "@/utils/derivedWallet";
 
 // Example of how to register a browser extension wallet plugin.
 // Browser extension wallets should call registerWallet once on page load.

--- a/apps/nextjs-x-chain/src/utils/derivedWallet.ts
+++ b/apps/nextjs-x-chain/src/utils/derivedWallet.ts
@@ -1,0 +1,71 @@
+import { AnyPublicKey as AptosAnyPublicKey } from "@aptos-labs/wallet-adapter-core";
+import { AccountAddress } from "@aptos-labs/ts-sdk";
+
+import { AccountInfo } from "@aptos-labs/wallet-adapter-core";
+
+import { EIP1193DerivedWallet } from "@aptos-labs/derived-wallet-ethereum";
+import {
+  SolanaDerivedWallet,
+  SolanaPublicKey,
+} from "@aptos-labs/derived-wallet-solana";
+import { AdapterWallet } from "@aptos-labs/wallet-adapter-react";
+
+// Define the type for the origin wallet details
+export type OriginWalletDetails =
+  | {
+      address: string | AccountAddress;
+      publicKey?: SolanaPublicKey | AptosAnyPublicKey | undefined;
+    }
+  | AccountInfo
+  | null;
+
+// Define a function to check if a wallet is a Solana derived wallet
+export function isSolanaDerivedWallet(
+  wallet: AdapterWallet
+): wallet is SolanaDerivedWallet {
+  return wallet instanceof SolanaDerivedWallet;
+}
+
+// Define a function to check if a wallet is an EIP1193 derived wallet
+export function isEIP1193DerivedWallet(
+  wallet: AdapterWallet
+): wallet is EIP1193DerivedWallet {
+  return wallet instanceof EIP1193DerivedWallet;
+}
+
+// Define specific return types based on wallet type
+type SolanaWalletDetails = { address: string; publicKey: SolanaPublicKey };
+type EVMWalletDetails = { address: string; publicKey?: undefined };
+
+// Define a function to get the origin wallet details based on the wallet type
+export async function getOriginWalletDetails(
+  wallet: SolanaDerivedWallet
+): Promise<SolanaWalletDetails>;
+export async function getOriginWalletDetails(
+  wallet: EIP1193DerivedWallet
+): Promise<EVMWalletDetails>;
+export async function getOriginWalletDetails(
+  wallet: AdapterWallet
+): Promise<OriginWalletDetails | undefined>;
+
+// Define the implementation of the function
+export async function getOriginWalletDetails(
+  wallet: AdapterWallet
+): Promise<OriginWalletDetails | undefined> {
+  if (isSolanaDerivedWallet(wallet)) {
+    const publicKey = wallet.solanaWallet.publicKey;
+    return {
+      publicKey: publicKey ?? undefined,
+      address: publicKey?.toBase58() ?? "",
+    };
+  } else if (isEIP1193DerivedWallet(wallet)) {
+    const [activeAccount] = await wallet.eip1193Ethers.listAccounts();
+    return {
+      publicKey: undefined, // No public key for EVM wallets
+      address: activeAccount.address,
+    };
+  } else {
+    // Assume Aptos Wallet
+    return undefined;
+  }
+}

--- a/packages/wallet-adapter-react/package.json
+++ b/packages/wallet-adapter-react/package.json
@@ -42,18 +42,14 @@
     "@types/react-dom": "^18.3.0",
     "eslint": "^8.15.0",
     "tsup": "^8.4.0",
-    "typescript": "^5.4.5",
-    "@aptos-labs/derived-wallet-solana": "workspace:*",
-    "@aptos-labs/derived-wallet-ethereum": "workspace:*"
+    "typescript": "^5.4.5"
   },
   "dependencies": {
     "@aptos-labs/wallet-adapter-core": "workspace:*",
     "@radix-ui/react-slot": "^1.0.2"
   },
   "peerDependencies": {
-    "react": "^18.0.0 || ^19.0.0",
-    "@aptos-labs/derived-wallet-solana": "workspace:*",
-    "@aptos-labs/derived-wallet-ethereum": "workspace:*"
+    "react": "^18.0.0 || ^19.0.0"
   },
   "files": [
     "dist",

--- a/packages/wallet-adapter-react/src/WalletProvider.tsx
+++ b/packages/wallet-adapter-react/src/WalletProvider.tsx
@@ -19,16 +19,9 @@ import {
   WalletReadyState,
   AptosSignInInput,
   AptosSignInOutput,
-  AnyPublicKey as AptosAnyPublicKey,
-  AccountAddress,
 } from "@aptos-labs/wallet-adapter-core";
 import { ReactNode, FC, useState, useEffect, useCallback, useRef } from "react";
 import { WalletContext } from "./useWallet";
-import {
-  SolanaDerivedWallet,
-  SolanaPublicKey,
-} from "@aptos-labs/derived-wallet-solana";
-import { EIP1193DerivedWallet } from "@aptos-labs/derived-wallet-ethereum";
 
 export interface AptosWalletProviderProps {
   children: ReactNode;
@@ -40,14 +33,6 @@ export interface AptosWalletProviderProps {
   disableTelemetry?: boolean;
   onError?: (error: any) => void;
 }
-
-export type OriginWalletDetails =
-  | {
-      address: string | AccountAddress;
-      publicKey?: SolanaPublicKey | AptosAnyPublicKey | undefined;
-    }
-  | AccountInfo
-  | null;
 
 const initialState: {
   account: AccountInfo | null;
@@ -86,7 +71,7 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
     const walletCore = new WalletCore(
       optInWallets,
       dappConfig,
-      disableTelemetry,
+      disableTelemetry
     );
     setWalletCore(walletCore);
   }, []);
@@ -119,7 +104,7 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
 
     // Make sure the wallet is installed
     const selectedWallet = walletCore.wallets.find(
-      (e) => e.name === walletName,
+      (e) => e.name === walletName
     ) as AdapterWallet | undefined;
     if (
       !selectedWallet ||
@@ -194,7 +179,7 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
   };
 
   const signAndSubmitTransaction = async (
-    transaction: InputTransactionData,
+    transaction: InputTransactionData
   ): Promise<AptosSignAndSubmitTransactionOutput> => {
     try {
       if (!walletCore) {
@@ -234,7 +219,7 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
   };
 
   const submitTransaction = async (
-    transaction: InputSubmitTransactionData,
+    transaction: InputSubmitTransactionData
   ): Promise<PendingTransactionResponse> => {
     if (!walletCore) {
       throw new Error("WalletCore is not initialized");
@@ -248,7 +233,7 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
   };
 
   const signMessage = async (
-    message: AptosSignMessageInput,
+    message: AptosSignMessageInput
   ): Promise<AptosSignMessageOutput> => {
     if (!walletCore) {
       throw new Error("WalletCore is not initialized");
@@ -262,7 +247,7 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
   };
 
   const signMessageAndVerify = async (
-    message: AptosSignMessageInput,
+    message: AptosSignMessageInput
   ): Promise<boolean> => {
     if (!walletCore) {
       throw new Error("WalletCore is not initialized");
@@ -349,7 +334,7 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
     // Manage current wallet state by removing optional duplications
     // as new wallets are coming
     const existingWalletIndex = wallets.findIndex(
-      (wallet) => wallet.name == standardWallet.name,
+      (wallet) => wallet.name == standardWallet.name
     );
     if (existingWalletIndex !== -1) {
       // If wallet exists, replace it with the new wallet
@@ -365,12 +350,12 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
   };
 
   const handleStandardNotDetectedWalletsAdded = (
-    notDetectedWallet: AdapterNotDetectedWallet,
+    notDetectedWallet: AdapterNotDetectedWallet
   ): void => {
     // Manage current wallet state by removing optional duplications
     // as new wallets are coming
     const existingWalletIndex = wallets.findIndex(
-      (wallet) => wallet.name == notDetectedWallet.name,
+      (wallet) => wallet.name == notDetectedWallet.name
     );
     if (existingWalletIndex !== -1) {
       // If wallet exists, replace it with the new wallet
@@ -393,7 +378,7 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
     walletCore?.on("standardWalletsAdded", handleStandardWalletsAdded);
     walletCore?.on(
       "standardNotDetectedWalletAdded",
-      handleStandardNotDetectedWalletsAdded,
+      handleStandardNotDetectedWalletsAdded
     );
     return () => {
       walletCore?.off("connect", handleConnect);
@@ -403,57 +388,10 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
       walletCore?.off("standardWalletsAdded", handleStandardWalletsAdded);
       walletCore?.off(
         "standardNotDetectedWalletAdded",
-        handleStandardNotDetectedWalletsAdded,
+        handleStandardNotDetectedWalletsAdded
       );
     };
   }, [wallets, account]);
-
-  // Define specific return types based on wallet type
-  type SolanaWalletDetails = { address: string; publicKey: SolanaPublicKey };
-  type EVMWalletDetails = { address: string; publicKey?: undefined };
-  type AptosWalletDetails = AccountInfo | null;
-
-  // Function overloads
-  function getOriginWalletDetails(
-    wallet: SolanaDerivedWallet,
-  ): Promise<SolanaWalletDetails>;
-  function getOriginWalletDetails(
-    wallet: EIP1193DerivedWallet,
-  ): Promise<EVMWalletDetails>;
-
-  // Implementation
-  async function getOriginWalletDetails(
-    wallet: AdapterWallet,
-  ): Promise<OriginWalletDetails | undefined> {
-    if (isSolanaDerivedWallet(wallet)) {
-      const publicKey = wallet.solanaWallet.publicKey;
-      return {
-        publicKey: publicKey ?? undefined,
-        address: publicKey?.toBase58() ?? "",
-      };
-    } else if (isEIP1193DerivedWallet(wallet)) {
-      const [activeAccount] = await wallet.eip1193Ethers.listAccounts();
-      return {
-        publicKey: undefined, // No public key for EVM wallets
-        address: activeAccount.address,
-      };
-    } else {
-      // Assume Aptos Wallet
-      return undefined;
-    }
-  }
-
-  function isSolanaDerivedWallet(
-    wallet: AdapterWallet,
-  ): wallet is SolanaDerivedWallet {
-    return wallet instanceof SolanaDerivedWallet;
-  }
-
-  function isEIP1193DerivedWallet(
-    wallet: AdapterWallet,
-  ): wallet is EIP1193DerivedWallet {
-    return wallet instanceof EIP1193DerivedWallet;
-  }
 
   return (
     <WalletContext.Provider
@@ -467,9 +405,6 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
         signMessageAndVerify,
         changeNetwork,
         submitTransaction,
-        getOriginWalletDetails,
-        isSolanaDerivedWallet,
-        isEIP1193DerivedWallet,
         account,
         network,
         connected,

--- a/packages/wallet-adapter-react/src/useWallet.tsx
+++ b/packages/wallet-adapter-react/src/useWallet.tsx
@@ -17,7 +17,6 @@ import {
   AptosSignInInput,
   AptosSignInOutput,
 } from "@aptos-labs/wallet-adapter-core";
-import { OriginWalletDetails } from "./WalletProvider";
 
 export interface WalletContextState {
   connected: boolean;
@@ -30,7 +29,7 @@ export interface WalletContextState {
     input: AptosSignInInput;
   }): Promise<AptosSignInOutput | void>;
   signAndSubmitTransaction(
-    transaction: InputTransactionData,
+    transaction: InputTransactionData
   ): Promise<AptosSignAndSubmitTransactionOutput>;
   signTransaction(args: {
     transactionOrPayload: AnyRawTransaction | InputTransactionData;
@@ -44,13 +43,8 @@ export interface WalletContextState {
   disconnect(): void;
   changeNetwork(network: Network): Promise<AptosChangeNetworkOutput>;
   submitTransaction(
-    transaction: InputSubmitTransactionData,
+    transaction: InputSubmitTransactionData
   ): Promise<PendingTransactionResponse>;
-  getOriginWalletDetails(
-    wallet: AdapterWallet,
-  ): Promise<OriginWalletDetails | undefined>;
-  isSolanaDerivedWallet(wallet: AdapterWallet): boolean;
-  isEIP1193DerivedWallet(wallet: AdapterWallet): boolean;
   wallet: AdapterWallet | null;
   wallets: ReadonlyArray<AdapterWallet>;
   notDetectedWallets: ReadonlyArray<AdapterNotDetectedWallet>;
@@ -61,7 +55,7 @@ const DEFAULT_CONTEXT = {
 };
 
 export const WalletContext = createContext<WalletContextState>(
-  DEFAULT_CONTEXT as WalletContextState,
+  DEFAULT_CONTEXT as WalletContextState
 );
 
 export function useWallet(): WalletContextState {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -773,12 +773,6 @@ importers:
         specifier: ^18.0.0 || ^19.0.0
         version: 18.3.1
     devDependencies:
-      '@aptos-labs/derived-wallet-ethereum':
-        specifier: workspace:*
-        version: link:../derived-wallet-ethereum
-      '@aptos-labs/derived-wallet-solana':
-        specifier: workspace:*
-        version: link:../derived-wallet-solana
       '@aptos-labs/wallet-adapter-tsconfig':
         specifier: workspace:*
         version: link:../tsconfig


### PR DESCRIPTION
Having the derived wallet packages as peerDependencies in the wallet-adapter-react packages requires users to install those packages even if they dont intend to use this feature.
We also can't define those as optional peerDependencies as the react package actually imports instances from those packages.

So removing the use of the derived wallet packages from the react package and move it to be implemented on the dapp level