### PR TITLE
Add support for the transactionSubmitter param

### DIFF
--- a/.changeset/sweet-aliens-crash.md
+++ b/.changeset/sweet-aliens-crash.md
@@ -1,0 +1,13 @@
+---
+"@aptos-labs/derived-wallet-ethereum": minor
+"@aptos-labs/derived-wallet-solana": minor
+"@aptos-labs/derived-wallet-base": minor
+"@aptos-labs/wallet-adapter-core": major
+"@aptos-labs/cross-chain-core": major
+"@aptos-labs/wallet-adapter-ant-design": major
+"@aptos-labs/wallet-adapter-mui-design": major
+"@aptos-labs/wallet-adapter-react": major
+"@aptos-labs/wallet-adapter-vue": major
+---
+
+Add support for transactionSubmitter, bump minimum TS SDK version to 3.x.x

--- a/apps/nextjs-example/package.json
+++ b/apps/nextjs-example/package.json
@@ -11,7 +11,7 @@
     "format": "prettier --write './**/*.{ts,tsx,js,jsx,json,md,html,css}'"
   },
   "dependencies": {
-    "@aptos-labs/ts-sdk": "^2.0.0",
+    "@aptos-labs/ts-sdk": "^3.1.1",
     "@aptos-labs/wallet-adapter-ant-design": "workspace:*",
     "@aptos-labs/wallet-adapter-core": "workspace:*",
     "@aptos-labs/wallet-adapter-mui-design": "workspace:*",

--- a/apps/nextjs-example/src/app/layout.tsx
+++ b/apps/nextjs-example/src/app/layout.tsx
@@ -10,6 +10,7 @@ import { Inter as FontSans } from "next/font/google";
 import { PropsWithChildren } from "react";
 import { AutoConnectProvider } from "@/components/AutoConnectProvider";
 import { ReactQueryClientProvider } from "@/components/ReactQueryClientProvider";
+import { TransactionSubmitterProvider } from "@/components/TransactionSubmitterProvider";
 
 const fontSans = FontSans({
   subsets: ["latin"],
@@ -39,10 +40,12 @@ export default function RootLayout({ children }: PropsWithChildren) {
         >
           <AutoConnectProvider>
             <ReactQueryClientProvider>
-              <WalletProvider>
-                {children}
-                <Toaster />
-              </WalletProvider>
+              <TransactionSubmitterProvider>
+                <WalletProvider>
+                  {children}
+                  <Toaster />
+                </WalletProvider>
+              </TransactionSubmitterProvider>
             </ReactQueryClientProvider>
           </AutoConnectProvider>
         </ThemeProvider>

--- a/apps/nextjs-example/src/app/page.tsx
+++ b/apps/nextjs-example/src/app/page.tsx
@@ -28,7 +28,6 @@ import {
   AdapterWallet,
   AptosChangeNetworkOutput,
   NetworkInfo,
-  WalletInfo,
   isAptosNetwork,
   useWallet,
 } from "@aptos-labs/wallet-adapter-react";
@@ -39,6 +38,7 @@ import Image from "next/image";
 // Imports for registering a browser extension wallet plugin on page load
 import { MyWallet } from "@/utils/standardWallet";
 import { registerWallet } from "@aptos-labs/wallet-standard";
+import { TransactionSubmitterToggle } from "@/components/TransactionSubmitterToggle";
 
 // Example of how to register a browser extension wallet plugin.
 // Browser extension wallets should call registerWallet once on page load.
@@ -76,7 +76,10 @@ export default function Home() {
             Demo App Source Code
           </a>
         </div>
-        <ThemeToggle />
+        <div className="flex items-center gap-2">
+          <TransactionSubmitterToggle />
+          <ThemeToggle />
+        </div>
       </div>
       <WalletSelection />
       {connected && (

--- a/apps/nextjs-example/src/components/TransactionSubmitterProvider.tsx
+++ b/apps/nextjs-example/src/components/TransactionSubmitterProvider.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { createContext, useContext, useState, ReactNode } from "react";
+
+interface TransactionSubmitterContextType {
+  useCustomSubmitter: boolean;
+  setUseCustomSubmitter: (value: boolean) => void;
+}
+
+const TransactionSubmitterContext = createContext<
+  TransactionSubmitterContextType | undefined
+>(undefined);
+
+export function TransactionSubmitterProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const [useCustomSubmitter, setUseCustomSubmitter] = useState(false);
+
+  return (
+    <TransactionSubmitterContext.Provider
+      value={{ useCustomSubmitter, setUseCustomSubmitter }}
+    >
+      {children}
+    </TransactionSubmitterContext.Provider>
+  );
+}
+
+export function useTransactionSubmitter() {
+  const context = useContext(TransactionSubmitterContext);
+  if (context === undefined) {
+    throw new Error(
+      "useTransactionSubmitter must be used within a TransactionSubmitterProvider",
+    );
+  }
+  return context;
+}

--- a/apps/nextjs-example/src/components/TransactionSubmitterToggle.tsx
+++ b/apps/nextjs-example/src/components/TransactionSubmitterToggle.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { useToast } from "@/components/ui/use-toast";
+import { useTransactionSubmitter } from "@/components/TransactionSubmitterProvider";
+import { Settings } from "lucide-react";
+
+export function TransactionSubmitterToggle() {
+  const { useCustomSubmitter, setUseCustomSubmitter } =
+    useTransactionSubmitter();
+  const { toast } = useToast();
+
+  const handleToggle = () => {
+    const newValue = !useCustomSubmitter;
+    setUseCustomSubmitter(newValue);
+
+    toast({
+      title: newValue ? "Custom Transaction Submitter Enabled" : "Custom Transaction Submitter Disabled",
+      description: newValue
+        ? "Using custom transaction submitter. Transaction details will be logged to the console."
+        : "Using default transaction submission.",
+      duration: 3000,
+    });
+  };
+
+  return (
+    <Button
+      variant="outline"
+      size="icon"
+      onClick={handleToggle}
+    >
+      <Settings
+        className={`h-[1.2rem] w-[1.2rem] transition-all ${
+          useCustomSubmitter
+            ? "rotate-180 text-blue-600 dark:text-blue-400"
+            : "rotate-0 text-muted-foreground"
+        }`}
+      />
+      <span className="sr-only">Toggle custom transaction submitter</span>
+    </Button>
+  );
+}

--- a/apps/nextjs-example/src/components/WalletProvider.tsx
+++ b/apps/nextjs-example/src/components/WalletProvider.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { AptosWalletAdapterProvider } from "@aptos-labs/wallet-adapter-react";
+import { AptosWalletAdapterProvider, DappConfig } from "@aptos-labs/wallet-adapter-react";
 import { setupAutomaticEthereumWalletDerivation } from "@aptos-labs/derived-wallet-ethereum";
 import { setupAutomaticSolanaWalletDerivation } from "@aptos-labs/derived-wallet-solana";
 import { PropsWithChildren } from "react";
@@ -8,6 +8,8 @@ import { Network } from "@aptos-labs/ts-sdk";
 import { useClaimSecretKey } from "@/hooks/useClaimSecretKey";
 import { useAutoConnect } from "./AutoConnectProvider";
 import { useToast } from "./ui/use-toast";
+import { myTransactionSubmitter } from "@/utils/transactionSubmitter";
+import { useTransactionSubmitter } from "./TransactionSubmitterProvider";
 
 const searchParams =
   typeof window !== "undefined"
@@ -29,29 +31,34 @@ if (typeof window !== "undefined") {
 export const WalletProvider = ({ children }: PropsWithChildren) => {
   const { autoConnect } = useAutoConnect();
   const { toast } = useToast();
+  const { useCustomSubmitter } = useTransactionSubmitter();
 
   // Enables claim flow when the `claim` query param is detected
   const claimSecretKey = useClaimSecretKey();
 
+  const dappConfig: DappConfig = {
+    network: Network.TESTNET,
+    aptosApiKeys: {
+      testnet: process.env.NEXT_PUBLIC_APTOS_API_KEY_TESNET,
+      devnet: process.env.NEXT_PUBLIC_APTOS_API_KEY_DEVNET,
+    },
+    aptosConnect: {
+      claimSecretKey,
+      dappId: "57fa42a9-29c6-4f1e-939c-4eefa36d9ff5",
+      dappImageURI,
+    },
+    mizuwallet: {
+      manifestURL:
+        "https://assets.mz.xyz/static/config/mizuwallet-connect-manifest.json",
+    },
+    transactionSubmitter: useCustomSubmitter ? myTransactionSubmitter : undefined,
+  };
+
   return (
     <AptosWalletAdapterProvider
+      key={useCustomSubmitter ? "custom" : "default"}
       autoConnect={autoConnect}
-      dappConfig={{
-        network: Network.TESTNET,
-        aptosApiKeys: {
-          testnet: process.env.NEXT_PUBLIC_APTOS_API_KEY_TESNET,
-          devnet: process.env.NEXT_PUBLIC_APTOS_API_KEY_DEVNET,
-        },
-        aptosConnect: {
-          claimSecretKey,
-          dappId: "57fa42a9-29c6-4f1e-939c-4eefa36d9ff5",
-          dappImageURI,
-        },
-        mizuwallet: {
-          manifestURL:
-            "https://assets.mz.xyz/static/config/mizuwallet-connect-manifest.json",
-        },
-      }}
+      dappConfig={dappConfig}
       onError={(error) => {
         toast({
           variant: "destructive",

--- a/apps/nextjs-example/src/components/WalletSelector.tsx
+++ b/apps/nextjs-example/src/components/WalletSelector.tsx
@@ -122,7 +122,7 @@ function ConnectWalletDialog({
   const { aptosConnectWallets, availableWallets, installableWallets } =
     groupAndSortWallets(
       [...wallets, ...notDetectedWallets],
-      walletSortingOptions
+      walletSortingOptions,
     );
 
   const hasAptosConnectWallets = !!aptosConnectWallets.length;

--- a/apps/nextjs-example/src/components/transactionFlows/SingleSigner.tsx
+++ b/apps/nextjs-example/src/components/transactionFlows/SingleSigner.tsx
@@ -60,11 +60,16 @@ export function SingleSigner() {
       data: {
         function: "0x1::coin::transfer",
         typeArguments: [APTOS_COIN],
-        functionArguments: [account.address, 1], // 1 is in Octas
+        functionArguments: [account.address.toString(), 1], // 1 is in Octas
       },
     };
     try {
-      const response = await signAndSubmitTransaction(transaction);
+      const response = await signAndSubmitTransaction({
+        ...transaction,
+        pluginParams: {
+          customParam: "customValue",
+        }
+      });
       await aptosClient(network).waitForTransaction({
         transactionHash: response.hash,
       });
@@ -109,7 +114,7 @@ export function SingleSigner() {
         data: {
           function: "0x1::coin::transfer",
           typeArguments: [parseTypeTag(APTOS_COIN)],
-          functionArguments: [AccountAddress.from(account.address), new U64(1)], // 1 is in Octas
+          functionArguments: [AccountAddress.from(account.address).toString(), new U64(1)], // 1 is in Octas
         },
       });
       await aptosClient(network).waitForTransaction({
@@ -151,7 +156,7 @@ export function SingleSigner() {
 
     try {
       const transactionToSign = await aptosClient(
-        network
+        network,
       ).transaction.build.simple({
         sender: account.address,
         data: {
@@ -178,7 +183,7 @@ export function SingleSigner() {
     const transaction: InputTransactionData = {
       data: {
         function: "0x1::account_abstraction::add_authentication_function",
-        functionArguments: [account.address, "dummyModule", "dummyFunction"],
+        functionArguments: [account.address.toString(), "dummyModule", "dummyFunction"],
       },
     };
     try {

--- a/apps/nextjs-example/src/components/transactionFlows/TransactionParameters.tsx
+++ b/apps/nextjs-example/src/components/transactionFlows/TransactionParameters.tsx
@@ -22,7 +22,7 @@ export function TransactionParameters() {
       data: {
         function: "0x1::coin::transfer",
         typeArguments: [APTOS_COIN],
-        functionArguments: [account.address, 1], // 1 is in Octas
+        functionArguments: [account.address.toString(), 1], // 1 is in Octas
       },
       options: { maxGasAmount: MaxGasAMount },
     };

--- a/apps/nextjs-example/src/utils/transactionSubmitter.ts
+++ b/apps/nextjs-example/src/utils/transactionSubmitter.ts
@@ -1,0 +1,32 @@
+import {
+  Aptos,
+  AptosConfig,
+  InputSubmitTransactionData,
+  PendingTransactionResponse,
+  TransactionSubmitter,
+} from "@aptos-labs/ts-sdk";
+
+/**
+ * This is a dummy transaction submitter that just logs the transaction and then
+ * submits it normally.
+ */
+class MyTransactionSubmitter implements TransactionSubmitter {
+  submitTransaction(
+    args: { aptosConfig: AptosConfig } & Omit<
+      InputSubmitTransactionData,
+      "transactionSubmitter"
+    >,
+  ): Promise<PendingTransactionResponse> {
+    const { aptosConfig } = args;
+    console.log("Submitting transaction with MyTransactionSubmitter", args);
+    const aptos = new Aptos(aptosConfig);
+    return aptos.transaction.submit.simple({
+        ...args,
+        // We do this so we don't recurse back to this function but instead use the
+        // proper regular txn submitter.
+        transactionSubmitter: null,
+    });
+  }
+}
+
+export const myTransactionSubmitter = new MyTransactionSubmitter();

--- a/apps/nextjs-x-chain/package.json
+++ b/apps/nextjs-x-chain/package.json
@@ -14,7 +14,7 @@
     "@aptos-labs/cross-chain-core": "workspace:*",
     "@aptos-labs/derived-wallet-ethereum": "workspace:^",
     "@aptos-labs/derived-wallet-solana": "workspace:^",
-    "@aptos-labs/ts-sdk": "^2.0.0",
+    "@aptos-labs/ts-sdk": "^3.1.1",
     "@aptos-labs/wallet-adapter-core": "workspace:*",
     "@aptos-labs/wallet-adapter-react": "workspace:*",
     "@aptos-labs/wallet-standard": "^0.5.0",

--- a/apps/nuxt-example/components/TransactonFlows/MultiAgent.vue
+++ b/apps/nuxt-example/components/TransactonFlows/MultiAgent.vue
@@ -57,7 +57,7 @@ const generateTransaction = async (): Promise<AnyRawTransaction> => {
     data: {
       function: "0x1::coin::transfer",
       typeArguments: [APTOS_COIN],
-      functionArguments: [account.value?.address, 1], // 1 is in Octas
+      functionArguments: [account.value?.address.toString(), 1], // 1 is in Octas
     },
   });
   return transactionToSign;

--- a/apps/nuxt-example/components/TransactonFlows/SingleSigner.vue
+++ b/apps/nuxt-example/components/TransactonFlows/SingleSigner.vue
@@ -53,7 +53,7 @@ const onSignAndSubmitTransaction = async () => {
     data: {
       function: "0x1::coin::transfer",
       typeArguments: [APTOS_COIN],
-      functionArguments: [account.value?.address, 1], // 1 is in Octas
+      functionArguments: [account.value?.address.toString(), 1], // 1 is in Octas
     },
   };
   try {
@@ -109,7 +109,7 @@ const onSignTransaction = async () => {
       type: "entry_function_payload",
       function: "0x1::coin::transfer",
       type_arguments: ["0x1::aptos_coin::AptosCoin"],
-      arguments: [account.value?.address, 1], // 1 is in Octas
+      arguments: [account.value?.address.toString(), 1], // 1 is in Octas
     };
     const response = await signTransaction(payload);
     toast({
@@ -132,7 +132,7 @@ const onSignTransactionV2 = async () => {
       data: {
         function: "0x1::coin::transfer",
         typeArguments: [APTOS_COIN],
-        functionArguments: [account.value?.address, 1], // 1 is in Octas
+        functionArguments: [account.value?.address.toString(), 1], // 1 is in Octas
       },
     });
     const response = await signTransaction(transactionToSign);

--- a/apps/nuxt-example/components/TransactonFlows/Sponsor.vue
+++ b/apps/nuxt-example/components/TransactonFlows/Sponsor.vue
@@ -40,7 +40,7 @@ const generateTransaction = async (): Promise<AnyRawTransaction> => {
     data: {
       function: "0x1::coin::transfer",
       typeArguments: [APTOS_COIN],
-      functionArguments: [account.value?.address, 1], // 1 is in Octas
+      functionArguments: [account.value?.address.toString(), 1], // 1 is in Octas
     },
   });
   return transactionToSign;

--- a/apps/nuxt-example/components/TransactonFlows/TransactionParameters.vue
+++ b/apps/nuxt-example/components/TransactonFlows/TransactionParameters.vue
@@ -20,7 +20,7 @@ const onSignAndSubmitTransaction = async () => {
     data: {
       function: "0x1::coin::transfer",
       typeArguments: [APTOS_COIN],
-      functionArguments: [account.value?.address, 1], // 1 is in Octas
+      functionArguments: [account.value?.address.toString(), 1], // 1 is in Octas
     },
     options: { maxGasAmount: MaxGasAMount },
   };

--- a/apps/nuxt-example/package.json
+++ b/apps/nuxt-example/package.json
@@ -10,7 +10,7 @@
     "postinstall": "nuxt prepare"
   },
   "dependencies": {
-    "@aptos-labs/ts-sdk": "^2.0.0",
+    "@aptos-labs/ts-sdk": "^3.1.1",
     "@aptos-labs/wallet-adapter-core": "workspace:*",
     "@aptos-labs/wallet-adapter-vue": "workspace:*",
     "@aptos-labs/wallet-standard": "^0.5.0",

--- a/packages/cross-chain-core/package.json
+++ b/packages/cross-chain-core/package.json
@@ -75,7 +75,7 @@
     "tweetnacl": "^1.0.3"
   },
   "peerDependencies": {
-    "@aptos-labs/ts-sdk": "^1.38.0 || ^2.0.0"
+    "@aptos-labs/ts-sdk": "^3.1.1"
   },
   "files": [
     "dist",

--- a/packages/derived-wallet-base/package.json
+++ b/packages/derived-wallet-base/package.json
@@ -32,7 +32,7 @@
     "@aptos-labs/wallet-standard": "^0.5.0"
   },
   "peerDependencies": {
-    "@aptos-labs/ts-sdk": "^1.38.0 || ^2.0.0"
+    "@aptos-labs/ts-sdk": "^3.1.1"
   },
   "devDependencies": {
     "@aptos-labs/eslint-config-adapter": "workspace:*",

--- a/packages/derived-wallet-ethereum/package.json
+++ b/packages/derived-wallet-ethereum/package.json
@@ -38,7 +38,7 @@
     "viem": "^2.23.12"
   },
   "peerDependencies": {
-    "@aptos-labs/ts-sdk": "^1.38.0 || ^2.0.0"
+    "@aptos-labs/ts-sdk": "^3.1.1"
   },
   "devDependencies": {
     "@aptos-labs/eslint-config-adapter": "workspace:*",

--- a/packages/derived-wallet-solana/package.json
+++ b/packages/derived-wallet-solana/package.json
@@ -39,7 +39,7 @@
     "@wallet-standard/app": "^1.1.0"
   },
   "peerDependencies": {
-    "@aptos-labs/ts-sdk": "^1.38.0 || ^2.0.0"
+    "@aptos-labs/ts-sdk": "^3.1.1"
   },
   "devDependencies": {
     "@aptos-labs/eslint-config-adapter": "workspace:*",

--- a/packages/wallet-adapter-core/package.json
+++ b/packages/wallet-adapter-core/package.json
@@ -59,7 +59,7 @@
     "tweetnacl": "^1.0.3"
   },
   "peerDependencies": {
-    "@aptos-labs/ts-sdk": "^1.38.0 || ^2.0.0"
+    "@aptos-labs/ts-sdk": "^3.1.1"
   },
   "files": [
     "dist",

--- a/packages/wallet-adapter-core/src/utils/helpers.ts
+++ b/packages/wallet-adapter-core/src/utils/helpers.ts
@@ -4,6 +4,7 @@ import {
   Hex,
   Network,
   NetworkToNodeAPI,
+  PluginSettings,
 } from "@aptos-labs/ts-sdk";
 import {
   NetworkInfo,
@@ -62,6 +63,10 @@ export const getAptosConfig = (
     throw new Error("Undefined network");
   }
 
+  const pluginSettings: PluginSettings = {
+    TRANSACTION_SUBMITTER: dappConfig?.transactionSubmitter,
+  };
+
   if (isAptosNetwork(networkInfo)) {
     const currentNetwork = convertNetwork(networkInfo);
 
@@ -70,11 +75,13 @@ export const getAptosConfig = (
       return new AptosConfig({
         network: currentNetwork,
         clientConfig: { API_KEY: apiKey ? apiKey[currentNetwork] : undefined },
+        pluginSettings,
       });
     }
 
     return new AptosConfig({
       network: currentNetwork,
+      pluginSettings,
     });
   }
 
@@ -91,6 +98,7 @@ export const getAptosConfig = (
       return new AptosConfig({
         network: Network.CUSTOM,
         fullnode: networkInfo.url,
+        pluginSettings,
       });
     }
   }

--- a/packages/wallet-adapter-core/src/utils/types.ts
+++ b/packages/wallet-adapter-core/src/utils/types.ts
@@ -1,6 +1,7 @@
 import {
   AccountAddressInput,
   InputGenerateTransactionOptions,
+  InputTransactionPluginData,
 } from "@aptos-labs/ts-sdk";
 import { InputGenerateTransactionPayloadData } from "@aptos-labs/ts-sdk";
 import { WalletReadyState } from "../constants";
@@ -36,15 +37,27 @@ export type AvailableWallets =
   | "MSafe"
   | "Rimosafe";
 
-export type InputTransactionData = {
+type InputTransactionDataInner = {
   sender?: AccountAddressInput;
   data: InputGenerateTransactionPayloadData;
   options?: InputGenerateTransactionOptions & {
     expirationSecondsFromNow?: number;
     expirationTimestamp?: number;
   };
+  /** This will always be set to true if a custom transaction submitter is provided. */
   withFeePayer?: boolean;
 };
+
+/**
+ * If `transactionSubmitter` is set it will be used, and override any transaction
+ * submitter configured in the DappConfig.
+ *
+ * The `pluginParams` parameter is used to provide additional parameters to a
+ * transaction submitter plugin, whether provided here or configured in the
+ * DappConfig.
+ */
+export type InputTransactionData = InputTransactionDataInner &
+  InputTransactionPluginData;
 
 export type WalletInfo = {
   name: string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,8 +37,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/derived-wallet-solana
       '@aptos-labs/ts-sdk':
-        specifier: ^2.0.0
-        version: 2.0.0(axios@1.10.0)(got@11.8.6)
+        specifier: ^3.1.1
+        version: 3.1.1(axios@1.10.0)(got@11.8.6)
       '@aptos-labs/wallet-adapter-ant-design':
         specifier: workspace:*
         version: link:../../packages/wallet-adapter-ant-design
@@ -53,7 +53,7 @@ importers:
         version: link:../../packages/wallet-adapter-react
       '@aptos-labs/wallet-standard':
         specifier: ^0.5.0
-        version: 0.5.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
+        version: 0.5.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
       '@radix-ui/react-collapsible':
         specifier: ^1.0.3
         version: 1.1.3(@types/react-dom@18.3.5(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -158,8 +158,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/derived-wallet-solana
       '@aptos-labs/ts-sdk':
-        specifier: ^2.0.0
-        version: 2.0.0(axios@1.10.0)(got@11.8.6)
+        specifier: ^3.1.1
+        version: 3.1.1(axios@1.10.0)(got@11.8.6)
       '@aptos-labs/wallet-adapter-core':
         specifier: workspace:*
         version: link:../../packages/wallet-adapter-core
@@ -168,7 +168,7 @@ importers:
         version: link:../../packages/wallet-adapter-react
       '@aptos-labs/wallet-standard':
         specifier: ^0.5.0
-        version: 0.5.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
+        version: 0.5.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
       '@radix-ui/react-collapsible':
         specifier: ^1.0.3
         version: 1.1.3(@types/react-dom@18.3.5(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -267,8 +267,8 @@ importers:
   apps/nuxt-example:
     dependencies:
       '@aptos-labs/ts-sdk':
-        specifier: ^2.0.0
-        version: 2.0.0(axios@1.10.0)(got@11.8.6)
+        specifier: ^3.1.1
+        version: 3.1.1(axios@1.10.0)(got@11.8.6)
       '@aptos-labs/wallet-adapter-core':
         specifier: workspace:*
         version: link:../../packages/wallet-adapter-core
@@ -277,7 +277,7 @@ importers:
         version: link:../../packages/wallet-adapter-vue
       '@aptos-labs/wallet-standard':
         specifier: ^0.5.0
-        version: 0.5.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
+        version: 0.5.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
       '@nuxtjs/google-fonts':
         specifier: ^3.2.0
         version: 3.2.0(magicast@0.3.5)
@@ -352,14 +352,14 @@ importers:
         specifier: workspace:*
         version: link:../derived-wallet-solana
       '@aptos-labs/ts-sdk':
-        specifier: ^1.38.0 || ^2.0.0
-        version: 2.0.0(axios@1.10.0)(got@11.8.6)
+        specifier: ^3.1.1
+        version: 3.1.1(axios@1.10.0)(got@11.8.6)
       '@aptos-labs/wallet-adapter-core':
         specifier: workspace:*
         version: link:../wallet-adapter-core
       '@aptos-labs/wallet-standard':
         specifier: ^0.5.0
-        version: 0.5.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
+        version: 0.5.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
       '@mysten/sui':
         specifier: ^1.21.2
         version: 1.25.0(typescript@5.8.2)
@@ -449,11 +449,11 @@ importers:
   packages/derived-wallet-base:
     dependencies:
       '@aptos-labs/ts-sdk':
-        specifier: ^1.38.0 || ^2.0.0
-        version: 2.0.0(axios@1.10.0)(got@11.8.6)
+        specifier: ^3.1.1
+        version: 3.1.1(axios@1.10.0)(got@11.8.6)
       '@aptos-labs/wallet-standard':
         specifier: ^0.5.0
-        version: 0.5.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
+        version: 0.5.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
     devDependencies:
       '@aptos-labs/eslint-config-adapter':
         specifier: workspace:*
@@ -490,13 +490,13 @@ importers:
         version: link:../derived-wallet-base
       '@aptos-labs/siwa':
         specifier: ^0.3.0
-        version: 0.3.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
+        version: 0.3.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
       '@aptos-labs/ts-sdk':
-        specifier: ^1.38.0 || ^2.0.0
-        version: 2.0.0(axios@1.10.0)(got@11.8.6)
+        specifier: ^3.1.1
+        version: 3.1.1(axios@1.10.0)(got@11.8.6)
       '@aptos-labs/wallet-standard':
         specifier: ^0.5.0
-        version: 0.5.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
+        version: 0.5.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
       '@wallet-standard/app':
         specifier: ^1.1.0
         version: 1.1.0
@@ -545,13 +545,13 @@ importers:
         version: link:../derived-wallet-base
       '@aptos-labs/siwa':
         specifier: ^0.3.0
-        version: 0.3.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
+        version: 0.3.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
       '@aptos-labs/ts-sdk':
-        specifier: ^1.38.0 || ^2.0.0
-        version: 2.0.0(axios@1.10.0)(got@11.8.6)
+        specifier: ^3.1.1
+        version: 3.1.1(axios@1.10.0)(got@11.8.6)
       '@aptos-labs/wallet-standard':
         specifier: ^0.5.0
-        version: 0.5.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
+        version: 0.5.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
       '@solana/wallet-adapter-base':
         specifier: ^0.9.23
         version: 0.9.24(@solana/web3.js@1.98.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
@@ -661,16 +661,16 @@ importers:
     dependencies:
       '@aptos-connect/wallet-adapter-plugin':
         specifier: 2.5.0
-        version: 2.5.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
+        version: 2.5.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
       '@aptos-labs/ts-sdk':
-        specifier: ^1.38.0 || ^2.0.0
-        version: 2.0.0(axios@1.10.0)(got@11.8.6)
+        specifier: ^3.1.1
+        version: 3.1.1(axios@1.10.0)(got@11.8.6)
       '@aptos-labs/wallet-standard':
         specifier: ^0.5.0
-        version: 0.5.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
+        version: 0.5.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
       '@msafe/aptos-aip62-wallet':
         specifier: ^1.0.18
-        version: 1.0.18(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-adapter-core@5.7.1(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-standard@0.5.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0))(@mizuwallet-sdk/protocol@0.0.6)(@wallet-standard/core@1.1.0)
+        version: 1.0.18(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-adapter-core@5.8.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6)))(@aptos-labs/wallet-standard@0.5.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0))(@mizuwallet-sdk/protocol@0.0.6)(@wallet-standard/core@1.1.0)
       buffer:
         specifier: ^6.0.3
         version: 6.0.3
@@ -914,12 +914,6 @@ packages:
       '@aptos-labs/ts-sdk': 1.26.0
       '@aptos-labs/wallet-standard': 0.2.0
 
-  '@aptos-connect/wallet-adapter-plugin@2.4.1':
-    resolution: {integrity: sha512-jFuOEtnNWvi8VjvrXrNFp4iI2dci8Jv0l1FIuC5khMZKj2sDHLNF1dbZtcXNTRbD32KDrzl0Lngi42K0gReX8Q==}
-    peerDependencies:
-      '@aptos-labs/ts-sdk': ^1.33.1
-      '@aptos-labs/wallet-standard': ^0.3.0
-
   '@aptos-connect/wallet-adapter-plugin@2.5.0':
     resolution: {integrity: sha512-tDR6Te8JYsSC5YTZTqj8EbFN3Uszo/YDX+cBEBY4juYb9+ht8y5Tn6m/2RJRW+7DL9uVA7JVt6yWFQVpo+MijQ==}
     peerDependencies:
@@ -979,8 +973,8 @@ packages:
     resolution: {integrity: sha512-cflGyknECg11wTkQ1o1OK759v1m+mpz0S0/ZXsHbPMO0dO6eQGLjH/Uk5/YWMe1Nat8/szcgIipKk8Xr6Unvzg==}
     engines: {node: '>=20.0.0'}
 
-  '@aptos-labs/ts-sdk@2.0.0':
-    resolution: {integrity: sha512-2sFX5nQZu70koLKs2AxJI0/P2ggevB0qa6F3i6FK6Zg0fhJXjHKr0TywwTvzM46qmn4vEygw+QTXnfhLGIbgEQ==}
+  '@aptos-labs/ts-sdk@3.1.1':
+    resolution: {integrity: sha512-K2icQiwaUs1V3T4f0fzL10P+nSsg/nt8Jb9mk9ognheHH/tn0v5TjkqlrzzICjh3MPKplXv1JvKAnbO9iORW4Q==}
     engines: {node: '>=20.0.0'}
 
   '@aptos-labs/wallet-adapter-core@5.0.0':
@@ -988,8 +982,8 @@ packages:
     peerDependencies:
       '@aptos-labs/ts-sdk': ^1.35.0
 
-  '@aptos-labs/wallet-adapter-core@5.7.1':
-    resolution: {integrity: sha512-eScjf13fXgi9ndpUijz4+D0IZGQRbllSuZHinXxMR+EVxPWbJSlJWFE+FmnT6ZLy8QN9iVnxiWB7/B0JckVX3A==}
+  '@aptos-labs/wallet-adapter-core@5.8.0':
+    resolution: {integrity: sha512-I/A72bYXlYgYasZGa1pMCHmBO+ZcfbBLdR4unI1XjncmFqssiRapf+iUbP1hy1t7LOPI54587Fi3U1+0CvcIVw==}
     peerDependencies:
       '@aptos-labs/ts-sdk': ^1.38.0 || ^2.0.0
 
@@ -1012,12 +1006,6 @@ packages:
     resolution: {integrity: sha512-1cSmPxKB8R5HIlYPTKej7LzKflWbkod5t8peZ+OOHA3LbB1KI39qQn6gLid8kFBluvYsmkE1XEIIUyKLx07TsA==}
     peerDependencies:
       '@aptos-labs/ts-sdk': ^1.37.1
-      '@wallet-standard/core': ^1.0.3
-
-  '@aptos-labs/wallet-standard@0.4.0':
-    resolution: {integrity: sha512-c38ZFQuqDMPzGPkksnXxwidlzG36PguplJGrMItPDmz/3u/GaM+2O9uE+0T721dTiuc6NJqbr8dZyw1kdQj2cg==}
-    peerDependencies:
-      '@aptos-labs/ts-sdk': ^2.0.0
       '@wallet-standard/core': ^1.0.3
 
   '@aptos-labs/wallet-standard@0.5.0':
@@ -10269,26 +10257,13 @@ snapshots:
       - aptos
       - debug
 
-  '@aptos-connect/wallet-adapter-plugin@2.4.1(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-standard@0.4.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))':
+  '@aptos-connect/wallet-adapter-plugin@2.5.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))':
     dependencies:
-      '@aptos-connect/wallet-api': 0.1.9(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
-      '@aptos-labs/ts-sdk': 2.0.0(axios@1.10.0)(got@11.8.6)
-      '@aptos-labs/wallet-standard': 0.4.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
-      '@identity-connect/crypto': 0.2.7(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
-      '@identity-connect/dapp-sdk': 0.10.4(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-standard@0.4.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
-    transitivePeerDependencies:
-      - '@telegram-apps/bridge'
-      - '@wallet-standard/core'
-      - aptos
-      - debug
-
-  '@aptos-connect/wallet-adapter-plugin@2.5.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))':
-    dependencies:
-      '@aptos-connect/wallet-api': 0.3.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
-      '@aptos-labs/ts-sdk': 2.0.0(axios@1.10.0)(got@11.8.6)
-      '@aptos-labs/wallet-standard': 0.5.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
-      '@identity-connect/crypto': 0.2.7(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
-      '@identity-connect/dapp-sdk': 0.11.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-standard@0.5.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
+      '@aptos-connect/wallet-api': 0.3.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
+      '@aptos-labs/ts-sdk': 3.1.1(axios@1.10.0)(got@11.8.6)
+      '@aptos-labs/wallet-standard': 0.5.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
+      '@identity-connect/crypto': 0.2.7(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
+      '@identity-connect/dapp-sdk': 0.11.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-standard@0.5.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
     transitivePeerDependencies:
       - '@telegram-apps/bridge'
       - '@wallet-standard/core'
@@ -10304,19 +10279,10 @@ snapshots:
     transitivePeerDependencies:
       - '@wallet-standard/core'
 
-  '@aptos-connect/wallet-api@0.1.9(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))':
+  '@aptos-connect/wallet-api@0.3.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))':
     dependencies:
-      '@aptos-labs/ts-sdk': 2.0.0(axios@1.10.0)(got@11.8.6)
-      '@aptos-labs/wallet-standard': 0.3.1(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
-      '@identity-connect/api': 0.7.0
-      aptos: 1.21.0(axios@1.10.0)(got@11.8.6)
-    transitivePeerDependencies:
-      - '@wallet-standard/core'
-
-  '@aptos-connect/wallet-api@0.3.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))':
-    dependencies:
-      '@aptos-labs/ts-sdk': 2.0.0(axios@1.10.0)(got@11.8.6)
-      '@aptos-labs/wallet-standard': 0.5.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
+      '@aptos-labs/ts-sdk': 3.1.1(axios@1.10.0)(got@11.8.6)
+      '@aptos-labs/wallet-standard': 0.5.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
       '@identity-connect/api': 0.7.0
       aptos: 1.21.0(axios@1.10.0)(got@11.8.6)
     transitivePeerDependencies:
@@ -10333,22 +10299,11 @@ snapshots:
     transitivePeerDependencies:
       - '@wallet-standard/core'
 
-  '@aptos-connect/web-transport@0.1.3(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-standard@0.4.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))':
+  '@aptos-connect/web-transport@0.3.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-standard@0.5.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))':
     dependencies:
-      '@aptos-connect/wallet-api': 0.1.9(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
-      '@aptos-labs/ts-sdk': 2.0.0(axios@1.10.0)(got@11.8.6)
-      '@aptos-labs/wallet-standard': 0.4.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
-      '@telegram-apps/bridge': 1.9.2
-      aptos: 1.21.0(axios@1.10.0)(got@11.8.6)
-      uuid: 9.0.1
-    transitivePeerDependencies:
-      - '@wallet-standard/core'
-
-  '@aptos-connect/web-transport@0.3.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-standard@0.5.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))':
-    dependencies:
-      '@aptos-connect/wallet-api': 0.3.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
-      '@aptos-labs/ts-sdk': 2.0.0(axios@1.10.0)(got@11.8.6)
-      '@aptos-labs/wallet-standard': 0.5.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
+      '@aptos-connect/wallet-api': 0.3.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
+      '@aptos-labs/ts-sdk': 3.1.1(axios@1.10.0)(got@11.8.6)
+      '@aptos-labs/wallet-standard': 0.5.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
       '@telegram-apps/bridge': 1.9.2
       aptos: 1.21.0(axios@1.10.0)(got@11.8.6)
       uuid: 9.0.1
@@ -10370,10 +10325,10 @@ snapshots:
     dependencies:
       '@aptos-labs/aptos-dynamic-transaction-composer': 0.1.3
 
-  '@aptos-labs/siwa@0.3.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)':
+  '@aptos-labs/siwa@0.3.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)':
     dependencies:
-      '@aptos-labs/ts-sdk': 2.0.0(axios@1.10.0)(got@11.8.6)
-      '@aptos-labs/wallet-standard': 0.5.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
+      '@aptos-labs/ts-sdk': 3.1.1(axios@1.10.0)(got@11.8.6)
+      '@aptos-labs/wallet-standard': 0.5.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
       '@noble/hashes': 1.7.1
     transitivePeerDependencies:
       - '@wallet-standard/core'
@@ -10396,7 +10351,7 @@ snapshots:
       - axios
       - got
 
-  '@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6)':
+  '@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6)':
     dependencies:
       '@aptos-labs/aptos-cli': 1.0.2
       '@aptos-labs/aptos-client': 1.2.0(axios@1.10.0)(got@11.8.6)
@@ -10433,13 +10388,12 @@ snapshots:
       - debug
       - got
 
-  '@aptos-labs/wallet-adapter-core@5.7.1(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))(axios@1.10.0)(got@11.8.6)':
+  '@aptos-labs/wallet-adapter-core@5.8.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))':
     dependencies:
-      '@aptos-connect/wallet-adapter-plugin': 2.4.1(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-standard@0.4.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
-      '@aptos-labs/ts-sdk': 2.0.0(axios@1.10.0)(got@11.8.6)
-      '@aptos-labs/wallet-standard': 0.4.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
-      '@atomrigslab/aptos-wallet-adapter': 0.1.21(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(axios@1.10.0)(got@11.8.6)
-      '@msafe/aptos-aip62-wallet': 1.0.18(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-adapter-core@5.7.1(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-standard@0.4.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0))(@mizuwallet-sdk/protocol@0.0.6)(@wallet-standard/core@1.1.0)
+      '@aptos-connect/wallet-adapter-plugin': 2.5.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
+      '@aptos-labs/ts-sdk': 3.1.1(axios@1.10.0)(got@11.8.6)
+      '@aptos-labs/wallet-standard': 0.5.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
+      '@msafe/aptos-aip62-wallet': 1.0.18(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-adapter-core@5.8.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6)))(@aptos-labs/wallet-standard@0.5.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0))(@mizuwallet-sdk/protocol@0.0.6)(@wallet-standard/core@1.1.0)
       buffer: 6.0.3
       eventemitter3: 4.0.7
       tweetnacl: 1.0.3
@@ -10448,9 +10402,7 @@ snapshots:
       - '@telegram-apps/bridge'
       - '@wallet-standard/core'
       - aptos
-      - axios
       - debug
-      - got
 
   '@aptos-labs/wallet-standard@0.0.11(axios@1.10.0)(got@11.8.6)':
     dependencies:
@@ -10475,33 +10427,14 @@ snapshots:
       '@aptos-labs/ts-sdk': 1.38.0(axios@1.10.0)(got@11.8.6)
       '@wallet-standard/core': 1.1.0
 
-  '@aptos-labs/wallet-standard@0.3.1(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)':
+  '@aptos-labs/wallet-standard@0.5.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)':
     dependencies:
-      '@aptos-labs/ts-sdk': 2.0.0(axios@1.10.0)(got@11.8.6)
-      '@wallet-standard/core': 1.1.0
-
-  '@aptos-labs/wallet-standard@0.4.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)':
-    dependencies:
-      '@aptos-labs/ts-sdk': 2.0.0(axios@1.10.0)(got@11.8.6)
-      '@wallet-standard/core': 1.1.0
-
-  '@aptos-labs/wallet-standard@0.5.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)':
-    dependencies:
-      '@aptos-labs/ts-sdk': 2.0.0(axios@1.10.0)(got@11.8.6)
+      '@aptos-labs/ts-sdk': 3.1.1(axios@1.10.0)(got@11.8.6)
       '@wallet-standard/core': 1.1.0
 
   '@atomrigslab/aptos-wallet-adapter@0.1.21(@aptos-labs/ts-sdk@1.38.0(axios@1.10.0)(got@11.8.6))(axios@1.10.0)(got@11.8.6)':
     dependencies:
       '@aptos-labs/ts-sdk': 1.38.0(axios@1.10.0)(got@11.8.6)
-      '@aptos-labs/wallet-standard': 0.0.11(axios@1.10.0)(got@11.8.6)
-      '@atomrigslab/dekey-web-wallet-provider': 1.2.1
-    transitivePeerDependencies:
-      - axios
-      - got
-
-  '@atomrigslab/aptos-wallet-adapter@0.1.21(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(axios@1.10.0)(got@11.8.6)':
-    dependencies:
-      '@aptos-labs/ts-sdk': 2.0.0(axios@1.10.0)(got@11.8.6)
       '@aptos-labs/wallet-standard': 0.0.11(axios@1.10.0)(got@11.8.6)
       '@atomrigslab/dekey-web-wallet-provider': 1.2.1
     transitivePeerDependencies:
@@ -11537,21 +11470,10 @@ snapshots:
       - '@wallet-standard/core'
       - aptos
 
-  '@identity-connect/crypto@0.2.5(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))':
+  '@identity-connect/crypto@0.2.7(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))':
     dependencies:
-      '@aptos-connect/wallet-api': 0.1.9(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
-      '@aptos-labs/ts-sdk': 2.0.0(axios@1.10.0)(got@11.8.6)
-      '@noble/hashes': 1.7.1
-      ed2curve: 0.3.0
-      tweetnacl: 1.0.3
-    transitivePeerDependencies:
-      - '@wallet-standard/core'
-      - aptos
-
-  '@identity-connect/crypto@0.2.7(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))':
-    dependencies:
-      '@aptos-connect/wallet-api': 0.3.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
-      '@aptos-labs/ts-sdk': 2.0.0(axios@1.10.0)(got@11.8.6)
+      '@aptos-connect/wallet-api': 0.3.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
+      '@aptos-labs/ts-sdk': 3.1.1(axios@1.10.0)(got@11.8.6)
       '@noble/hashes': 1.7.1
       ed2curve: 0.3.0
       tweetnacl: 1.0.3
@@ -11576,32 +11498,15 @@ snapshots:
       - aptos
       - debug
 
-  '@identity-connect/dapp-sdk@0.10.4(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-standard@0.4.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))':
+  '@identity-connect/dapp-sdk@0.11.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-standard@0.5.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))':
     dependencies:
-      '@aptos-connect/wallet-api': 0.1.9(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
-      '@aptos-connect/web-transport': 0.1.3(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-standard@0.4.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
-      '@aptos-labs/ts-sdk': 2.0.0(axios@1.10.0)(got@11.8.6)
-      '@aptos-labs/wallet-standard': 0.4.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
+      '@aptos-connect/wallet-api': 0.3.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
+      '@aptos-connect/web-transport': 0.3.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-standard@0.5.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
+      '@aptos-labs/ts-sdk': 3.1.1(axios@1.10.0)(got@11.8.6)
+      '@aptos-labs/wallet-standard': 0.5.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
       '@identity-connect/api': 0.7.0
-      '@identity-connect/crypto': 0.2.5(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
-      '@identity-connect/wallet-api': 0.1.2(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
-      axios: 1.8.4
-      uuid: 9.0.1
-    transitivePeerDependencies:
-      - '@telegram-apps/bridge'
-      - '@wallet-standard/core'
-      - aptos
-      - debug
-
-  '@identity-connect/dapp-sdk@0.11.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-standard@0.5.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))':
-    dependencies:
-      '@aptos-connect/wallet-api': 0.3.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
-      '@aptos-connect/web-transport': 0.3.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-standard@0.5.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
-      '@aptos-labs/ts-sdk': 2.0.0(axios@1.10.0)(got@11.8.6)
-      '@aptos-labs/wallet-standard': 0.5.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
-      '@identity-connect/api': 0.7.0
-      '@identity-connect/crypto': 0.2.7(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
-      '@identity-connect/wallet-api': 0.1.2(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
+      '@identity-connect/crypto': 0.2.7(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
+      '@identity-connect/wallet-api': 0.1.2(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
       axios: 1.10.0
       uuid: 9.0.1
     transitivePeerDependencies:
@@ -11615,9 +11520,9 @@ snapshots:
       '@aptos-labs/ts-sdk': 1.38.0(axios@1.10.0)(got@11.8.6)
       aptos: 1.21.0(axios@1.10.0)(got@11.8.6)
 
-  '@identity-connect/wallet-api@0.1.2(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(aptos@1.21.0(axios@1.10.0)(got@11.8.6))':
+  '@identity-connect/wallet-api@0.1.2(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(aptos@1.21.0(axios@1.10.0)(got@11.8.6))':
     dependencies:
-      '@aptos-labs/ts-sdk': 2.0.0(axios@1.10.0)(got@11.8.6)
+      '@aptos-labs/ts-sdk': 3.1.1(axios@1.10.0)(got@11.8.6)
       aptos: 1.21.0(axios@1.10.0)(got@11.8.6)
 
   '@injectivelabs/abacus-proto-ts@1.14.0':
@@ -12101,9 +12006,9 @@ snapshots:
       graphql-request: 7.1.2(graphql@16.10.0)
       jwt-decode: 4.0.0
 
-  '@mizuwallet-sdk/core@1.4.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(graphql-request@7.1.2(graphql@16.10.0))':
+  '@mizuwallet-sdk/core@1.4.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(graphql-request@7.1.2(graphql@16.10.0))':
     dependencies:
-      '@aptos-labs/ts-sdk': 2.0.0(axios@1.10.0)(got@11.8.6)
+      '@aptos-labs/ts-sdk': 3.1.1(axios@1.10.0)(got@11.8.6)
       '@mizuwallet-sdk/protocol': 0.0.6
       buffer: 6.0.3
       graphql-request: 7.1.2(graphql@16.10.0)
@@ -12115,25 +12020,12 @@ snapshots:
       tweetnacl: 1.0.3
       tweetnacl-util: 0.15.1
 
-  '@msafe/aptos-aip62-wallet@1.0.18(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-adapter-core@5.7.1(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-standard@0.4.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0))(@mizuwallet-sdk/protocol@0.0.6)(@wallet-standard/core@1.1.0)':
+  '@msafe/aptos-aip62-wallet@1.0.18(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-adapter-core@5.8.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6)))(@aptos-labs/wallet-standard@0.5.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0))(@mizuwallet-sdk/protocol@0.0.6)(@wallet-standard/core@1.1.0)':
     dependencies:
-      '@aptos-labs/ts-sdk': 2.0.0(axios@1.10.0)(got@11.8.6)
-      '@aptos-labs/wallet-adapter-core': 5.7.1(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))(axios@1.10.0)(got@11.8.6)
-      '@aptos-labs/wallet-standard': 0.4.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
-      '@mizuwallet-sdk/core': 1.4.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(graphql-request@7.1.2(graphql@16.10.0))
-      '@telegram-apps/bridge': 1.9.2
-      '@wallet-standard/core': 1.1.0
-      graphql: 16.10.0
-      graphql-request: 7.1.2(graphql@16.10.0)
-    transitivePeerDependencies:
-      - '@mizuwallet-sdk/protocol'
-
-  '@msafe/aptos-aip62-wallet@1.0.18(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-adapter-core@5.7.1(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-standard@0.5.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0))(@mizuwallet-sdk/protocol@0.0.6)(@wallet-standard/core@1.1.0)':
-    dependencies:
-      '@aptos-labs/ts-sdk': 2.0.0(axios@1.10.0)(got@11.8.6)
-      '@aptos-labs/wallet-adapter-core': 5.7.1(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))(axios@1.10.0)(got@11.8.6)
-      '@aptos-labs/wallet-standard': 0.5.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
-      '@mizuwallet-sdk/core': 1.4.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(graphql-request@7.1.2(graphql@16.10.0))
+      '@aptos-labs/ts-sdk': 3.1.1(axios@1.10.0)(got@11.8.6)
+      '@aptos-labs/wallet-adapter-core': 5.8.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
+      '@aptos-labs/wallet-standard': 0.5.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
+      '@mizuwallet-sdk/core': 1.4.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(graphql-request@7.1.2(graphql@16.10.0))
       '@telegram-apps/bridge': 1.9.2
       '@wallet-standard/core': 1.1.0
       graphql: 16.10.0


### PR DESCRIPTION
## Summary
This PR adds support for setting a transaction submitter. If given, the wallet adapter will submit txns directly using this submitter rather than via the wallet.

## Test Plan
https://github.com/aptos-labs/aptos-wallet-adapter/pull/606#issuecomment-3022409934