### PR TITLE
[core] Bump wallet standard to 0.5.0 and @aptos-connect/wallet-adapter-plugin to 2.5.0

### DIFF
--- a/.changeset/tired-lines-serve.md
+++ b/.changeset/tired-lines-serve.md
@@ -1,0 +1,10 @@
+---
+"@aptos-labs/derived-wallet-ethereum": minor
+"@aptos-labs/derived-wallet-solana": minor
+"@aptos-labs/wallet-adapter-react": minor
+"@aptos-labs/derived-wallet-base": minor
+"@aptos-labs/wallet-adapter-core": minor
+"@aptos-labs/cross-chain-core": minor
+---
+
+Bump @aptos-labs/wallet-standard to 0.5.0 which removes the `message` and `signingMessage` fields from the `AptosSignInInput` of the `signIn` request.

--- a/apps/nextjs-example/package.json
+++ b/apps/nextjs-example/package.json
@@ -18,7 +18,7 @@
     "@aptos-labs/wallet-adapter-react": "workspace:*",
     "@aptos-labs/derived-wallet-ethereum": "workspace:^",
     "@aptos-labs/derived-wallet-solana": "workspace:^",
-    "@aptos-labs/wallet-standard": "^0.3.0",
+    "@aptos-labs/wallet-standard": "^0.5.0",
     "@radix-ui/react-collapsible": "^1.0.3",
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-dropdown-menu": "^2.0.6",

--- a/apps/nextjs-x-chain/package.json
+++ b/apps/nextjs-x-chain/package.json
@@ -17,7 +17,7 @@
     "@aptos-labs/ts-sdk": "^2.0.0",
     "@aptos-labs/wallet-adapter-core": "workspace:*",
     "@aptos-labs/wallet-adapter-react": "workspace:*",
-    "@aptos-labs/wallet-standard": "^0.3.0",
+    "@aptos-labs/wallet-standard": "^0.5.0",
     "@radix-ui/react-collapsible": "^1.0.3",
     "@radix-ui/react-dialog": "^1.0.5",
     "@radix-ui/react-dropdown-menu": "^2.0.6",

--- a/apps/nuxt-example/package.json
+++ b/apps/nuxt-example/package.json
@@ -13,7 +13,7 @@
     "@aptos-labs/ts-sdk": "^2.0.0",
     "@aptos-labs/wallet-adapter-core": "workspace:*",
     "@aptos-labs/wallet-adapter-vue": "workspace:*",
-    "@aptos-labs/wallet-standard": "^0.3.0",
+    "@aptos-labs/wallet-standard": "^0.5.0",
     "@nuxtjs/google-fonts": "^3.2.0",
     "buffer": "^6.0.3",
     "class-variance-authority": "^0.7.0",

--- a/packages/cross-chain-core/package.json
+++ b/packages/cross-chain-core/package.json
@@ -53,7 +53,7 @@
     "@aptos-labs/wallet-adapter-core": "workspace:*",
     "@aptos-labs/derived-wallet-ethereum": "workspace:*",
     "@aptos-labs/derived-wallet-solana": "workspace:*",
-    "@aptos-labs/wallet-standard": "^0.3.0",
+    "@aptos-labs/wallet-standard": "^0.5.0",
     "@mysten/sui": "^1.21.2",
     "@mysten/wallet-standard": "^0.13.26",
     "@solana/spl-token": "^0.4.12",

