### PR TITLE
Use fee payer account details from `.env` file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,8 @@ jobs:
           GITHUB_TOKEN: ${{ steps.authenticate.outputs.token }}
           NPM_TOKEN: ${{ secrets.APTOS_LABS_NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
+          NEXT_PUBLIC_SWAP_CCTP_SPONSOR_ACCOUNT_PRIVATE_KEY: ${{ secrets.NEXT_PUBLIC_SWAP_CCTP_SPONSOR_ACCOUNT_PRIVATE_KEY }}
+          NEXT_PUBLIC_SWAP_CCTP_MAIN_SIGNER_PRIVATE_KEY: ${{ secrets.NEXT_PUBLIC_SWAP_CCTP_MAIN_SIGNER_PRIVATE_KEY }}
       - name: Deploy example dapps on Publish to npm
         if: steps.changesets.outputs.published == 'true' # Runs only if publishing happened
         run: |

--- a/apps/nextjs-x-chain/src/app/components/CCTPTransfer.tsx
+++ b/apps/nextjs-x-chain/src/app/components/CCTPTransfer.tsx
@@ -42,21 +42,21 @@ const provider = crossChainCore.getProvider("Wormhole");
 let mainSigner: Account;
 let sponsorAccount: Account;
 
+// Set the main signer account
+const mainSignerPrivateKey =
+  process.env.NEXT_PUBLIC_SWAP_CCTP_MAIN_SIGNER_PRIVATE_KEY ||
+  "0x0000000000000000000000000000000000000000000000000000000000000000";
 const privateKey = new Ed25519PrivateKey(
-  PrivateKey.formatPrivateKey(
-    (process.env.NEXT_PUBLIC_SWAP_CCTP_MAIN_SIGNER_PRIVATE_KEY as string) ??
-      "0x0000000000000000000000000000000000000000000000000000000000000000",
-    PrivateKeyVariants.Ed25519
-  )
+  PrivateKey.formatPrivateKey(mainSignerPrivateKey, PrivateKeyVariants.Ed25519)
 );
 mainSigner = Account.fromPrivateKey({ privateKey });
 
+// Set the sponsor account
+const sponsorPrivateKey =
+  process.env.NEXT_PUBLIC_SWAP_CCTP_SPONSOR_ACCOUNT_PRIVATE_KEY ||
+  "0x0000000000000000000000000000000000000000000000000000000000000000";
 const feePayerPrivateKey = new Ed25519PrivateKey(
-  PrivateKey.formatPrivateKey(
-    (process.env.NEXT_PUBLIC_SWAP_CCTP_SPONSOR_ACCOUNT_PRIVATE_KEY as string) ??
-      "0x0000000000000000000000000000000000000000000000000000000000000000",
-    PrivateKeyVariants.Ed25519
-  )
+  PrivateKey.formatPrivateKey(sponsorPrivateKey, PrivateKeyVariants.Ed25519)
 );
 sponsorAccount = Account.fromPrivateKey({
   privateKey: feePayerPrivateKey,


### PR DESCRIPTION
Using sponsor account configured in `.env` file for:
1. When signing and submitting a transaction from a x-chain account.
2. When the x-chain account initiates a CCTP transfer (from the origin x-chain wallet to its derived aptos account). 

Also, added to the repository secrets.