### PR TITLE
Fix potential wallet duplications

### DIFF
--- a/.changeset/petite-mice-dream.md
+++ b/.changeset/petite-mice-dream.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/wallet-adapter-core": patch
+---
+
+Fix potential wallet duplications by not pushing the wallet if it already exists in the known standard wallets array

--- a/packages/wallet-adapter-core/src/WalletCore.ts
+++ b/packages/wallet-adapter-core/src/WalletCore.ts
@@ -234,12 +234,8 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
         return;
       }
 
-      // Remove optional duplications in the _all_wallets array
-      this._standard_wallets = this._standard_wallets.filter(
-        (item) => item.name !== wallet.name
-      );
-
       const isValid = isWalletWithRequiredFeatureSet(wallet);
+
       if (isValid) {
         // check if we already have this wallet as a not detected wallet
         const index = this._standard_not_detected_wallets.findIndex(
@@ -250,9 +246,15 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
           this._standard_not_detected_wallets.splice(index, 1);
         }
 
-        wallet.readyState = WalletReadyState.Installed;
-        this._standard_wallets.push(wallet);
-        this.emit("standardWalletsAdded", wallet);
+        // ✅ Check if wallet already exists in _standard_wallets
+        const alreadyExists = this._standard_wallets.some(
+          (w) => w.name === wallet.name
+        );
+        if (!alreadyExists) {
+          wallet.readyState = WalletReadyState.Installed;
+          this._standard_wallets.push(wallet);
+          this.emit("standardWalletsAdded", wallet);
+        }
       }
     });
   }


### PR DESCRIPTION
Sometimes wallets show up as duplicated in the wallet selector modal. Was able to reproduce it only in production (might be because of react double rerender in dev) and only for x-chain wallets.

Fixing it by first check if wallet already exists in the `standard_wallets` array, and only if it is not push it and fire the `standardWalletsAdded` event