### PR TITLE
Skip prompt window if using AC one-click signing

### DIFF
--- a/packages/wallet-adapter-core/src/WalletCore.ts
+++ b/packages/wallet-adapter-core/src/WalletCore.ts
@@ -89,6 +89,7 @@ import {
   removeLocalStorage,
   setLocalStorage,
 } from "./utils";
+import { isAptosConnectWallet } from "./utils/walletSelector";
 import {
   aptosStandardSupportedWalletList,
   crossChainStandardSupportedWalletList,
@@ -734,9 +735,13 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
         transactionInput.transactionSubmitter
       );
 
+      // if Aptos Connect wallet, use one-click signing
+      const isAptosConnect = isAptosConnectWallet(this._wallet);
+
       if (
         this._wallet.features["aptos:signAndSubmitTransaction"] &&
-        !shouldUseTxnSubmitter
+        !shouldUseTxnSubmitter &&
+        !isAptosConnect
       ) {
         // check for backward compatibility. before version 1.1.0 the standard expected
         // AnyRawTransaction input so the adapter built the transaction before sending it to the wallet


### PR DESCRIPTION
- there was an issue with Aptos Connect prompt pages failing to open
  - [Github issue](https://github.com/aptos-labs/aptos-wallet-adapter/issues/650)
  - [Linear task](https://linear.app/aptoslabs/issue/PET-156/wallet-connection-fails-in-moar-market-with-aptos-connect)
- if an AC wallet is connected, don't double prompt and use one-click signing

## Test plan
- [ ] not sure the best way to test this..