--- a/packages/derived-wallet-base/package.json
+++ b/packages/derived-wallet-base/package.json
@@ -29,7 +29,7 @@
     ]
   },
   "dependencies": {
-    "@aptos-labs/wallet-standard": "^0.3.0"
+    "@aptos-labs/wallet-standard": "^0.5.0"
   },
   "peerDependencies": {
     "@aptos-labs/ts-sdk": "^1.38.0 || ^2.0.0"

--- a/packages/derived-wallet-ethereum/package.json
+++ b/packages/derived-wallet-ethereum/package.json
@@ -30,8 +30,8 @@
   },
   "dependencies": {
     "@aptos-labs/derived-wallet-base": "workspace:^",
-    "@aptos-labs/siwa": "^0.2.5",
-    "@aptos-labs/wallet-standard": "^0.3.0",
+    "@aptos-labs/siwa": "^0.3.0",
+    "@aptos-labs/wallet-standard": "^0.5.0",
     "@wallet-standard/app": "^1.1.0",
     "ethers": "^6.13.5",
     "mipd": "^0.0.7",

--- a/packages/derived-wallet-solana/package.json
+++ b/packages/derived-wallet-solana/package.json
@@ -30,8 +30,8 @@
   },
   "dependencies": {
     "@aptos-labs/derived-wallet-base": "workspace:^",
-    "@aptos-labs/siwa": "^0.2.5",
-    "@aptos-labs/wallet-standard": "^0.3.0",
+    "@aptos-labs/siwa": "^0.3.0",
+    "@aptos-labs/wallet-standard": "^0.5.0",
     "@solana/wallet-adapter-base": "^0.9.23",
     "@solana/wallet-standard-util": "^1.1.2",
     "@solana/wallet-standard-wallet-adapter-base": "^1.1.4",

--- a/packages/wallet-adapter-core/package.json
+++ b/packages/wallet-adapter-core/package.json
@@ -51,8 +51,8 @@
     "typescript": "^4.5.3"
   },
   "dependencies": {
-    "@aptos-connect/wallet-adapter-plugin": "2.4.1",
-    "@aptos-labs/wallet-standard": "^0.4.0",
+    "@aptos-connect/wallet-adapter-plugin": "2.5.0",
+    "@aptos-labs/wallet-standard": "^0.5.0",
     "@msafe/aptos-aip62-wallet": "^1.0.18",
     "buffer": "^6.0.3",
     "eventemitter3": "^4.0.7",

--- a/packages/wallet-adapter-core/src/index.ts
+++ b/packages/wallet-adapter-core/src/index.ts
@@ -1,10 +1,15 @@
+import { AptosSignInBoundFields } from "@aptos-labs/wallet-standard";
 import { WALLET_ADAPTER_CORE_VERSION } from "./version";
 
 export type {
   AptosSignInOutput,
   AptosSignInInput,
-  AptosSignInRequiredFields,
+  AptosSignInBoundFields,
 } from "@aptos-labs/wallet-standard";
+/**
+ * @deprecated Use `AptosSignInBoundFields` instead. This will be removed in future versions.
+ */
+export type AptosSignInRequiredFields = AptosSignInBoundFields;
 
 export * from "./WalletCore";
 export * from "./constants";

--- a/packages/wallet-adapter-react/src/WalletProvider.tsx
+++ b/packages/wallet-adapter-react/src/WalletProvider.tsx
@@ -157,7 +157,11 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
   const signIn = async (args: {
     walletName: string;
     input: AptosSignInInput;
-  }): Promise<void | AptosSignInOutput> => {
+  }): Promise<AptosSignInOutput> => {
+    if (!walletCore) {
+      throw new Error("WalletCore is not initialized");
+    }
+
     try {
       setIsLoading(true);
       return await walletCore?.signIn(args);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,7 +38,7 @@ importers:
         version: link:../../packages/derived-wallet-solana
       '@aptos-labs/ts-sdk':
         specifier: ^2.0.0
-        version: 2.0.0(axios@1.8.4)(got@11.8.6)
+        version: 2.0.0(axios@1.10.0)(got@11.8.6)
       '@aptos-labs/wallet-adapter-ant-design':
         specifier: workspace:*
         version: link:../../packages/wallet-adapter-ant-design
@@ -52,8 +52,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/wallet-adapter-react
       '@aptos-labs/wallet-standard':
-        specifier: ^0.3.0
-        version: 0.3.0(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0)
+        specifier: ^0.5.0
+        version: 0.5.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
       '@radix-ui/react-collapsible':
         specifier: ^1.0.3
         version: 1.1.3(@types/react-dom@18.3.5(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -159,7 +159,7 @@ importers:
         version: link:../../packages/derived-wallet-solana
       '@aptos-labs/ts-sdk':
         specifier: ^2.0.0
-        version: 2.0.0(axios@1.8.4)(got@11.8.6)
+        version: 2.0.0(axios@1.10.0)(got@11.8.6)
       '@aptos-labs/wallet-adapter-core':
         specifier: workspace:*
         version: link:../../packages/wallet-adapter-core
@@ -167,8 +167,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/wallet-adapter-react
       '@aptos-labs/wallet-standard':
-        specifier: ^0.3.0
-        version: 0.3.0(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0)
+        specifier: ^0.5.0
+        version: 0.5.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
       '@radix-ui/react-collapsible':
         specifier: ^1.0.3
         version: 1.1.3(@types/react-dom@18.3.5(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -268,7 +268,7 @@ importers:
     dependencies:
       '@aptos-labs/ts-sdk':
         specifier: ^2.0.0
-        version: 2.0.0(axios@1.8.4)(got@11.8.6)
+        version: 2.0.0(axios@1.10.0)(got@11.8.6)
       '@aptos-labs/wallet-adapter-core':
         specifier: workspace:*
         version: link:../../packages/wallet-adapter-core
@@ -276,8 +276,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/wallet-adapter-vue
       '@aptos-labs/wallet-standard':
-        specifier: ^0.3.0
-        version: 0.3.0(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0)
+        specifier: ^0.5.0
+        version: 0.5.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
       '@nuxtjs/google-fonts':
         specifier: ^3.2.0
         version: 3.2.0(magicast@0.3.5)
@@ -353,13 +353,13 @@ importers:
         version: link:../derived-wallet-solana
       '@aptos-labs/ts-sdk':
         specifier: ^1.38.0 || ^2.0.0
-        version: 2.0.0(axios@1.8.4)(got@11.8.6)
+        version: 2.0.0(axios@1.10.0)(got@11.8.6)
       '@aptos-labs/wallet-adapter-core':
         specifier: workspace:*
         version: link:../wallet-adapter-core
       '@aptos-labs/wallet-standard':
-        specifier: ^0.3.0
-        version: 0.3.0(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0)
+        specifier: ^0.5.0
+        version: 0.5.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
       '@mysten/sui':
         specifier: ^1.21.2
         version: 1.25.0(typescript@5.8.2)
@@ -383,10 +383,10 @@ importers:
         version: 1.1.0
       '@wormhole-foundation/sdk':
         specifier: 1.5.2
-        version: 1.5.2(@types/react@18.3.20)(axios@1.8.4)(bufferutil@4.0.9)(got@11.8.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)(utf-8-validate@5.0.10)
+        version: 1.5.2(@types/react@18.3.20)(axios@1.10.0)(bufferutil@4.0.9)(got@11.8.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)(utf-8-validate@5.0.10)
       '@wormhole-foundation/sdk-aptos':
         specifier: ^1.5.2
-        version: 1.14.0(axios@1.8.4)(got@11.8.6)
+        version: 1.14.0(axios@1.10.0)(got@11.8.6)
       '@wormhole-foundation/sdk-evm':
         specifier: ^1.5.2
         version: 1.14.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
@@ -450,10 +450,10 @@ importers:
     dependencies:
       '@aptos-labs/ts-sdk':
         specifier: ^1.38.0 || ^2.0.0
-        version: 2.0.0(axios@1.8.4)(got@11.8.6)
+        version: 2.0.0(axios@1.10.0)(got@11.8.6)
       '@aptos-labs/wallet-standard':
-        specifier: ^0.3.0
-        version: 0.3.0(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0)
+        specifier: ^0.5.0
+        version: 0.5.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
     devDependencies:
       '@aptos-labs/eslint-config-adapter':
         specifier: workspace:*
@@ -489,14 +489,14 @@ importers:
         specifier: workspace:^
         version: link:../derived-wallet-base
       '@aptos-labs/siwa':
-        specifier: ^0.2.5
-        version: 0.2.5(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0)
+        specifier: ^0.3.0
+        version: 0.3.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
       '@aptos-labs/ts-sdk':
         specifier: ^1.38.0 || ^2.0.0
-        version: 2.0.0(axios@1.8.4)(got@11.8.6)
+        version: 2.0.0(axios@1.10.0)(got@11.8.6)
       '@aptos-labs/wallet-standard':
-        specifier: ^0.3.0
-        version: 0.3.0(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0)
+        specifier: ^0.5.0
+        version: 0.5.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
       '@wallet-standard/app':
         specifier: ^1.1.0
         version: 1.1.0
@@ -544,14 +544,14 @@ importers:
         specifier: workspace:^
         version: link:../derived-wallet-base
       '@aptos-labs/siwa':
-        specifier: ^0.2.5
-        version: 0.2.5(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0)
+        specifier: ^0.3.0
+        version: 0.3.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
       '@aptos-labs/ts-sdk':
         specifier: ^1.38.0 || ^2.0.0
-        version: 2.0.0(axios@1.8.4)(got@11.8.6)
+        version: 2.0.0(axios@1.10.0)(got@11.8.6)
       '@aptos-labs/wallet-standard':
-        specifier: ^0.3.0
-        version: 0.3.0(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0)
+        specifier: ^0.5.0
+        version: 0.5.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
       '@solana/wallet-adapter-base':
         specifier: ^0.9.23
         version: 0.9.24(@solana/web3.js@1.98.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
@@ -660,17 +660,17 @@ importers:
   packages/wallet-adapter-core:
     dependencies:
       '@aptos-connect/wallet-adapter-plugin':
-        specifier: 2.4.1
-        version: 2.4.1(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(@aptos-labs/wallet-standard@0.4.0(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.8.4)(got@11.8.6))
+        specifier: 2.5.0
+        version: 2.5.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
       '@aptos-labs/ts-sdk':
         specifier: ^1.38.0 || ^2.0.0
-        version: 2.0.0(axios@1.8.4)(got@11.8.6)
+        version: 2.0.0(axios@1.10.0)(got@11.8.6)
       '@aptos-labs/wallet-standard':
-        specifier: ^0.4.0
-        version: 0.4.0(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0)
+        specifier: ^0.5.0
+        version: 0.5.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
       '@msafe/aptos-aip62-wallet':
         specifier: ^1.0.18
-        version: 1.0.18(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(@aptos-labs/wallet-adapter-core@5.7.1(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.8.4)(got@11.8.6))(axios@1.8.4)(got@11.8.6))(@aptos-labs/wallet-standard@0.4.0(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0))(@mizuwallet-sdk/protocol@0.0.6)(@wallet-standard/core@1.1.0)
+        version: 1.0.18(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-adapter-core@5.7.1(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-standard@0.5.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0))(@mizuwallet-sdk/protocol@0.0.6)(@wallet-standard/core@1.1.0)
       buffer:
         specifier: ^6.0.3
         version: 6.0.3
@@ -793,7 +793,7 @@ importers:
     dependencies:
       '@aptos-labs/wallet-adapter-core':
         specifier: 5.0.0
-        version: 5.0.0(@aptos-labs/ts-sdk@1.38.0(axios@1.8.4)(got@11.8.6))(@mizuwallet-sdk/core@1.4.0(@aptos-labs/ts-sdk@1.38.0(axios@1.8.4)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(graphql-request@7.1.2(graphql@16.10.0)))(@mizuwallet-sdk/protocol@0.0.6)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.8.4)(got@11.8.6))(axios@1.8.4)(got@11.8.6)
+        version: 5.0.0(@aptos-labs/ts-sdk@1.38.0(axios@1.10.0)(got@11.8.6))(@mizuwallet-sdk/core@1.4.0(@aptos-labs/ts-sdk@1.38.0(axios@1.10.0)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(graphql-request@7.1.2(graphql@16.10.0)))(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))(axios@1.10.0)(got@11.8.6)
       vue:
         specifier: ^3.5.13
         version: 3.5.13(typescript@5.8.3)
@@ -920,8 +920,19 @@ packages:
       '@aptos-labs/ts-sdk': ^1.33.1
       '@aptos-labs/wallet-standard': ^0.3.0
 
+  '@aptos-connect/wallet-adapter-plugin@2.5.0':
+    resolution: {integrity: sha512-tDR6Te8JYsSC5YTZTqj8EbFN3Uszo/YDX+cBEBY4juYb9+ht8y5Tn6m/2RJRW+7DL9uVA7JVt6yWFQVpo+MijQ==}
+    peerDependencies:
+      '@aptos-labs/ts-sdk': ^1.33.1
+
   '@aptos-connect/wallet-api@0.1.9':
     resolution: {integrity: sha512-Olxvg/Jpf426uiEIUbxFuoRluhX3dja9EUqklY29yw/wOY7QDFv0+Es71xp8R2lgaU3gPFJxUwko1Jwz0XjswQ==}
+    peerDependencies:
+      '@aptos-labs/ts-sdk': ^1.33.1
+      aptos: ^1.20.0
+
+  '@aptos-connect/wallet-api@0.3.0':
+    resolution: {integrity: sha512-MpHB1w5PZZyliwo8Xcjo3memJ4mDTRGSW5fFVJvFChD/p8qbIkAjdHQ1dw7DVo5/JYU5A8DkszG89DFtIfipPQ==}
     peerDependencies:
       '@aptos-labs/ts-sdk': ^1.33.1
       aptos: ^1.20.0
@@ -931,6 +942,14 @@ packages:
     peerDependencies:
       '@aptos-labs/ts-sdk': ^1.33.1
       '@aptos-labs/wallet-standard': ^0.3.0
+      '@telegram-apps/bridge': ^1.0.0
+      aptos: ^1.20.0
+
+  '@aptos-connect/web-transport@0.3.0':
+    resolution: {integrity: sha512-NhWViwYH8M2s6kv3WBAevTBgJfToBmT7jcCwaT4Ys0dne5V3ixiM5Y8cg0AqCnIbulDb3cfwfE1rCVYvBCZ47w==}
+    peerDependencies:
+      '@aptos-labs/ts-sdk': ^1.33.1
+      '@aptos-labs/wallet-standard': ^0.5.0
       '@telegram-apps/bridge': ^1.0.0
       aptos: ^1.20.0
 
@@ -951,10 +970,10 @@ packages:
   '@aptos-labs/script-composer-pack@0.0.9':
     resolution: {integrity: sha512-Y3kA1rgF65HETgoTn2omDymsgO+fnZouPLrKJZ9sbxTGdOekIIHtGee3A2gk84eCqa02ZKBumZmP+IDCXRtU/g==}
 
-  '@aptos-labs/siwa@0.2.5':
-    resolution: {integrity: sha512-BDiZa5z8a1DRG95OO1e9EwAnjLUurwpAKcnmJcqYwNH+q5p3NsdPeEF071xmZNB9urPbOOJyGwGwHDH2TgUBCw==}
+  '@aptos-labs/siwa@0.3.0':
+    resolution: {integrity: sha512-7czUL8++or7DAk8KX9R6UicgluuR/WbACJoqGV7SI8TRz2quLGHheu75G743Zxzns4JHRMsYK97L9cyoVtm4jA==}
     peerDependencies:
-      '@aptos-labs/ts-sdk': '>=1.33.2'
+      '@aptos-labs/ts-sdk': '>=1.37.0'
 
   '@aptos-labs/ts-sdk@1.38.0':
     resolution: {integrity: sha512-cflGyknECg11wTkQ1o1OK759v1m+mpz0S0/ZXsHbPMO0dO6eQGLjH/Uk5/YWMe1Nat8/szcgIipKk8Xr6Unvzg==}
@@ -989,12 +1008,6 @@ packages:
       '@aptos-labs/ts-sdk': ^1.17.0
       '@wallet-standard/core': ^1.0.3
 
-  '@aptos-labs/wallet-standard@0.3.0':
-    resolution: {integrity: sha512-M0Luh2hWW0BlSHv90YytOJmbE5VeHR/w8ddd7BO8N8jZ2WylKW6AHdkn6oUi1Ft9yb2dt3Qp+T/Sd2JFoRGyzw==}
-    peerDependencies:
-      '@aptos-labs/ts-sdk': ^1.17.0
-      '@wallet-standard/core': ^1.0.3
-
   '@aptos-labs/wallet-standard@0.3.1':
     resolution: {integrity: sha512-1cSmPxKB8R5HIlYPTKej7LzKflWbkod5t8peZ+OOHA3LbB1KI39qQn6gLid8kFBluvYsmkE1XEIIUyKLx07TsA==}
     peerDependencies:
@@ -1003,6 +1016,12 @@ packages:
 
   '@aptos-labs/wallet-standard@0.4.0':
     resolution: {integrity: sha512-c38ZFQuqDMPzGPkksnXxwidlzG36PguplJGrMItPDmz/3u/GaM+2O9uE+0T721dTiuc6NJqbr8dZyw1kdQj2cg==}
+    peerDependencies:
+      '@aptos-labs/ts-sdk': ^2.0.0
+      '@wallet-standard/core': ^1.0.3
+
+  '@aptos-labs/wallet-standard@0.5.0':
+    resolution: {integrity: sha512-OEzajPOgdyosFHDCqRbu5Ql6NsiQnkspcVKUPe4iSWx93mZOEmCLE2MHfmqPDMqKBBPxbGZNc1+I7vjrPGZJCw==}
     peerDependencies:
       '@aptos-labs/ts-sdk': ^2.0.0
       '@wallet-standard/core': ^1.0.3
@@ -1841,11 +1860,22 @@ packages:
     peerDependencies:
       '@aptos-labs/ts-sdk': ^1.33.1
 
+  '@identity-connect/crypto@0.2.7':
+    resolution: {integrity: sha512-82yPYAV+3eOpIGODqchlEZ4eFHwbyQ7FqLdq952dUHvSSAlTpts+X9kvhYOPlohJSViyY11ZQP1OGzCG+d6QgA==}
+    peerDependencies:
+      '@aptos-labs/ts-sdk': ^1.33.1
+
   '@identity-connect/dapp-sdk@0.10.4':
     resolution: {integrity: sha512-wC1yh0K2EbmIG6oCN7+KRaVXHBUKasuBsm2z/Lq1x5zGJNtFtg6pXQl087ngHixpSCPINx5QqZXd9uXI/oqSmQ==}
     peerDependencies:
       '@aptos-labs/ts-sdk': ^1.33.1
       '@aptos-labs/wallet-standard': ^0.3.0
+
+  '@identity-connect/dapp-sdk@0.11.0':
+    resolution: {integrity: sha512-tPmHZiy2xMADj3y3KZKyspMF9KelDaFvBmHZPZZDyf3TVmjOxShXF3QWymoQqNiGvw7PTzSNlg6PPczp8MJiUw==}
+    peerDependencies:
+      '@aptos-labs/ts-sdk': ^1.33.1
+      '@aptos-labs/wallet-standard': ^0.5.0
 
   '@identity-connect/wallet-api@0.1.2':
     resolution: {integrity: sha512-8wyC0rWYb4+L0/K9Kf+LV9U8k5ZUkbauyf4lVVdUatCw1trsBVXObACKzgEidfpfgx23S9w7hctLpegb/QkwSg==}
@@ -4797,6 +4827,9 @@ packages:
   axe-core@4.10.3:
     resolution: {integrity: sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==}
     engines: {node: '>=4'}
+
+  axios@1.10.0:
+    resolution: {integrity: sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==}
 
   axios@1.8.4:
     resolution: {integrity: sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==}
@@ -10235,67 +10268,101 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@aptos-connect/wallet-adapter-plugin@2.3.2(@aptos-labs/ts-sdk@1.38.0(axios@1.8.4)(got@11.8.6))(@aptos-labs/wallet-standard@0.2.0(@aptos-labs/ts-sdk@1.38.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.8.4)(got@11.8.6))':
+  '@aptos-connect/wallet-adapter-plugin@2.3.2(@aptos-labs/ts-sdk@1.38.0(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-standard@0.2.0(@aptos-labs/ts-sdk@1.38.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))':
     dependencies:
-      '@aptos-connect/wallet-api': 0.1.9(@aptos-labs/ts-sdk@1.38.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.8.4)(got@11.8.6))
-      '@aptos-labs/ts-sdk': 1.38.0(axios@1.8.4)(got@11.8.6)
-      '@aptos-labs/wallet-standard': 0.2.0(@aptos-labs/ts-sdk@1.38.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0)
-      '@identity-connect/crypto': 0.2.5(@aptos-labs/ts-sdk@1.38.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.8.4)(got@11.8.6))
-      '@identity-connect/dapp-sdk': 0.10.4(@aptos-labs/ts-sdk@1.38.0(axios@1.8.4)(got@11.8.6))(@aptos-labs/wallet-standard@0.2.0(@aptos-labs/ts-sdk@1.38.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.8.4)(got@11.8.6))
+      '@aptos-connect/wallet-api': 0.1.9(@aptos-labs/ts-sdk@1.38.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
+      '@aptos-labs/ts-sdk': 1.38.0(axios@1.10.0)(got@11.8.6)
+      '@aptos-labs/wallet-standard': 0.2.0(@aptos-labs/ts-sdk@1.38.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
+      '@identity-connect/crypto': 0.2.5(@aptos-labs/ts-sdk@1.38.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
+      '@identity-connect/dapp-sdk': 0.10.4(@aptos-labs/ts-sdk@1.38.0(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-standard@0.2.0(@aptos-labs/ts-sdk@1.38.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
     transitivePeerDependencies:
       - '@telegram-apps/bridge'
       - '@wallet-standard/core'
       - aptos
       - debug
 
-  '@aptos-connect/wallet-adapter-plugin@2.4.1(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(@aptos-labs/wallet-standard@0.4.0(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.8.4)(got@11.8.6))':
+  '@aptos-connect/wallet-adapter-plugin@2.4.1(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-standard@0.4.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))':
     dependencies:
-      '@aptos-connect/wallet-api': 0.1.9(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.8.4)(got@11.8.6))
-      '@aptos-labs/ts-sdk': 2.0.0(axios@1.8.4)(got@11.8.6)
-      '@aptos-labs/wallet-standard': 0.4.0(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0)
-      '@identity-connect/crypto': 0.2.5(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.8.4)(got@11.8.6))
-      '@identity-connect/dapp-sdk': 0.10.4(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(@aptos-labs/wallet-standard@0.4.0(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.8.4)(got@11.8.6))
+      '@aptos-connect/wallet-api': 0.1.9(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
+      '@aptos-labs/ts-sdk': 2.0.0(axios@1.10.0)(got@11.8.6)
+      '@aptos-labs/wallet-standard': 0.4.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
+      '@identity-connect/crypto': 0.2.5(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
+      '@identity-connect/dapp-sdk': 0.10.4(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-standard@0.4.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
     transitivePeerDependencies:
       - '@telegram-apps/bridge'
       - '@wallet-standard/core'
       - aptos
       - debug
 
-  '@aptos-connect/wallet-api@0.1.9(@aptos-labs/ts-sdk@1.38.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.8.4)(got@11.8.6))':
+  '@aptos-connect/wallet-adapter-plugin@2.5.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))':
     dependencies:
-      '@aptos-labs/ts-sdk': 1.38.0(axios@1.8.4)(got@11.8.6)
-      '@aptos-labs/wallet-standard': 0.3.1(@aptos-labs/ts-sdk@1.38.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0)
+      '@aptos-connect/wallet-api': 0.3.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
+      '@aptos-labs/ts-sdk': 2.0.0(axios@1.10.0)(got@11.8.6)
+      '@aptos-labs/wallet-standard': 0.5.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
+      '@identity-connect/crypto': 0.2.7(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
+      '@identity-connect/dapp-sdk': 0.11.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-standard@0.5.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
+    transitivePeerDependencies:
+      - '@telegram-apps/bridge'
+      - '@wallet-standard/core'
+      - aptos
+      - debug
+
+  '@aptos-connect/wallet-api@0.1.9(@aptos-labs/ts-sdk@1.38.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))':
+    dependencies:
+      '@aptos-labs/ts-sdk': 1.38.0(axios@1.10.0)(got@11.8.6)
+      '@aptos-labs/wallet-standard': 0.3.1(@aptos-labs/ts-sdk@1.38.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
       '@identity-connect/api': 0.7.0
-      aptos: 1.21.0(axios@1.8.4)(got@11.8.6)
+      aptos: 1.21.0(axios@1.10.0)(got@11.8.6)
     transitivePeerDependencies:
       - '@wallet-standard/core'
 
-  '@aptos-connect/wallet-api@0.1.9(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.8.4)(got@11.8.6))':
+  '@aptos-connect/wallet-api@0.1.9(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))':
     dependencies:
-      '@aptos-labs/ts-sdk': 2.0.0(axios@1.8.4)(got@11.8.6)
-      '@aptos-labs/wallet-standard': 0.3.1(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0)
+      '@aptos-labs/ts-sdk': 2.0.0(axios@1.10.0)(got@11.8.6)
+      '@aptos-labs/wallet-standard': 0.3.1(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
       '@identity-connect/api': 0.7.0
-      aptos: 1.21.0(axios@1.8.4)(got@11.8.6)
+      aptos: 1.21.0(axios@1.10.0)(got@11.8.6)
     transitivePeerDependencies:
       - '@wallet-standard/core'
 
-  '@aptos-connect/web-transport@0.1.3(@aptos-labs/ts-sdk@1.38.0(axios@1.8.4)(got@11.8.6))(@aptos-labs/wallet-standard@0.2.0(@aptos-labs/ts-sdk@1.38.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.8.4)(got@11.8.6))':
+  '@aptos-connect/wallet-api@0.3.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))':
     dependencies:
-      '@aptos-connect/wallet-api': 0.1.9(@aptos-labs/ts-sdk@1.38.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.8.4)(got@11.8.6))
-      '@aptos-labs/ts-sdk': 1.38.0(axios@1.8.4)(got@11.8.6)
-      '@aptos-labs/wallet-standard': 0.2.0(@aptos-labs/ts-sdk@1.38.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0)
-      aptos: 1.21.0(axios@1.8.4)(got@11.8.6)
+      '@aptos-labs/ts-sdk': 2.0.0(axios@1.10.0)(got@11.8.6)
+      '@aptos-labs/wallet-standard': 0.5.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
+      '@identity-connect/api': 0.7.0
+      aptos: 1.21.0(axios@1.10.0)(got@11.8.6)
+    transitivePeerDependencies:
+      - '@wallet-standard/core'
+
+  '@aptos-connect/web-transport@0.1.3(@aptos-labs/ts-sdk@1.38.0(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-standard@0.2.0(@aptos-labs/ts-sdk@1.38.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))':
+    dependencies:
+      '@aptos-connect/wallet-api': 0.1.9(@aptos-labs/ts-sdk@1.38.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
+      '@aptos-labs/ts-sdk': 1.38.0(axios@1.10.0)(got@11.8.6)
+      '@aptos-labs/wallet-standard': 0.2.0(@aptos-labs/ts-sdk@1.38.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
+      '@telegram-apps/bridge': 1.9.2
+      aptos: 1.21.0(axios@1.10.0)(got@11.8.6)
       uuid: 9.0.1
     transitivePeerDependencies:
       - '@wallet-standard/core'
 
-  '@aptos-connect/web-transport@0.1.3(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(@aptos-labs/wallet-standard@0.4.0(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.8.4)(got@11.8.6))':
+  '@aptos-connect/web-transport@0.1.3(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-standard@0.4.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))':
     dependencies:
-      '@aptos-connect/wallet-api': 0.1.9(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.8.4)(got@11.8.6))
-      '@aptos-labs/ts-sdk': 2.0.0(axios@1.8.4)(got@11.8.6)
-      '@aptos-labs/wallet-standard': 0.4.0(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0)
+      '@aptos-connect/wallet-api': 0.1.9(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
+      '@aptos-labs/ts-sdk': 2.0.0(axios@1.10.0)(got@11.8.6)
+      '@aptos-labs/wallet-standard': 0.4.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
       '@telegram-apps/bridge': 1.9.2
-      aptos: 1.21.0(axios@1.8.4)(got@11.8.6)
+      aptos: 1.21.0(axios@1.10.0)(got@11.8.6)
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - '@wallet-standard/core'
+
+  '@aptos-connect/web-transport@0.3.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-standard@0.5.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))':
+    dependencies:
+      '@aptos-connect/wallet-api': 0.3.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
+      '@aptos-labs/ts-sdk': 2.0.0(axios@1.10.0)(got@11.8.6)
+      '@aptos-labs/wallet-standard': 0.5.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
+      '@telegram-apps/bridge': 1.9.2
+      aptos: 1.21.0(axios@1.10.0)(got@11.8.6)
       uuid: 9.0.1
     transitivePeerDependencies:
       - '@wallet-standard/core'
@@ -10304,9 +10371,9 @@ snapshots:
     dependencies:
       commander: 12.1.0
 
-  '@aptos-labs/aptos-client@1.2.0(axios@1.8.4)(got@11.8.6)':
+  '@aptos-labs/aptos-client@1.2.0(axios@1.10.0)(got@11.8.6)':
     dependencies:
-      axios: 1.8.4
+      axios: 1.10.0
       got: 11.8.6
 
   '@aptos-labs/aptos-dynamic-transaction-composer@0.1.3': {}
@@ -10315,18 +10382,18 @@ snapshots:
     dependencies:
       '@aptos-labs/aptos-dynamic-transaction-composer': 0.1.3
 
-  '@aptos-labs/siwa@0.2.5(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0)':
+  '@aptos-labs/siwa@0.3.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)':
     dependencies:
-      '@aptos-labs/ts-sdk': 2.0.0(axios@1.8.4)(got@11.8.6)
-      '@aptos-labs/wallet-standard': 0.3.0(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0)
+      '@aptos-labs/ts-sdk': 2.0.0(axios@1.10.0)(got@11.8.6)
+      '@aptos-labs/wallet-standard': 0.5.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
       '@noble/hashes': 1.7.1
     transitivePeerDependencies:
       - '@wallet-standard/core'
 
-  '@aptos-labs/ts-sdk@1.38.0(axios@1.8.4)(got@11.8.6)':
+  '@aptos-labs/ts-sdk@1.38.0(axios@1.10.0)(got@11.8.6)':
     dependencies:
       '@aptos-labs/aptos-cli': 1.0.2
-      '@aptos-labs/aptos-client': 1.2.0(axios@1.8.4)(got@11.8.6)
+      '@aptos-labs/aptos-client': 1.2.0(axios@1.10.0)(got@11.8.6)
       '@aptos-labs/script-composer-pack': 0.0.9
       '@noble/curves': 1.8.1
       '@noble/hashes': 1.7.1
@@ -10341,10 +10408,10 @@ snapshots:
       - axios
       - got
 
-  '@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6)':
+  '@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6)':
     dependencies:
       '@aptos-labs/aptos-cli': 1.0.2
-      '@aptos-labs/aptos-client': 1.2.0(axios@1.8.4)(got@11.8.6)
+      '@aptos-labs/aptos-client': 1.2.0(axios@1.10.0)(got@11.8.6)
       '@noble/curves': 1.8.1
       '@noble/hashes': 1.7.1
       '@scure/bip32': 1.6.2
@@ -10358,13 +10425,13 @@ snapshots:
       - axios
       - got
 
-  '@aptos-labs/wallet-adapter-core@5.0.0(@aptos-labs/ts-sdk@1.38.0(axios@1.8.4)(got@11.8.6))(@mizuwallet-sdk/core@1.4.0(@aptos-labs/ts-sdk@1.38.0(axios@1.8.4)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(graphql-request@7.1.2(graphql@16.10.0)))(@mizuwallet-sdk/protocol@0.0.6)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.8.4)(got@11.8.6))(axios@1.8.4)(got@11.8.6)':
+  '@aptos-labs/wallet-adapter-core@5.0.0(@aptos-labs/ts-sdk@1.38.0(axios@1.10.0)(got@11.8.6))(@mizuwallet-sdk/core@1.4.0(@aptos-labs/ts-sdk@1.38.0(axios@1.10.0)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(graphql-request@7.1.2(graphql@16.10.0)))(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))(axios@1.10.0)(got@11.8.6)':
     dependencies:
-      '@aptos-connect/wallet-adapter-plugin': 2.3.2(@aptos-labs/ts-sdk@1.38.0(axios@1.8.4)(got@11.8.6))(@aptos-labs/wallet-standard@0.2.0(@aptos-labs/ts-sdk@1.38.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.8.4)(got@11.8.6))
-      '@aptos-labs/ts-sdk': 1.38.0(axios@1.8.4)(got@11.8.6)
-      '@aptos-labs/wallet-standard': 0.2.0(@aptos-labs/ts-sdk@1.38.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0)
-      '@atomrigslab/aptos-wallet-adapter': 0.1.21(@aptos-labs/ts-sdk@1.38.0(axios@1.8.4)(got@11.8.6))(axios@1.8.4)(got@11.8.6)
-      '@mizuwallet-sdk/aptos-wallet-adapter': 0.3.2(@mizuwallet-sdk/core@1.4.0(@aptos-labs/ts-sdk@1.38.0(axios@1.8.4)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(graphql-request@7.1.2(graphql@16.10.0)))(@mizuwallet-sdk/protocol@0.0.6)(@wallet-standard/core@1.1.0)(axios@1.8.4)(got@11.8.6)
+      '@aptos-connect/wallet-adapter-plugin': 2.3.2(@aptos-labs/ts-sdk@1.38.0(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-standard@0.2.0(@aptos-labs/ts-sdk@1.38.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
+      '@aptos-labs/ts-sdk': 1.38.0(axios@1.10.0)(got@11.8.6)
+      '@aptos-labs/wallet-standard': 0.2.0(@aptos-labs/ts-sdk@1.38.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
+      '@atomrigslab/aptos-wallet-adapter': 0.1.21(@aptos-labs/ts-sdk@1.38.0(axios@1.10.0)(got@11.8.6))(axios@1.10.0)(got@11.8.6)
+      '@mizuwallet-sdk/aptos-wallet-adapter': 0.3.2(@mizuwallet-sdk/core@1.4.0(@aptos-labs/ts-sdk@1.38.0(axios@1.10.0)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(graphql-request@7.1.2(graphql@16.10.0)))(@mizuwallet-sdk/protocol@0.0.6)(@wallet-standard/core@1.1.0)(axios@1.10.0)(got@11.8.6)
       buffer: 6.0.3
       eventemitter3: 4.0.7
       tweetnacl: 1.0.3
@@ -10378,13 +10445,13 @@ snapshots:
       - debug
       - got
 
-  '@aptos-labs/wallet-adapter-core@5.7.1(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.8.4)(got@11.8.6))(axios@1.8.4)(got@11.8.6)':
+  '@aptos-labs/wallet-adapter-core@5.7.1(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))(axios@1.10.0)(got@11.8.6)':
     dependencies:
-      '@aptos-connect/wallet-adapter-plugin': 2.4.1(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(@aptos-labs/wallet-standard@0.4.0(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.8.4)(got@11.8.6))
-      '@aptos-labs/ts-sdk': 2.0.0(axios@1.8.4)(got@11.8.6)
-      '@aptos-labs/wallet-standard': 0.4.0(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0)
-      '@atomrigslab/aptos-wallet-adapter': 0.1.21(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(axios@1.8.4)(got@11.8.6)
-      '@msafe/aptos-aip62-wallet': 1.0.18(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(@aptos-labs/wallet-adapter-core@5.7.1(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.8.4)(got@11.8.6))(axios@1.8.4)(got@11.8.6))(@aptos-labs/wallet-standard@0.4.0(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0))(@mizuwallet-sdk/protocol@0.0.6)(@wallet-standard/core@1.1.0)
+      '@aptos-connect/wallet-adapter-plugin': 2.4.1(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-standard@0.4.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
+      '@aptos-labs/ts-sdk': 2.0.0(axios@1.10.0)(got@11.8.6)
+      '@aptos-labs/wallet-standard': 0.4.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
+      '@atomrigslab/aptos-wallet-adapter': 0.1.21(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(axios@1.10.0)(got@11.8.6)
+      '@msafe/aptos-aip62-wallet': 1.0.18(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-adapter-core@5.7.1(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-standard@0.4.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0))(@mizuwallet-sdk/protocol@0.0.6)(@wallet-standard/core@1.1.0)
       buffer: 6.0.3
       eventemitter3: 4.0.7
       tweetnacl: 1.0.3
@@ -10397,57 +10464,57 @@ snapshots:
       - debug
       - got
 
-  '@aptos-labs/wallet-standard@0.0.11(axios@1.8.4)(got@11.8.6)':
+  '@aptos-labs/wallet-standard@0.0.11(axios@1.10.0)(got@11.8.6)':
     dependencies:
-      '@aptos-labs/ts-sdk': 1.38.0(axios@1.8.4)(got@11.8.6)
+      '@aptos-labs/ts-sdk': 1.38.0(axios@1.10.0)(got@11.8.6)
       '@wallet-standard/core': 1.0.3
     transitivePeerDependencies:
       - axios
       - got
 
-  '@aptos-labs/wallet-standard@0.1.0-ms.1(@aptos-labs/ts-sdk@1.38.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0)':
+  '@aptos-labs/wallet-standard@0.1.0-ms.1(@aptos-labs/ts-sdk@1.38.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)':
     dependencies:
-      '@aptos-labs/ts-sdk': 1.38.0(axios@1.8.4)(got@11.8.6)
+      '@aptos-labs/ts-sdk': 1.38.0(axios@1.10.0)(got@11.8.6)
       '@wallet-standard/core': 1.1.0
 
-  '@aptos-labs/wallet-standard@0.2.0(@aptos-labs/ts-sdk@1.38.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0)':
+  '@aptos-labs/wallet-standard@0.2.0(@aptos-labs/ts-sdk@1.38.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)':
     dependencies:
-      '@aptos-labs/ts-sdk': 1.38.0(axios@1.8.4)(got@11.8.6)
+      '@aptos-labs/ts-sdk': 1.38.0(axios@1.10.0)(got@11.8.6)
       '@wallet-standard/core': 1.1.0
 
-  '@aptos-labs/wallet-standard@0.3.0(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0)':
+  '@aptos-labs/wallet-standard@0.3.1(@aptos-labs/ts-sdk@1.38.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)':
     dependencies:
-      '@aptos-labs/ts-sdk': 2.0.0(axios@1.8.4)(got@11.8.6)
+      '@aptos-labs/ts-sdk': 1.38.0(axios@1.10.0)(got@11.8.6)
       '@wallet-standard/core': 1.1.0
 
-  '@aptos-labs/wallet-standard@0.3.1(@aptos-labs/ts-sdk@1.38.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0)':
+  '@aptos-labs/wallet-standard@0.3.1(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)':
     dependencies:
-      '@aptos-labs/ts-sdk': 1.38.0(axios@1.8.4)(got@11.8.6)
+      '@aptos-labs/ts-sdk': 2.0.0(axios@1.10.0)(got@11.8.6)
       '@wallet-standard/core': 1.1.0
 
-  '@aptos-labs/wallet-standard@0.3.1(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0)':
+  '@aptos-labs/wallet-standard@0.4.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)':
     dependencies:
-      '@aptos-labs/ts-sdk': 2.0.0(axios@1.8.4)(got@11.8.6)
+      '@aptos-labs/ts-sdk': 2.0.0(axios@1.10.0)(got@11.8.6)
       '@wallet-standard/core': 1.1.0
 
-  '@aptos-labs/wallet-standard@0.4.0(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0)':
+  '@aptos-labs/wallet-standard@0.5.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)':
     dependencies:
-      '@aptos-labs/ts-sdk': 2.0.0(axios@1.8.4)(got@11.8.6)
+      '@aptos-labs/ts-sdk': 2.0.0(axios@1.10.0)(got@11.8.6)
       '@wallet-standard/core': 1.1.0
 
-  '@atomrigslab/aptos-wallet-adapter@0.1.21(@aptos-labs/ts-sdk@1.38.0(axios@1.8.4)(got@11.8.6))(axios@1.8.4)(got@11.8.6)':
+  '@atomrigslab/aptos-wallet-adapter@0.1.21(@aptos-labs/ts-sdk@1.38.0(axios@1.10.0)(got@11.8.6))(axios@1.10.0)(got@11.8.6)':
     dependencies:
-      '@aptos-labs/ts-sdk': 1.38.0(axios@1.8.4)(got@11.8.6)
-      '@aptos-labs/wallet-standard': 0.0.11(axios@1.8.4)(got@11.8.6)
+      '@aptos-labs/ts-sdk': 1.38.0(axios@1.10.0)(got@11.8.6)
+      '@aptos-labs/wallet-standard': 0.0.11(axios@1.10.0)(got@11.8.6)
       '@atomrigslab/dekey-web-wallet-provider': 1.2.1
     transitivePeerDependencies:
       - axios
       - got
 
-  '@atomrigslab/aptos-wallet-adapter@0.1.21(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(axios@1.8.4)(got@11.8.6)':
+  '@atomrigslab/aptos-wallet-adapter@0.1.21(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(axios@1.10.0)(got@11.8.6)':
     dependencies:
-      '@aptos-labs/ts-sdk': 2.0.0(axios@1.8.4)(got@11.8.6)
-      '@aptos-labs/wallet-standard': 0.0.11(axios@1.8.4)(got@11.8.6)
+      '@aptos-labs/ts-sdk': 2.0.0(axios@1.10.0)(got@11.8.6)
+      '@aptos-labs/wallet-standard': 0.0.11(axios@1.10.0)(got@11.8.6)
       '@atomrigslab/dekey-web-wallet-provider': 1.2.1
     transitivePeerDependencies:
       - axios
@@ -11471,10 +11538,10 @@ snapshots:
 
   '@identity-connect/api@0.7.0': {}
 
-  '@identity-connect/crypto@0.2.5(@aptos-labs/ts-sdk@1.38.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.8.4)(got@11.8.6))':
+  '@identity-connect/crypto@0.2.5(@aptos-labs/ts-sdk@1.38.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))':
     dependencies:
-      '@aptos-connect/wallet-api': 0.1.9(@aptos-labs/ts-sdk@1.38.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.8.4)(got@11.8.6))
-      '@aptos-labs/ts-sdk': 1.38.0(axios@1.8.4)(got@11.8.6)
+      '@aptos-connect/wallet-api': 0.1.9(@aptos-labs/ts-sdk@1.38.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
+      '@aptos-labs/ts-sdk': 1.38.0(axios@1.10.0)(got@11.8.6)
       '@noble/hashes': 1.7.1
       ed2curve: 0.3.0
       tweetnacl: 1.0.3
@@ -11482,10 +11549,10 @@ snapshots:
       - '@wallet-standard/core'
       - aptos
 
-  '@identity-connect/crypto@0.2.5(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.8.4)(got@11.8.6))':
+  '@identity-connect/crypto@0.2.5(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))':
     dependencies:
-      '@aptos-connect/wallet-api': 0.1.9(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.8.4)(got@11.8.6))
-      '@aptos-labs/ts-sdk': 2.0.0(axios@1.8.4)(got@11.8.6)
+      '@aptos-connect/wallet-api': 0.1.9(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
+      '@aptos-labs/ts-sdk': 2.0.0(axios@1.10.0)(got@11.8.6)
       '@noble/hashes': 1.7.1
       ed2curve: 0.3.0
       tweetnacl: 1.0.3
@@ -11493,15 +11560,26 @@ snapshots:
       - '@wallet-standard/core'
       - aptos
 
-  '@identity-connect/dapp-sdk@0.10.4(@aptos-labs/ts-sdk@1.38.0(axios@1.8.4)(got@11.8.6))(@aptos-labs/wallet-standard@0.2.0(@aptos-labs/ts-sdk@1.38.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.8.4)(got@11.8.6))':
+  '@identity-connect/crypto@0.2.7(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))':
     dependencies:
-      '@aptos-connect/wallet-api': 0.1.9(@aptos-labs/ts-sdk@1.38.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.8.4)(got@11.8.6))
-      '@aptos-connect/web-transport': 0.1.3(@aptos-labs/ts-sdk@1.38.0(axios@1.8.4)(got@11.8.6))(@aptos-labs/wallet-standard@0.2.0(@aptos-labs/ts-sdk@1.38.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.8.4)(got@11.8.6))
-      '@aptos-labs/ts-sdk': 1.38.0(axios@1.8.4)(got@11.8.6)
-      '@aptos-labs/wallet-standard': 0.2.0(@aptos-labs/ts-sdk@1.38.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0)
+      '@aptos-connect/wallet-api': 0.3.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
+      '@aptos-labs/ts-sdk': 2.0.0(axios@1.10.0)(got@11.8.6)
+      '@noble/hashes': 1.7.1
+      ed2curve: 0.3.0
+      tweetnacl: 1.0.3
+    transitivePeerDependencies:
+      - '@wallet-standard/core'
+      - aptos
+
+  '@identity-connect/dapp-sdk@0.10.4(@aptos-labs/ts-sdk@1.38.0(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-standard@0.2.0(@aptos-labs/ts-sdk@1.38.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))':
+    dependencies:
+      '@aptos-connect/wallet-api': 0.1.9(@aptos-labs/ts-sdk@1.38.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
+      '@aptos-connect/web-transport': 0.1.3(@aptos-labs/ts-sdk@1.38.0(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-standard@0.2.0(@aptos-labs/ts-sdk@1.38.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
+      '@aptos-labs/ts-sdk': 1.38.0(axios@1.10.0)(got@11.8.6)
+      '@aptos-labs/wallet-standard': 0.2.0(@aptos-labs/ts-sdk@1.38.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
       '@identity-connect/api': 0.7.0
-      '@identity-connect/crypto': 0.2.5(@aptos-labs/ts-sdk@1.38.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.8.4)(got@11.8.6))
-      '@identity-connect/wallet-api': 0.1.2(@aptos-labs/ts-sdk@1.38.0(axios@1.8.4)(got@11.8.6))(aptos@1.21.0(axios@1.8.4)(got@11.8.6))
+      '@identity-connect/crypto': 0.2.5(@aptos-labs/ts-sdk@1.38.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
+      '@identity-connect/wallet-api': 0.1.2(@aptos-labs/ts-sdk@1.38.0(axios@1.10.0)(got@11.8.6))(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
       axios: 1.8.4
       uuid: 9.0.1
     transitivePeerDependencies:
@@ -11510,15 +11588,15 @@ snapshots:
       - aptos
       - debug
 
-  '@identity-connect/dapp-sdk@0.10.4(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(@aptos-labs/wallet-standard@0.4.0(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.8.4)(got@11.8.6))':
+  '@identity-connect/dapp-sdk@0.10.4(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-standard@0.4.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))':
     dependencies:
-      '@aptos-connect/wallet-api': 0.1.9(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.8.4)(got@11.8.6))
-      '@aptos-connect/web-transport': 0.1.3(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(@aptos-labs/wallet-standard@0.4.0(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.8.4)(got@11.8.6))
-      '@aptos-labs/ts-sdk': 2.0.0(axios@1.8.4)(got@11.8.6)
-      '@aptos-labs/wallet-standard': 0.4.0(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0)
+      '@aptos-connect/wallet-api': 0.1.9(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
+      '@aptos-connect/web-transport': 0.1.3(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-standard@0.4.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
+      '@aptos-labs/ts-sdk': 2.0.0(axios@1.10.0)(got@11.8.6)
+      '@aptos-labs/wallet-standard': 0.4.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
       '@identity-connect/api': 0.7.0
-      '@identity-connect/crypto': 0.2.5(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.8.4)(got@11.8.6))
-      '@identity-connect/wallet-api': 0.1.2(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(aptos@1.21.0(axios@1.8.4)(got@11.8.6))
+      '@identity-connect/crypto': 0.2.5(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
+      '@identity-connect/wallet-api': 0.1.2(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
       axios: 1.8.4
       uuid: 9.0.1
     transitivePeerDependencies:
@@ -11527,15 +11605,32 @@ snapshots:
       - aptos
       - debug
 
-  '@identity-connect/wallet-api@0.1.2(@aptos-labs/ts-sdk@1.38.0(axios@1.8.4)(got@11.8.6))(aptos@1.21.0(axios@1.8.4)(got@11.8.6))':
+  '@identity-connect/dapp-sdk@0.11.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-standard@0.5.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))':
     dependencies:
-      '@aptos-labs/ts-sdk': 1.38.0(axios@1.8.4)(got@11.8.6)
-      aptos: 1.21.0(axios@1.8.4)(got@11.8.6)
+      '@aptos-connect/wallet-api': 0.3.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
+      '@aptos-connect/web-transport': 0.3.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-standard@0.5.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
+      '@aptos-labs/ts-sdk': 2.0.0(axios@1.10.0)(got@11.8.6)
+      '@aptos-labs/wallet-standard': 0.5.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
+      '@identity-connect/api': 0.7.0
+      '@identity-connect/crypto': 0.2.7(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
+      '@identity-connect/wallet-api': 0.1.2(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
+      axios: 1.10.0
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - '@telegram-apps/bridge'
+      - '@wallet-standard/core'
+      - aptos
+      - debug
 
-  '@identity-connect/wallet-api@0.1.2(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(aptos@1.21.0(axios@1.8.4)(got@11.8.6))':
+  '@identity-connect/wallet-api@0.1.2(@aptos-labs/ts-sdk@1.38.0(axios@1.10.0)(got@11.8.6))(aptos@1.21.0(axios@1.10.0)(got@11.8.6))':
     dependencies:
-      '@aptos-labs/ts-sdk': 2.0.0(axios@1.8.4)(got@11.8.6)
-      aptos: 1.21.0(axios@1.8.4)(got@11.8.6)
+      '@aptos-labs/ts-sdk': 1.38.0(axios@1.10.0)(got@11.8.6)
+      aptos: 1.21.0(axios@1.10.0)(got@11.8.6)
+
+  '@identity-connect/wallet-api@0.1.2(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(aptos@1.21.0(axios@1.10.0)(got@11.8.6))':
+    dependencies:
+      '@aptos-labs/ts-sdk': 2.0.0(axios@1.10.0)(got@11.8.6)
+      aptos: 1.21.0(axios@1.10.0)(got@11.8.6)
 
   '@injectivelabs/abacus-proto-ts@1.14.0':
     dependencies:
@@ -11998,11 +12093,11 @@ snapshots:
 
   '@microsoft/tsdoc@0.14.2': {}
 
-  '@mizuwallet-sdk/aptos-wallet-adapter@0.3.2(@mizuwallet-sdk/core@1.4.0(@aptos-labs/ts-sdk@1.38.0(axios@1.8.4)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(graphql-request@7.1.2(graphql@16.10.0)))(@mizuwallet-sdk/protocol@0.0.6)(@wallet-standard/core@1.1.0)(axios@1.8.4)(got@11.8.6)':
+  '@mizuwallet-sdk/aptos-wallet-adapter@0.3.2(@mizuwallet-sdk/core@1.4.0(@aptos-labs/ts-sdk@1.38.0(axios@1.10.0)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(graphql-request@7.1.2(graphql@16.10.0)))(@mizuwallet-sdk/protocol@0.0.6)(@wallet-standard/core@1.1.0)(axios@1.10.0)(got@11.8.6)':
     dependencies:
-      '@aptos-labs/ts-sdk': 1.38.0(axios@1.8.4)(got@11.8.6)
-      '@aptos-labs/wallet-standard': 0.1.0-ms.1(@aptos-labs/ts-sdk@1.38.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0)
-      '@mizuwallet-sdk/core': 1.4.0(@aptos-labs/ts-sdk@1.38.0(axios@1.8.4)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(graphql-request@7.1.2(graphql@16.10.0))
+      '@aptos-labs/ts-sdk': 1.38.0(axios@1.10.0)(got@11.8.6)
+      '@aptos-labs/wallet-standard': 0.1.0-ms.1(@aptos-labs/ts-sdk@1.38.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
+      '@mizuwallet-sdk/core': 1.4.0(@aptos-labs/ts-sdk@1.38.0(axios@1.10.0)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(graphql-request@7.1.2(graphql@16.10.0))
       '@mizuwallet-sdk/protocol': 0.0.6
       buffer: 6.0.3
     transitivePeerDependencies:
@@ -12010,17 +12105,17 @@ snapshots:
       - axios
       - got
 
-  '@mizuwallet-sdk/core@1.4.0(@aptos-labs/ts-sdk@1.38.0(axios@1.8.4)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(graphql-request@7.1.2(graphql@16.10.0))':
+  '@mizuwallet-sdk/core@1.4.0(@aptos-labs/ts-sdk@1.38.0(axios@1.10.0)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(graphql-request@7.1.2(graphql@16.10.0))':
     dependencies:
-      '@aptos-labs/ts-sdk': 1.38.0(axios@1.8.4)(got@11.8.6)
+      '@aptos-labs/ts-sdk': 1.38.0(axios@1.10.0)(got@11.8.6)
       '@mizuwallet-sdk/protocol': 0.0.6
       buffer: 6.0.3
       graphql-request: 7.1.2(graphql@16.10.0)
       jwt-decode: 4.0.0
 
-  '@mizuwallet-sdk/core@1.4.0(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(graphql-request@7.1.2(graphql@16.10.0))':
+  '@mizuwallet-sdk/core@1.4.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(graphql-request@7.1.2(graphql@16.10.0))':
     dependencies:
-      '@aptos-labs/ts-sdk': 2.0.0(axios@1.8.4)(got@11.8.6)
+      '@aptos-labs/ts-sdk': 2.0.0(axios@1.10.0)(got@11.8.6)
       '@mizuwallet-sdk/protocol': 0.0.6
       buffer: 6.0.3
       graphql-request: 7.1.2(graphql@16.10.0)
@@ -12032,12 +12127,25 @@ snapshots:
       tweetnacl: 1.0.3
       tweetnacl-util: 0.15.1
 
-  '@msafe/aptos-aip62-wallet@1.0.18(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(@aptos-labs/wallet-adapter-core@5.7.1(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.8.4)(got@11.8.6))(axios@1.8.4)(got@11.8.6))(@aptos-labs/wallet-standard@0.4.0(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0))(@mizuwallet-sdk/protocol@0.0.6)(@wallet-standard/core@1.1.0)':
+  '@msafe/aptos-aip62-wallet@1.0.18(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-adapter-core@5.7.1(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-standard@0.4.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0))(@mizuwallet-sdk/protocol@0.0.6)(@wallet-standard/core@1.1.0)':
     dependencies:
-      '@aptos-labs/ts-sdk': 2.0.0(axios@1.8.4)(got@11.8.6)
-      '@aptos-labs/wallet-adapter-core': 5.7.1(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.8.4)(got@11.8.6))(axios@1.8.4)(got@11.8.6)
-      '@aptos-labs/wallet-standard': 0.4.0(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(@wallet-standard/core@1.1.0)
-      '@mizuwallet-sdk/core': 1.4.0(@aptos-labs/ts-sdk@2.0.0(axios@1.8.4)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(graphql-request@7.1.2(graphql@16.10.0))
+      '@aptos-labs/ts-sdk': 2.0.0(axios@1.10.0)(got@11.8.6)
+      '@aptos-labs/wallet-adapter-core': 5.7.1(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))(axios@1.10.0)(got@11.8.6)
+      '@aptos-labs/wallet-standard': 0.4.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
+      '@mizuwallet-sdk/core': 1.4.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(graphql-request@7.1.2(graphql@16.10.0))
+      '@telegram-apps/bridge': 1.9.2
+      '@wallet-standard/core': 1.1.0
+      graphql: 16.10.0
+      graphql-request: 7.1.2(graphql@16.10.0)
+    transitivePeerDependencies:
+      - '@mizuwallet-sdk/protocol'
+
+  '@msafe/aptos-aip62-wallet@1.0.18(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-adapter-core@5.7.1(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-standard@0.5.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0))(@mizuwallet-sdk/protocol@0.0.6)(@wallet-standard/core@1.1.0)':
+    dependencies:
+      '@aptos-labs/ts-sdk': 2.0.0(axios@1.10.0)(got@11.8.6)
+      '@aptos-labs/wallet-adapter-core': 5.7.1(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))(axios@1.10.0)(got@11.8.6)
+      '@aptos-labs/wallet-standard': 0.5.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
+      '@mizuwallet-sdk/core': 1.4.0(@aptos-labs/ts-sdk@2.0.0(axios@1.10.0)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(graphql-request@7.1.2(graphql@16.10.0))
       '@telegram-apps/bridge': 1.9.2
       '@wallet-standard/core': 1.1.0
       graphql: 16.10.0
@@ -14672,46 +14780,46 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@wormhole-foundation/sdk-aptos-cctp@1.5.2(axios@1.8.4)(got@11.8.6)':
+  '@wormhole-foundation/sdk-aptos-cctp@1.5.2(axios@1.10.0)(got@11.8.6)':
     dependencies:
-      '@aptos-labs/ts-sdk': 1.38.0(axios@1.8.4)(got@11.8.6)
-      '@wormhole-foundation/sdk-aptos': 1.5.2(axios@1.8.4)(got@11.8.6)
+      '@aptos-labs/ts-sdk': 1.38.0(axios@1.10.0)(got@11.8.6)
+      '@wormhole-foundation/sdk-aptos': 1.5.2(axios@1.10.0)(got@11.8.6)
       '@wormhole-foundation/sdk-connect': 1.5.2
     transitivePeerDependencies:
       - axios
       - debug
       - got
 
-  '@wormhole-foundation/sdk-aptos-core@1.5.2(axios@1.8.4)(got@11.8.6)':
+  '@wormhole-foundation/sdk-aptos-core@1.5.2(axios@1.10.0)(got@11.8.6)':
     dependencies:
-      '@wormhole-foundation/sdk-aptos': 1.5.2(axios@1.8.4)(got@11.8.6)
+      '@wormhole-foundation/sdk-aptos': 1.5.2(axios@1.10.0)(got@11.8.6)
       '@wormhole-foundation/sdk-connect': 1.5.2
     transitivePeerDependencies:
       - axios
       - debug
       - got
 
-  '@wormhole-foundation/sdk-aptos-tokenbridge@1.5.2(axios@1.8.4)(got@11.8.6)':
+  '@wormhole-foundation/sdk-aptos-tokenbridge@1.5.2(axios@1.10.0)(got@11.8.6)':
     dependencies:
-      '@wormhole-foundation/sdk-aptos': 1.5.2(axios@1.8.4)(got@11.8.6)
+      '@wormhole-foundation/sdk-aptos': 1.5.2(axios@1.10.0)(got@11.8.6)
       '@wormhole-foundation/sdk-connect': 1.5.2
     transitivePeerDependencies:
       - axios
       - debug
       - got
 
-  '@wormhole-foundation/sdk-aptos@1.14.0(axios@1.8.4)(got@11.8.6)':
+  '@wormhole-foundation/sdk-aptos@1.14.0(axios@1.10.0)(got@11.8.6)':
     dependencies:
-      '@aptos-labs/ts-sdk': 1.38.0(axios@1.8.4)(got@11.8.6)
+      '@aptos-labs/ts-sdk': 1.38.0(axios@1.10.0)(got@11.8.6)
       '@wormhole-foundation/sdk-connect': 1.14.0
     transitivePeerDependencies:
       - axios
       - debug
       - got
 
-  '@wormhole-foundation/sdk-aptos@1.5.2(axios@1.8.4)(got@11.8.6)':
+  '@wormhole-foundation/sdk-aptos@1.5.2(axios@1.10.0)(got@11.8.6)':
     dependencies:
-      '@aptos-labs/ts-sdk': 1.38.0(axios@1.8.4)(got@11.8.6)
+      '@aptos-labs/ts-sdk': 1.38.0(axios@1.10.0)(got@11.8.6)
       '@wormhole-foundation/sdk-connect': 1.5.2
     transitivePeerDependencies:
       - axios
@@ -15009,15 +15117,15 @@ snapshots:
       - debug
       - typescript
 
-  '@wormhole-foundation/sdk@1.5.2(@types/react@18.3.20)(axios@1.8.4)(bufferutil@4.0.9)(got@11.8.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)(utf-8-validate@5.0.10)':
+  '@wormhole-foundation/sdk@1.5.2(@types/react@18.3.20)(axios@1.10.0)(bufferutil@4.0.9)(got@11.8.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.2)(utf-8-validate@5.0.10)':
     dependencies:
       '@wormhole-foundation/sdk-algorand': 1.5.2
       '@wormhole-foundation/sdk-algorand-core': 1.5.2
       '@wormhole-foundation/sdk-algorand-tokenbridge': 1.5.2
-      '@wormhole-foundation/sdk-aptos': 1.5.2(axios@1.8.4)(got@11.8.6)
-      '@wormhole-foundation/sdk-aptos-cctp': 1.5.2(axios@1.8.4)(got@11.8.6)
-      '@wormhole-foundation/sdk-aptos-core': 1.5.2(axios@1.8.4)(got@11.8.6)
-      '@wormhole-foundation/sdk-aptos-tokenbridge': 1.5.2(axios@1.8.4)(got@11.8.6)
+      '@wormhole-foundation/sdk-aptos': 1.5.2(axios@1.10.0)(got@11.8.6)
+      '@wormhole-foundation/sdk-aptos-cctp': 1.5.2(axios@1.10.0)(got@11.8.6)
+      '@wormhole-foundation/sdk-aptos-core': 1.5.2(axios@1.10.0)(got@11.8.6)
+      '@wormhole-foundation/sdk-aptos-tokenbridge': 1.5.2(axios@1.10.0)(got@11.8.6)
       '@wormhole-foundation/sdk-base': 1.5.2
       '@wormhole-foundation/sdk-connect': 1.5.2
       '@wormhole-foundation/sdk-cosmwasm': 1.5.2(@types/react@18.3.20)(bufferutil@4.0.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(utf-8-validate@5.0.10)
@@ -15246,9 +15354,9 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.1
 
-  aptos@1.21.0(axios@1.8.4)(got@11.8.6):
+  aptos@1.21.0(axios@1.10.0)(got@11.8.6):
     dependencies:
-      '@aptos-labs/aptos-client': 1.2.0(axios@1.8.4)(got@11.8.6)
+      '@aptos-labs/aptos-client': 1.2.0(axios@1.10.0)(got@11.8.6)
       '@noble/hashes': 1.3.3
       '@scure/bip39': 1.2.1
       eventemitter3: 5.0.1
@@ -15404,6 +15512,14 @@ snapshots:
       possible-typed-array-names: 1.1.0
 
   axe-core@4.10.3: {}
+
+  axios@1.10.0:
+    dependencies:
+      follow-redirects: 1.15.9
+      form-data: 4.0.2
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
 
   axios@1.8.4:
     dependencies:


### PR DESCRIPTION
### Description
Bump wallet standard to 0.5.0 to support the latest version of SIWA.

### Tests
- [x] CI Passes