### PR TITLE
Add support for base settings when building Aptos

### DIFF
--- a/packages/cross-chain-core/package.json
+++ b/packages/cross-chain-core/package.json
@@ -75,7 +75,7 @@
     "tweetnacl": "^1.0.3"
   },
   "peerDependencies": {
-    "@aptos-labs/ts-sdk": "^1.38.0 || ^2.0.0"
+    "@aptos-labs/ts-sdk": "^1.38.0 || ^2.0.0 || ^3.0.0"
   },
   "files": [
     "dist",

--- a/packages/derived-wallet-base/package.json
+++ b/packages/derived-wallet-base/package.json
@@ -32,7 +32,7 @@
     "@aptos-labs/wallet-standard": "^0.3.0"
   },
   "peerDependencies": {
-    "@aptos-labs/ts-sdk": "^1.38.0 || ^2.0.0"
+    "@aptos-labs/ts-sdk": "^1.38.0 || ^2.0.0 || ^3.0.0"
   },
   "devDependencies": {
     "@aptos-labs/eslint-config-adapter": "workspace:*",

--- a/packages/derived-wallet-ethereum/package.json
+++ b/packages/derived-wallet-ethereum/package.json
@@ -38,7 +38,7 @@
     "viem": "^2.23.12"
   },
   "peerDependencies": {
-    "@aptos-labs/ts-sdk": "^1.38.0 || ^2.0.0"
+    "@aptos-labs/ts-sdk": "^1.38.0 || ^2.0.0 || ^3.0.0"
   },
   "devDependencies": {
     "@aptos-labs/eslint-config-adapter": "workspace:*",

--- a/packages/derived-wallet-solana/package.json
+++ b/packages/derived-wallet-solana/package.json
@@ -39,7 +39,7 @@
     "@wallet-standard/app": "^1.1.0"
   },
   "peerDependencies": {
-    "@aptos-labs/ts-sdk": "^1.38.0 || ^2.0.0"
+    "@aptos-labs/ts-sdk": "^1.38.0 || ^2.0.0 || ^3.0.0"
   },
   "devDependencies": {
     "@aptos-labs/eslint-config-adapter": "workspace:*",

--- a/packages/wallet-adapter-core/src/WalletCore.ts
+++ b/packages/wallet-adapter-core/src/WalletCore.ts
@@ -6,6 +6,7 @@ import {
   AnyPublicKeyVariant,
   AnyRawTransaction,
   Aptos,
+  AptosSettings,
   Ed25519PublicKey,
   InputSubmitTransactionData,
   MultiEd25519PublicKey,
@@ -114,6 +115,15 @@ export type AdapterNotDetectedWallet = Omit<
 
 export interface DappConfig {
   network: Network;
+  /**
+   * These settings will be used as a base when building an Aptos client. Certain
+   * settings here such as nodeUrl, API keys, etc. may be overridden.
+   */
+  baseSettings?: Omit<AptosSettings, "network">;
+  /**
+   * If both additionalSettings and aptosApiKeys are provided, aptosApiKeys will take
+   * precedence.
+   */
   aptosApiKeys?: Partial<Record<Network, string>>;
   aptosConnectDappId?: string;
   aptosConnect?: Omit<AptosConnectWalletConfig, "network">;

--- a/packages/wallet-adapter-core/src/utils/helpers.ts
+++ b/packages/wallet-adapter-core/src/utils/helpers.ts
@@ -68,12 +68,14 @@ export const getAptosConfig = (
     if (isAptosLiveNetwork(currentNetwork)) {
       const apiKey = dappConfig?.aptosApiKeys;
       return new AptosConfig({
+        ...dappConfig?.baseSettings,
         network: currentNetwork,
         clientConfig: { API_KEY: apiKey ? apiKey[currentNetwork] : undefined },
       });
     }
 
     return new AptosConfig({
+      ...dappConfig?.baseSettings,
       network: currentNetwork,
     });
   }
@@ -89,6 +91,7 @@ export const getAptosConfig = (
 
     if (isKnownNetwork) {
       return new AptosConfig({
+        ...dappConfig?.baseSettings,
         network: Network.CUSTOM,
         fullnode: networkInfo.url,
       });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -352,7 +352,7 @@ importers:
         specifier: workspace:*
         version: link:../derived-wallet-solana
       '@aptos-labs/ts-sdk':
-        specifier: ^1.38.0 || ^2.0.0
+        specifier: ^1.38.0 || ^2.0.0 || ^3.0.0
         version: 2.0.0(axios@1.8.4)(got@11.8.6)
       '@aptos-labs/wallet-adapter-core':
         specifier: workspace:*
@@ -449,7 +449,7 @@ importers:
   packages/derived-wallet-base:
     dependencies:
       '@aptos-labs/ts-sdk':
-        specifier: ^1.38.0 || ^2.0.0
+        specifier: ^1.38.0 || ^2.0.0 || ^3.0.0
         version: 2.0.0(axios@1.8.4)(got@11.8.6)
       '@aptos-labs/wallet-standard':
         specifier: ^0.3.0
@@ -492,7 +492,7 @@ importers:
         specifier: ^0.2.5
         version: 0.2.5(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0)
       '@aptos-labs/ts-sdk':
-        specifier: ^1.38.0 || ^2.0.0
+        specifier: ^1.38.0 || ^2.0.0 || ^3.0.0
         version: 2.0.0(axios@1.8.4)(got@11.8.6)
       '@aptos-labs/wallet-standard':
         specifier: ^0.3.0
@@ -547,7 +547,7 @@ importers:
         specifier: ^0.2.5
         version: 0.2.5(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0)
       '@aptos-labs/ts-sdk':
-        specifier: ^1.38.0 || ^2.0.0
+        specifier: ^1.38.0 || ^2.0.0 || ^3.0.0
         version: 2.0.0(axios@1.8.4)(got@11.8.6)
       '@aptos-labs/wallet-standard':
         specifier: ^0.3.0


### PR DESCRIPTION
## Stack
- Prev: N/A
- Next: #605

<!--stack_end-->

## Summary
This PR adds support for the dapp providing more settings for the wallet adapter to use when building an Aptos client. This can be used to override things related to txn submission for example, such as with the new txn submission plugin support.

## Test Plan
todo