### PR TITLE
Bump ts-sdk version

### DIFF
--- a/.changeset/floppy-wombats-try.md
+++ b/.changeset/floppy-wombats-try.md
@@ -1,0 +1,9 @@
+---
+"@aptos-labs/derived-wallet-ethereum": patch
+"@aptos-labs/derived-wallet-solana": patch
+"@aptos-labs/derived-wallet-base": patch
+"@aptos-labs/wallet-adapter-core": patch
+"@aptos-labs/cross-chain-core": patch
+---
+
+Bump aptos ts-sdk version

--- a/apps/nextjs-example/package.json
+++ b/apps/nextjs-example/package.json
@@ -11,7 +11,7 @@
     "format": "prettier --write './**/*.{ts,tsx,js,jsx,json,md,html,css}'"
   },
   "dependencies": {
-    "@aptos-labs/ts-sdk": "^3.1.1",
+    "@aptos-labs/ts-sdk": "^3.1.2",
     "@aptos-labs/wallet-adapter-ant-design": "workspace:*",
     "@aptos-labs/wallet-adapter-core": "workspace:*",
     "@aptos-labs/wallet-adapter-mui-design": "workspace:*",

--- a/apps/nextjs-example/src/components/transactionFlows/SingleSigner.tsx
+++ b/apps/nextjs-example/src/components/transactionFlows/SingleSigner.tsx
@@ -60,7 +60,7 @@ export function SingleSigner() {
       data: {
         function: "0x1::coin::transfer",
         typeArguments: [APTOS_COIN],
-        functionArguments: [account.address.toString(), 1], // 1 is in Octas
+        functionArguments: [account.address, 1], // 1 is in Octas
       },
     };
     try {
@@ -68,7 +68,7 @@ export function SingleSigner() {
         ...transaction,
         pluginParams: {
           customParam: "customValue",
-        }
+        },
       });
       await aptosClient(network).waitForTransaction({
         transactionHash: response.hash,
@@ -114,7 +114,7 @@ export function SingleSigner() {
         data: {
           function: "0x1::coin::transfer",
           typeArguments: [parseTypeTag(APTOS_COIN)],
-          functionArguments: [AccountAddress.from(account.address).toString(), new U64(1)], // 1 is in Octas
+          functionArguments: [AccountAddress.from(account.address), new U64(1)], // 1 is in Octas
         },
       });
       await aptosClient(network).waitForTransaction({
@@ -136,7 +136,7 @@ export function SingleSigner() {
         data: {
           function: "0x1::coin::transfer",
           typeArguments: [APTOS_COIN],
-          functionArguments: [account?.address.toString(), 1],
+          functionArguments: [account?.address, 1],
         },
       };
       const response = await signTransaction({
@@ -156,13 +156,13 @@ export function SingleSigner() {
 
     try {
       const transactionToSign = await aptosClient(
-        network,
+        network
       ).transaction.build.simple({
         sender: account.address,
         data: {
           function: "0x1::coin::transfer",
           typeArguments: [APTOS_COIN],
-          functionArguments: [account.address.toString(), 1],
+          functionArguments: [account.address, 1],
         },
       });
       const response = await signTransaction({
@@ -183,7 +183,7 @@ export function SingleSigner() {
     const transaction: InputTransactionData = {
       data: {
         function: "0x1::account_abstraction::add_authentication_function",
-        functionArguments: [account.address.toString(), "dummyModule", "dummyFunction"],
+        functionArguments: [account.address, "dummyModule", "dummyFunction"],
       },
     };
     try {

--- a/apps/nextjs-example/src/components/transactionFlows/Sponsor.tsx
+++ b/apps/nextjs-example/src/components/transactionFlows/Sponsor.tsx
@@ -30,13 +30,13 @@ export function Sponsor() {
 
   // Generate a raw transaction using the SDK
   const generateTransaction = async (
-    sender: Account,
+    sender: Account
   ): Promise<AnyRawTransaction> => {
     if (!account) {
       throw new Error("no account");
     }
     const transactionToSign = await aptosClient(
-      network,
+      network
     ).transaction.build.simple({
       sender: sender.accountAddress,
       withFeePayer: true,
@@ -44,7 +44,7 @@ export function Sponsor() {
         function: "0x1::resource_account::create_resource_account",
         typeArguments: [],
         functionArguments: [
-          account.address.toString(),
+          account.address,
           AccountAddress.from("0x0").toUint8Array(),
         ],
       },

--- a/apps/nextjs-example/src/components/transactionFlows/TransactionParameters.tsx
+++ b/apps/nextjs-example/src/components/transactionFlows/TransactionParameters.tsx
@@ -22,7 +22,7 @@ export function TransactionParameters() {
       data: {
         function: "0x1::coin::transfer",
         typeArguments: [APTOS_COIN],
-        functionArguments: [account.address.toString(), 1], // 1 is in Octas
+        functionArguments: [account.address, 1], // 1 is in Octas
       },
       options: { maxGasAmount: MaxGasAMount },
     };
@@ -31,7 +31,7 @@ export function TransactionParameters() {
       const executedTransaction = await aptosClient(network).waitForTransaction(
         {
           transactionHash: commitedTransaction.hash,
-        },
+        }
       );
       // Check maxGasAmount is respected by the current connected Wallet
       if ((executedTransaction as any).max_gas_amount == MaxGasAMount) {

--- a/apps/nextjs-x-chain/package.json
+++ b/apps/nextjs-x-chain/package.json
@@ -14,7 +14,7 @@
     "@aptos-labs/cross-chain-core": "workspace:*",
     "@aptos-labs/derived-wallet-ethereum": "workspace:^",
     "@aptos-labs/derived-wallet-solana": "workspace:^",
-    "@aptos-labs/ts-sdk": "^3.1.1",
+    "@aptos-labs/ts-sdk": "^3.1.2",
     "@aptos-labs/wallet-adapter-core": "workspace:*",
     "@aptos-labs/wallet-adapter-react": "workspace:*",
     "@aptos-labs/wallet-standard": "^0.5.0",

--- a/apps/nextjs-x-chain/src/components/transactionFlows/SingleSigner.tsx
+++ b/apps/nextjs-x-chain/src/components/transactionFlows/SingleSigner.tsx
@@ -98,7 +98,7 @@ export function SingleSigner({ dappNetwork }: SingleSignerProps) {
       const payload: InputTransactionData = {
         data: {
           function: "0x1::aptos_account::transfer",
-          functionArguments: [account.address.toString(), 1],
+          functionArguments: [account.address, 1],
         },
         withFeePayer: true,
       };
@@ -145,7 +145,7 @@ export function SingleSigner({ dappNetwork }: SingleSignerProps) {
       // We are on Devnet, so just use a simple transfer transaction as the derived account can fund their own account with APT.
       transactionData = {
         function: "0x1::aptos_account::transfer",
-        functionArguments: [account.address.toString(), 717],
+        functionArguments: [account.address, 717],
       };
     }
 

--- a/apps/nuxt-example/package.json
+++ b/apps/nuxt-example/package.json
@@ -10,7 +10,7 @@
     "postinstall": "nuxt prepare"
   },
   "dependencies": {
-    "@aptos-labs/ts-sdk": "^3.1.1",
+    "@aptos-labs/ts-sdk": "^3.1.2",
     "@aptos-labs/wallet-adapter-core": "workspace:*",
     "@aptos-labs/wallet-adapter-vue": "workspace:*",
     "@aptos-labs/wallet-standard": "^0.5.0",

--- a/packages/cross-chain-core/package.json
+++ b/packages/cross-chain-core/package.json
@@ -75,7 +75,7 @@
     "tweetnacl": "^1.0.3"
   },
   "peerDependencies": {
-    "@aptos-labs/ts-sdk": "^3.1.1"
+    "@aptos-labs/ts-sdk": "^3.1.2"
   },
   "files": [
     "dist",

--- a/packages/derived-wallet-base/package.json
+++ b/packages/derived-wallet-base/package.json
@@ -32,7 +32,7 @@
     "@aptos-labs/wallet-standard": "^0.5.0"
   },
   "peerDependencies": {
-    "@aptos-labs/ts-sdk": "^3.1.1"
+    "@aptos-labs/ts-sdk": "^3.1.2"
   },
   "devDependencies": {
     "@aptos-labs/eslint-config-adapter": "workspace:*",

--- a/packages/derived-wallet-ethereum/package.json
+++ b/packages/derived-wallet-ethereum/package.json
@@ -38,7 +38,7 @@
     "viem": "^2.23.12"
   },
   "peerDependencies": {
-    "@aptos-labs/ts-sdk": "^3.1.1"
+    "@aptos-labs/ts-sdk": "^3.1.2"
   },
   "devDependencies": {
     "@aptos-labs/eslint-config-adapter": "workspace:*",

--- a/packages/derived-wallet-solana/package.json
+++ b/packages/derived-wallet-solana/package.json
@@ -39,7 +39,7 @@
     "@wallet-standard/app": "^1.1.0"
   },
   "peerDependencies": {
-    "@aptos-labs/ts-sdk": "^3.1.1"
+    "@aptos-labs/ts-sdk": "^3.1.2"
   },
   "devDependencies": {
     "@aptos-labs/eslint-config-adapter": "workspace:*",

--- a/packages/wallet-adapter-core/package.json
+++ b/packages/wallet-adapter-core/package.json
@@ -59,7 +59,7 @@
     "tweetnacl": "^1.0.3"
   },
   "peerDependencies": {
-    "@aptos-labs/ts-sdk": "^3.1.1"
+    "@aptos-labs/ts-sdk": "^3.1.2"
   },
   "files": [
     "dist",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,8 +37,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/derived-wallet-solana
       '@aptos-labs/ts-sdk':
-        specifier: ^3.1.1
-        version: 3.1.1(axios@1.10.0)(got@11.8.6)
+        specifier: ^3.1.2
+        version: 3.1.2(axios@1.10.0)(got@11.8.6)
       '@aptos-labs/wallet-adapter-ant-design':
         specifier: workspace:*
         version: link:../../packages/wallet-adapter-ant-design
@@ -53,7 +53,7 @@ importers:
         version: link:../../packages/wallet-adapter-react
       '@aptos-labs/wallet-standard':
         specifier: ^0.5.0
-        version: 0.5.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
+        version: 0.5.0(@aptos-labs/ts-sdk@3.1.2(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
       '@radix-ui/react-collapsible':
         specifier: ^1.0.3
         version: 1.1.3(@types/react-dom@18.3.5(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -158,8 +158,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/derived-wallet-solana
       '@aptos-labs/ts-sdk':
-        specifier: ^3.1.1
-        version: 3.1.1(axios@1.10.0)(got@11.8.6)
+        specifier: ^3.1.2
+        version: 3.1.2(axios@1.10.0)(got@11.8.6)
       '@aptos-labs/wallet-adapter-core':
         specifier: workspace:*
         version: link:../../packages/wallet-adapter-core
@@ -168,7 +168,7 @@ importers:
         version: link:../../packages/wallet-adapter-react
       '@aptos-labs/wallet-standard':
         specifier: ^0.5.0
-        version: 0.5.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
+        version: 0.5.0(@aptos-labs/ts-sdk@3.1.2(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
       '@radix-ui/react-collapsible':
         specifier: ^1.0.3
         version: 1.1.3(@types/react-dom@18.3.5(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -267,8 +267,8 @@ importers:
   apps/nuxt-example:
     dependencies:
       '@aptos-labs/ts-sdk':
-        specifier: ^3.1.1
-        version: 3.1.1(axios@1.10.0)(got@11.8.6)
+        specifier: ^3.1.2
+        version: 3.1.2(axios@1.10.0)(got@11.8.6)
       '@aptos-labs/wallet-adapter-core':
         specifier: workspace:*
         version: link:../../packages/wallet-adapter-core
@@ -277,7 +277,7 @@ importers:
         version: link:../../packages/wallet-adapter-vue
       '@aptos-labs/wallet-standard':
         specifier: ^0.5.0
-        version: 0.5.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
+        version: 0.5.0(@aptos-labs/ts-sdk@3.1.2(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
       '@nuxtjs/google-fonts':
         specifier: ^3.2.0
         version: 3.2.0(magicast@0.3.5)
@@ -352,14 +352,14 @@ importers:
         specifier: workspace:*
         version: link:../derived-wallet-solana
       '@aptos-labs/ts-sdk':
-        specifier: ^3.1.1
-        version: 3.1.1(axios@1.10.0)(got@11.8.6)
+        specifier: ^3.1.2
+        version: 3.1.2(axios@1.10.0)(got@11.8.6)
       '@aptos-labs/wallet-adapter-core':
         specifier: workspace:*
         version: link:../wallet-adapter-core
       '@aptos-labs/wallet-standard':
         specifier: ^0.5.0
-        version: 0.5.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
+        version: 0.5.0(@aptos-labs/ts-sdk@3.1.2(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
       '@mysten/sui':
         specifier: ^1.21.2
         version: 1.25.0(typescript@5.8.2)
@@ -449,11 +449,11 @@ importers:
   packages/derived-wallet-base:
     dependencies:
       '@aptos-labs/ts-sdk':
-        specifier: ^3.1.1
-        version: 3.1.1(axios@1.10.0)(got@11.8.6)
+        specifier: ^3.1.2
+        version: 3.1.2(axios@1.10.0)(got@11.8.6)
       '@aptos-labs/wallet-standard':
         specifier: ^0.5.0
-        version: 0.5.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
+        version: 0.5.0(@aptos-labs/ts-sdk@3.1.2(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
     devDependencies:
       '@aptos-labs/eslint-config-adapter':
         specifier: workspace:*
@@ -490,13 +490,13 @@ importers:
         version: link:../derived-wallet-base
       '@aptos-labs/siwa':
         specifier: ^0.3.0
-        version: 0.3.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
+        version: 0.3.0(@aptos-labs/ts-sdk@3.1.2(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
       '@aptos-labs/ts-sdk':
-        specifier: ^3.1.1
-        version: 3.1.1(axios@1.10.0)(got@11.8.6)
+        specifier: ^3.1.2
+        version: 3.1.2(axios@1.10.0)(got@11.8.6)
       '@aptos-labs/wallet-standard':
         specifier: ^0.5.0
-        version: 0.5.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
+        version: 0.5.0(@aptos-labs/ts-sdk@3.1.2(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
       '@wallet-standard/app':
         specifier: ^1.1.0
         version: 1.1.0
@@ -545,13 +545,13 @@ importers:
         version: link:../derived-wallet-base
       '@aptos-labs/siwa':
         specifier: ^0.3.0
-        version: 0.3.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
+        version: 0.3.0(@aptos-labs/ts-sdk@3.1.2(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
       '@aptos-labs/ts-sdk':
-        specifier: ^3.1.1
-        version: 3.1.1(axios@1.10.0)(got@11.8.6)
+        specifier: ^3.1.2
+        version: 3.1.2(axios@1.10.0)(got@11.8.6)
       '@aptos-labs/wallet-standard':
         specifier: ^0.5.0
-        version: 0.5.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
+        version: 0.5.0(@aptos-labs/ts-sdk@3.1.2(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
       '@solana/wallet-adapter-base':
         specifier: ^0.9.23
         version: 0.9.24(@solana/web3.js@1.98.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
@@ -661,16 +661,16 @@ importers:
     dependencies:
       '@aptos-connect/wallet-adapter-plugin':
         specifier: 2.5.0
-        version: 2.5.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
+        version: 2.5.0(@aptos-labs/ts-sdk@3.1.2(axios@1.10.0)(got@11.8.6))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
       '@aptos-labs/ts-sdk':
-        specifier: ^3.1.1
-        version: 3.1.1(axios@1.10.0)(got@11.8.6)
+        specifier: ^3.1.2
+        version: 3.1.2(axios@1.10.0)(got@11.8.6)
       '@aptos-labs/wallet-standard':
         specifier: ^0.5.0
-        version: 0.5.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
+        version: 0.5.0(@aptos-labs/ts-sdk@3.1.2(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
       '@msafe/aptos-aip62-wallet':
         specifier: ^1.0.18
-        version: 1.0.18(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-adapter-core@5.8.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6)))(@aptos-labs/wallet-standard@0.5.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0))(@mizuwallet-sdk/protocol@0.0.6)(@wallet-standard/core@1.1.0)
+        version: 1.0.18(@aptos-labs/ts-sdk@3.1.2(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-adapter-core@6.0.0(@aptos-labs/ts-sdk@3.1.2(axios@1.10.0)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6)))(@aptos-labs/wallet-standard@0.5.0(@aptos-labs/ts-sdk@3.1.2(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0))(@mizuwallet-sdk/protocol@0.0.6)(@wallet-standard/core@1.1.0)
       buffer:
         specifier: ^6.0.3
         version: 6.0.3
@@ -973,8 +973,8 @@ packages:
     resolution: {integrity: sha512-cflGyknECg11wTkQ1o1OK759v1m+mpz0S0/ZXsHbPMO0dO6eQGLjH/Uk5/YWMe1Nat8/szcgIipKk8Xr6Unvzg==}
     engines: {node: '>=20.0.0'}
 
-  '@aptos-labs/ts-sdk@3.1.1':
-    resolution: {integrity: sha512-K2icQiwaUs1V3T4f0fzL10P+nSsg/nt8Jb9mk9ognheHH/tn0v5TjkqlrzzICjh3MPKplXv1JvKAnbO9iORW4Q==}
+  '@aptos-labs/ts-sdk@3.1.2':
+    resolution: {integrity: sha512-wEe8+JhtjfuDHLsAUHfUcLmR3EvWHN9LzhE98vKAI5nDJmme6dC5JnBwwK+p+XIrbQqCc6qFEAEpzjMpJLpE6A==}
     engines: {node: '>=20.0.0'}
 
   '@aptos-labs/wallet-adapter-core@5.0.0':
@@ -982,10 +982,10 @@ packages:
     peerDependencies:
       '@aptos-labs/ts-sdk': ^1.35.0
 
-  '@aptos-labs/wallet-adapter-core@5.8.0':
-    resolution: {integrity: sha512-I/A72bYXlYgYasZGa1pMCHmBO+ZcfbBLdR4unI1XjncmFqssiRapf+iUbP1hy1t7LOPI54587Fi3U1+0CvcIVw==}
+  '@aptos-labs/wallet-adapter-core@6.0.0':
+    resolution: {integrity: sha512-EY0RQ2ZpSKIhX+lSkDC5kIdq8BlBCK9MfP8XdYMu6jBhaw/Jk66uuweJ4JUrHtbj78cg2oXpkL7UXkTAOa5I5A==}
     peerDependencies:
-      '@aptos-labs/ts-sdk': ^1.38.0 || ^2.0.0
+      '@aptos-labs/ts-sdk': ^3.1.1
 
   '@aptos-labs/wallet-standard@0.0.11':
     resolution: {integrity: sha512-8dygyPBby7TaMJjUSyeVP4R1WC9D/FPpX9gVMMLaqTKCXrSbkzhGDxcuwbMZ3ziEwRmx3zz+d6BIJbDhd0hm5g==}
@@ -10257,13 +10257,13 @@ snapshots:
       - aptos
       - debug
 
-  '@aptos-connect/wallet-adapter-plugin@2.5.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))':
+  '@aptos-connect/wallet-adapter-plugin@2.5.0(@aptos-labs/ts-sdk@3.1.2(axios@1.10.0)(got@11.8.6))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))':
     dependencies:
-      '@aptos-connect/wallet-api': 0.3.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
-      '@aptos-labs/ts-sdk': 3.1.1(axios@1.10.0)(got@11.8.6)
-      '@aptos-labs/wallet-standard': 0.5.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
-      '@identity-connect/crypto': 0.2.7(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
-      '@identity-connect/dapp-sdk': 0.11.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-standard@0.5.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
+      '@aptos-connect/wallet-api': 0.3.0(@aptos-labs/ts-sdk@3.1.2(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
+      '@aptos-labs/ts-sdk': 3.1.2(axios@1.10.0)(got@11.8.6)
+      '@aptos-labs/wallet-standard': 0.5.0(@aptos-labs/ts-sdk@3.1.2(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
+      '@identity-connect/crypto': 0.2.7(@aptos-labs/ts-sdk@3.1.2(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
+      '@identity-connect/dapp-sdk': 0.11.0(@aptos-labs/ts-sdk@3.1.2(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-standard@0.5.0(@aptos-labs/ts-sdk@3.1.2(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
     transitivePeerDependencies:
       - '@telegram-apps/bridge'
       - '@wallet-standard/core'
@@ -10279,10 +10279,10 @@ snapshots:
     transitivePeerDependencies:
       - '@wallet-standard/core'
 
-  '@aptos-connect/wallet-api@0.3.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))':
+  '@aptos-connect/wallet-api@0.3.0(@aptos-labs/ts-sdk@3.1.2(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))':
     dependencies:
-      '@aptos-labs/ts-sdk': 3.1.1(axios@1.10.0)(got@11.8.6)
-      '@aptos-labs/wallet-standard': 0.5.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
+      '@aptos-labs/ts-sdk': 3.1.2(axios@1.10.0)(got@11.8.6)
+      '@aptos-labs/wallet-standard': 0.5.0(@aptos-labs/ts-sdk@3.1.2(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
       '@identity-connect/api': 0.7.0
       aptos: 1.21.0(axios@1.10.0)(got@11.8.6)
     transitivePeerDependencies:
@@ -10299,11 +10299,11 @@ snapshots:
     transitivePeerDependencies:
       - '@wallet-standard/core'
 
-  '@aptos-connect/web-transport@0.3.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-standard@0.5.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))':
+  '@aptos-connect/web-transport@0.3.0(@aptos-labs/ts-sdk@3.1.2(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-standard@0.5.0(@aptos-labs/ts-sdk@3.1.2(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))':
     dependencies:
-      '@aptos-connect/wallet-api': 0.3.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
-      '@aptos-labs/ts-sdk': 3.1.1(axios@1.10.0)(got@11.8.6)
-      '@aptos-labs/wallet-standard': 0.5.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
+      '@aptos-connect/wallet-api': 0.3.0(@aptos-labs/ts-sdk@3.1.2(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
+      '@aptos-labs/ts-sdk': 3.1.2(axios@1.10.0)(got@11.8.6)
+      '@aptos-labs/wallet-standard': 0.5.0(@aptos-labs/ts-sdk@3.1.2(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
       '@telegram-apps/bridge': 1.9.2
       aptos: 1.21.0(axios@1.10.0)(got@11.8.6)
       uuid: 9.0.1
@@ -10325,10 +10325,10 @@ snapshots:
     dependencies:
       '@aptos-labs/aptos-dynamic-transaction-composer': 0.1.3
 
-  '@aptos-labs/siwa@0.3.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)':
+  '@aptos-labs/siwa@0.3.0(@aptos-labs/ts-sdk@3.1.2(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)':
     dependencies:
-      '@aptos-labs/ts-sdk': 3.1.1(axios@1.10.0)(got@11.8.6)
-      '@aptos-labs/wallet-standard': 0.5.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
+      '@aptos-labs/ts-sdk': 3.1.2(axios@1.10.0)(got@11.8.6)
+      '@aptos-labs/wallet-standard': 0.5.0(@aptos-labs/ts-sdk@3.1.2(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
       '@noble/hashes': 1.7.1
     transitivePeerDependencies:
       - '@wallet-standard/core'
@@ -10351,7 +10351,7 @@ snapshots:
       - axios
       - got
 
-  '@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6)':
+  '@aptos-labs/ts-sdk@3.1.2(axios@1.10.0)(got@11.8.6)':
     dependencies:
       '@aptos-labs/aptos-cli': 1.0.2
       '@aptos-labs/aptos-client': 1.2.0(axios@1.10.0)(got@11.8.6)
@@ -10388,12 +10388,12 @@ snapshots:
       - debug
       - got
 
-  '@aptos-labs/wallet-adapter-core@5.8.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))':
+  '@aptos-labs/wallet-adapter-core@6.0.0(@aptos-labs/ts-sdk@3.1.2(axios@1.10.0)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))':
     dependencies:
-      '@aptos-connect/wallet-adapter-plugin': 2.5.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
-      '@aptos-labs/ts-sdk': 3.1.1(axios@1.10.0)(got@11.8.6)
-      '@aptos-labs/wallet-standard': 0.5.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
-      '@msafe/aptos-aip62-wallet': 1.0.18(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-adapter-core@5.8.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6)))(@aptos-labs/wallet-standard@0.5.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0))(@mizuwallet-sdk/protocol@0.0.6)(@wallet-standard/core@1.1.0)
+      '@aptos-connect/wallet-adapter-plugin': 2.5.0(@aptos-labs/ts-sdk@3.1.2(axios@1.10.0)(got@11.8.6))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
+      '@aptos-labs/ts-sdk': 3.1.2(axios@1.10.0)(got@11.8.6)
+      '@aptos-labs/wallet-standard': 0.5.0(@aptos-labs/ts-sdk@3.1.2(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
+      '@msafe/aptos-aip62-wallet': 1.0.18(@aptos-labs/ts-sdk@3.1.2(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-adapter-core@6.0.0(@aptos-labs/ts-sdk@3.1.2(axios@1.10.0)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6)))(@aptos-labs/wallet-standard@0.5.0(@aptos-labs/ts-sdk@3.1.2(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0))(@mizuwallet-sdk/protocol@0.0.6)(@wallet-standard/core@1.1.0)
       buffer: 6.0.3
       eventemitter3: 4.0.7
       tweetnacl: 1.0.3
@@ -10427,9 +10427,9 @@ snapshots:
       '@aptos-labs/ts-sdk': 1.38.0(axios@1.10.0)(got@11.8.6)
       '@wallet-standard/core': 1.1.0
 
-  '@aptos-labs/wallet-standard@0.5.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)':
+  '@aptos-labs/wallet-standard@0.5.0(@aptos-labs/ts-sdk@3.1.2(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)':
     dependencies:
-      '@aptos-labs/ts-sdk': 3.1.1(axios@1.10.0)(got@11.8.6)
+      '@aptos-labs/ts-sdk': 3.1.2(axios@1.10.0)(got@11.8.6)
       '@wallet-standard/core': 1.1.0
 
   '@atomrigslab/aptos-wallet-adapter@0.1.21(@aptos-labs/ts-sdk@1.38.0(axios@1.10.0)(got@11.8.6))(axios@1.10.0)(got@11.8.6)':
@@ -11470,10 +11470,10 @@ snapshots:
       - '@wallet-standard/core'
       - aptos
 
-  '@identity-connect/crypto@0.2.7(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))':
+  '@identity-connect/crypto@0.2.7(@aptos-labs/ts-sdk@3.1.2(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))':
     dependencies:
-      '@aptos-connect/wallet-api': 0.3.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
-      '@aptos-labs/ts-sdk': 3.1.1(axios@1.10.0)(got@11.8.6)
+      '@aptos-connect/wallet-api': 0.3.0(@aptos-labs/ts-sdk@3.1.2(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
+      '@aptos-labs/ts-sdk': 3.1.2(axios@1.10.0)(got@11.8.6)
       '@noble/hashes': 1.7.1
       ed2curve: 0.3.0
       tweetnacl: 1.0.3
@@ -11498,15 +11498,15 @@ snapshots:
       - aptos
       - debug
 
-  '@identity-connect/dapp-sdk@0.11.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-standard@0.5.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))':
+  '@identity-connect/dapp-sdk@0.11.0(@aptos-labs/ts-sdk@3.1.2(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-standard@0.5.0(@aptos-labs/ts-sdk@3.1.2(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))':
     dependencies:
-      '@aptos-connect/wallet-api': 0.3.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
-      '@aptos-connect/web-transport': 0.3.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-standard@0.5.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
-      '@aptos-labs/ts-sdk': 3.1.1(axios@1.10.0)(got@11.8.6)
-      '@aptos-labs/wallet-standard': 0.5.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
+      '@aptos-connect/wallet-api': 0.3.0(@aptos-labs/ts-sdk@3.1.2(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
+      '@aptos-connect/web-transport': 0.3.0(@aptos-labs/ts-sdk@3.1.2(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-standard@0.5.0(@aptos-labs/ts-sdk@3.1.2(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
+      '@aptos-labs/ts-sdk': 3.1.2(axios@1.10.0)(got@11.8.6)
+      '@aptos-labs/wallet-standard': 0.5.0(@aptos-labs/ts-sdk@3.1.2(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
       '@identity-connect/api': 0.7.0
-      '@identity-connect/crypto': 0.2.7(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
-      '@identity-connect/wallet-api': 0.1.2(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
+      '@identity-connect/crypto': 0.2.7(@aptos-labs/ts-sdk@3.1.2(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
+      '@identity-connect/wallet-api': 0.1.2(@aptos-labs/ts-sdk@3.1.2(axios@1.10.0)(got@11.8.6))(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
       axios: 1.10.0
       uuid: 9.0.1
     transitivePeerDependencies:
@@ -11520,9 +11520,9 @@ snapshots:
       '@aptos-labs/ts-sdk': 1.38.0(axios@1.10.0)(got@11.8.6)
       aptos: 1.21.0(axios@1.10.0)(got@11.8.6)
 
-  '@identity-connect/wallet-api@0.1.2(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(aptos@1.21.0(axios@1.10.0)(got@11.8.6))':
+  '@identity-connect/wallet-api@0.1.2(@aptos-labs/ts-sdk@3.1.2(axios@1.10.0)(got@11.8.6))(aptos@1.21.0(axios@1.10.0)(got@11.8.6))':
     dependencies:
-      '@aptos-labs/ts-sdk': 3.1.1(axios@1.10.0)(got@11.8.6)
+      '@aptos-labs/ts-sdk': 3.1.2(axios@1.10.0)(got@11.8.6)
       aptos: 1.21.0(axios@1.10.0)(got@11.8.6)
 
   '@injectivelabs/abacus-proto-ts@1.14.0':
@@ -12006,9 +12006,9 @@ snapshots:
       graphql-request: 7.1.2(graphql@16.10.0)
       jwt-decode: 4.0.0
 
-  '@mizuwallet-sdk/core@1.4.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(graphql-request@7.1.2(graphql@16.10.0))':
+  '@mizuwallet-sdk/core@1.4.0(@aptos-labs/ts-sdk@3.1.2(axios@1.10.0)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(graphql-request@7.1.2(graphql@16.10.0))':
     dependencies:
-      '@aptos-labs/ts-sdk': 3.1.1(axios@1.10.0)(got@11.8.6)
+      '@aptos-labs/ts-sdk': 3.1.2(axios@1.10.0)(got@11.8.6)
       '@mizuwallet-sdk/protocol': 0.0.6
       buffer: 6.0.3
       graphql-request: 7.1.2(graphql@16.10.0)
@@ -12020,12 +12020,12 @@ snapshots:
       tweetnacl: 1.0.3
       tweetnacl-util: 0.15.1
 
-  '@msafe/aptos-aip62-wallet@1.0.18(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-adapter-core@5.8.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6)))(@aptos-labs/wallet-standard@0.5.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0))(@mizuwallet-sdk/protocol@0.0.6)(@wallet-standard/core@1.1.0)':
+  '@msafe/aptos-aip62-wallet@1.0.18(@aptos-labs/ts-sdk@3.1.2(axios@1.10.0)(got@11.8.6))(@aptos-labs/wallet-adapter-core@6.0.0(@aptos-labs/ts-sdk@3.1.2(axios@1.10.0)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6)))(@aptos-labs/wallet-standard@0.5.0(@aptos-labs/ts-sdk@3.1.2(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0))(@mizuwallet-sdk/protocol@0.0.6)(@wallet-standard/core@1.1.0)':
     dependencies:
-      '@aptos-labs/ts-sdk': 3.1.1(axios@1.10.0)(got@11.8.6)
-      '@aptos-labs/wallet-adapter-core': 5.8.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
-      '@aptos-labs/wallet-standard': 0.5.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
-      '@mizuwallet-sdk/core': 1.4.0(@aptos-labs/ts-sdk@3.1.1(axios@1.10.0)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(graphql-request@7.1.2(graphql@16.10.0))
+      '@aptos-labs/ts-sdk': 3.1.2(axios@1.10.0)(got@11.8.6)
+      '@aptos-labs/wallet-adapter-core': 6.0.0(@aptos-labs/ts-sdk@3.1.2(axios@1.10.0)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(axios@1.10.0)(got@11.8.6))
+      '@aptos-labs/wallet-standard': 0.5.0(@aptos-labs/ts-sdk@3.1.2(axios@1.10.0)(got@11.8.6))(@wallet-standard/core@1.1.0)
+      '@mizuwallet-sdk/core': 1.4.0(@aptos-labs/ts-sdk@3.1.2(axios@1.10.0)(got@11.8.6))(@mizuwallet-sdk/protocol@0.0.6)(graphql-request@7.1.2(graphql@16.10.0))
       '@telegram-apps/bridge': 1.9.2
       '@wallet-standard/core': 1.1.0
       graphql: 16.10.0


### PR DESCRIPTION
- Remove `toString()` from the account address when contracting a transaction