### PR TITLE
Update Aptos ts-sdk package version

### DIFF
--- a/.changeset/old-donkeys-call.md
+++ b/.changeset/old-donkeys-call.md
@@ -1,0 +1,9 @@
+---
+"@aptos-labs/derived-wallet-ethereum": patch
+"@aptos-labs/derived-wallet-solana": patch
+"@aptos-labs/derived-wallet-base": patch
+"@aptos-labs/wallet-adapter-core": patch
+"@aptos-labs/cross-chain-core": patch
+---
+
+Upgrade aptos ts-sdk package

--- a/apps/nextjs-example/package.json
+++ b/apps/nextjs-example/package.json
@@ -11,7 +11,7 @@
     "format": "prettier --write './**/*.{ts,tsx,js,jsx,json,md,html,css}'"
   },
   "dependencies": {
-    "@aptos-labs/ts-sdk": "^5.0.0",
+    "@aptos-labs/ts-sdk": "^5.1.1",
     "@aptos-labs/wallet-adapter-ant-design": "workspace:*",
     "@aptos-labs/wallet-adapter-core": "workspace:*",
     "@aptos-labs/wallet-adapter-mui-design": "workspace:*",

--- a/apps/nextjs-example/src/components/WalletProvider.tsx
+++ b/apps/nextjs-example/src/components/WalletProvider.tsx
@@ -50,10 +50,6 @@ export const WalletProvider = ({ children }: PropsWithChildren) => {
       dappId: "57fa42a9-29c6-4f1e-939c-4eefa36d9ff5",
       dappImageURI,
     },
-    mizuwallet: {
-      manifestURL:
-        "https://assets.mz.xyz/static/config/mizuwallet-connect-manifest.json",
-    },
     transactionSubmitter: useCustomSubmitter
       ? myTransactionSubmitter
       : undefined,

--- a/apps/nextjs-x-chain/package.json
+++ b/apps/nextjs-x-chain/package.json
@@ -15,7 +15,7 @@
     "@aptos-labs/derived-wallet-ethereum": "workspace:^",
     "@aptos-labs/derived-wallet-solana": "workspace:^",
     "@aptos-labs/gas-station-client": "^2.0.3",
-    "@aptos-labs/ts-sdk": "^5.0.0",
+    "@aptos-labs/ts-sdk": "^5.1.1",
     "@aptos-labs/wallet-adapter-core": "workspace:*",
     "@aptos-labs/wallet-adapter-react": "workspace:*",
     "@aptos-labs/wallet-standard": "^0.5.2",

--- a/apps/nextjs-x-chain/src/components/WalletProvider.tsx
+++ b/apps/nextjs-x-chain/src/components/WalletProvider.tsx
@@ -38,10 +38,6 @@ export const WalletProvider = ({ children }: PropsWithChildren) => {
           dappId: "57fa42a9-29c6-4f1e-939c-4eefa36d9ff5",
           dappImageURI,
         },
-        mizuwallet: {
-          manifestURL:
-            "https://assets.mz.xyz/static/config/mizuwallet-connect-manifest.json",
-        },
         crossChainWallets: true,
       }}
       onError={(error) => {

--- a/packages/cross-chain-core/package.json
+++ b/packages/cross-chain-core/package.json
@@ -73,7 +73,7 @@
     "tweetnacl": "^1.0.3"
   },
   "peerDependencies": {
-    "@aptos-labs/ts-sdk": "^5.0.0"
+    "@aptos-labs/ts-sdk": "^5.1.1"
   },
   "files": [
     "dist",

--- a/packages/derived-wallet-base/package.json
+++ b/packages/derived-wallet-base/package.json
@@ -32,7 +32,7 @@
     "@aptos-labs/wallet-standard": "^0.5.2"
   },
   "peerDependencies": {
-    "@aptos-labs/ts-sdk": "^5.0.0"
+    "@aptos-labs/ts-sdk": "^5.1.1"
   },
   "devDependencies": {
     "@aptos-labs/eslint-config-adapter": "workspace:*",

--- a/packages/derived-wallet-ethereum/package.json
+++ b/packages/derived-wallet-ethereum/package.json
@@ -38,7 +38,7 @@
     "viem": "^2.23.12"
   },
   "peerDependencies": {
-    "@aptos-labs/ts-sdk": "^5.0.0"
+    "@aptos-labs/ts-sdk": "^5.1.1"
   },
   "devDependencies": {
     "@aptos-labs/eslint-config-adapter": "workspace:*",

--- a/packages/derived-wallet-solana/package.json
+++ b/packages/derived-wallet-solana/package.json
@@ -39,7 +39,7 @@
     "@wallet-standard/app": "^1.1.0"
   },
   "peerDependencies": {
-    "@aptos-labs/ts-sdk": "^5.0.0"
+    "@aptos-labs/ts-sdk": "^5.1.1"
   },
   "devDependencies": {
     "@aptos-labs/eslint-config-adapter": "workspace:*",

--- a/packages/wallet-adapter-core/package.json
+++ b/packages/wallet-adapter-core/package.json
@@ -58,7 +58,7 @@
     "tweetnacl": "^1.0.3"
   },
   "peerDependencies": {
-    "@aptos-labs/ts-sdk": "^5.0.0"
+    "@aptos-labs/ts-sdk": "^5.1.1"
   },
   "files": [
     "dist",

--- a/packages/wallet-adapter-core/src/WalletCore.ts
+++ b/packages/wallet-adapter-core/src/WalletCore.ts
@@ -2,14 +2,9 @@ import EventEmitter from "eventemitter3";
 import {
   AccountAddress,
   AccountAuthenticator,
-  AnyPublicKey,
-  AnyPublicKeyVariant,
   AnyRawTransaction,
   Aptos,
-  Ed25519PublicKey,
   InputSubmitTransactionData,
-  MultiEd25519PublicKey,
-  MultiEd25519Signature,
   Network,
   NetworkToChainId,
   PendingTransactionResponse,
@@ -115,7 +110,7 @@ export type AdapterNotDetectedWallet = Omit<
 };
 
 export interface DappConfig {
-  network: Network | 'shelbynet';
+  network: Network;
   /**
    * If provided, the wallet adapter will submit transactions using the provided
    * transaction submitter rather than via the wallet.
@@ -131,6 +126,9 @@ export interface DappConfig {
     manifestURL: string;
     appId?: string;
   };
+  /**
+   * @deprecated will be removed in a future version
+   */
   msafeWalletConfig?: {
     appId?: string;
     appUrl?: string;
@@ -192,7 +190,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
   constructor(
     optInWallets?: ReadonlyArray<AvailableWallets>,
     dappConfig?: DappConfig,
-    disableTelemetry?: boolean,
+    disableTelemetry?: boolean
   ) {
     super();
     this._optInWallets = optInWallets || [];
@@ -239,7 +237,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
    * @param extensionwWallets
    */
   private setExtensionAIP62Wallets(
-    extensionwWallets: readonly AptosWallet[],
+    extensionwWallets: readonly AptosWallet[]
   ): void {
     extensionwWallets.map((wallet: AdapterWallet) => {
       if (this.excludeWallet(wallet)) {
@@ -256,7 +254,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
       if (isValid) {
         // check if we already have this wallet as a not detected wallet
         const index = this._standard_not_detected_wallets.findIndex(
-          (notDetctedWallet) => notDetctedWallet.name == wallet.name,
+          (notDetctedWallet) => notDetctedWallet.name == wallet.name
         );
         // if we do, remove it from the not detected wallets array as it is now become detected
         if (index !== -1) {
@@ -265,7 +263,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
 
         // ✅ Check if wallet already exists in _standard_wallets
         const alreadyExists = this._standard_wallets.some(
-          (w) => w.name === wallet.name,
+          (w) => w.name === wallet.name
         );
         if (!alreadyExists) {
           wallet.readyState = WalletReadyState.Installed;
@@ -315,7 +313,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
     walletRegistry.map((supportedWallet: AptosStandardSupportedWallet) => {
       // Check if we already have this wallet as a detected AIP-62 wallet standard
       const existingStandardWallet = this._standard_wallets.find(
-        (wallet) => wallet.name == supportedWallet.name,
+        (wallet) => wallet.name == supportedWallet.name
       );
       // If it is detected, it means the user has the wallet installed, so dont add it to the wallets array
       if (existingStandardWallet) {
@@ -373,7 +371,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
    * @param wallet A wallet
    */
   private ensureWalletExists(
-    wallet: AdapterWallet | null,
+    wallet: AdapterWallet | null
   ): asserts wallet is AdapterWallet {
     if (!wallet) {
       throw new WalletNotConnectedError().name;
@@ -388,7 +386,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
    * @param account An account
    */
   private ensureAccountExists(
-    account: AccountInfo | null,
+    account: AccountInfo | null
   ): asserts account is AccountInfo {
     if (!account) {
       throw new WalletAccountError("Account is not set").name;
@@ -539,7 +537,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
     // Check if we are in a redirectable view (i.e on mobile AND not in an in-app browser)
     if (isRedirectable()) {
       const selectedWallet = this._standard_not_detected_wallets.find(
-        (wallet: AdapterNotDetectedWallet) => wallet.name === walletName,
+        (wallet: AdapterNotDetectedWallet) => wallet.name === walletName
       );
 
       if (selectedWallet) {
@@ -567,7 +565,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
     const allDetectedWallets = this._standard_wallets;
 
     const selectedWallet = allDetectedWallets.find(
-      (wallet: AdapterWallet) => wallet.name === walletName,
+      (wallet: AdapterWallet) => wallet.name === walletName
     );
 
     if (!selectedWallet) return;
@@ -577,7 +575,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
       // if the selected wallet is already connected, we don't need to connect again
       if (this._wallet?.name === walletName)
         throw new WalletConnectionError(
-          `${walletName} wallet is already connected`,
+          `${walletName} wallet is already connected`
         ).message;
     }
 
@@ -610,7 +608,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
 
     const allDetectedWallets = this._standard_wallets;
     const selectedWallet = allDetectedWallets.find(
-      (wallet: AdapterWallet) => wallet.name === walletName,
+      (wallet: AdapterWallet) => wallet.name === walletName
     );
 
     if (!selectedWallet) {
@@ -619,14 +617,14 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
 
     if (!selectedWallet.features["aptos:signIn"]) {
       throw new WalletNotSupportedMethod(
-        `aptos:signIn is not supported by ${walletName}`,
+        `aptos:signIn is not supported by ${walletName}`
       ).message;
     }
 
     return await this.connectWallet(selectedWallet, async () => {
       if (!selectedWallet.features["aptos:signIn"]) {
         throw new WalletNotSupportedMethod(
-          `aptos:signIn is not supported by ${selectedWallet.name}`,
+          `aptos:signIn is not supported by ${selectedWallet.name}`
         ).message;
       }
 
@@ -652,7 +650,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
    */
   private async connectWallet<T>(
     selectedWallet: AdapterWallet,
-    onConnect: () => Promise<{ account: AccountInfo; output: T }>,
+    onConnect: () => Promise<{ account: AccountInfo; output: T }>
   ): Promise<T> {
     try {
       this._connecting = true;
@@ -703,7 +701,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
    * @returns AptosSignAndSubmitTransactionOutput
    */
   async signAndSubmitTransaction(
-    transactionInput: InputTransactionData,
+    transactionInput: InputTransactionData
   ): Promise<AptosSignAndSubmitTransactionOutput> {
     try {
       if ("function" in transactionInput.data) {
@@ -754,7 +752,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
           });
 
           type AptosSignAndSubmitTransactionV1Method = (
-            transaction: AnyRawTransaction,
+            transaction: AnyRawTransaction
           ) => Promise<UserResponse<AptosSignAndSubmitTransactionOutput>>;
 
           const signAndSubmitTransactionMethod = this._wallet.features[
@@ -763,7 +761,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
             .signAndSubmitTransaction as unknown as AptosSignAndSubmitTransactionV1Method;
 
           const response = (await signAndSubmitTransactionMethod(
-            transaction,
+            transaction
           )) as UserResponse<AptosSignAndSubmitTransactionOutput>;
 
           if (response.status === UserResponseStatus.REJECTED) {
@@ -859,7 +857,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
           "aptos:signTransaction"
         ].signTransaction(
           transactionOrPayload,
-          asFeePayer,
+          asFeePayer
         )) as UserResponse<AccountAuthenticator>;
         if (response.status === UserResponseStatus.REJECTED) {
           throw new WalletConnectionError("User has rejected the request")
@@ -895,7 +893,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
           AptosSignTransactionMethodV1_1;
 
         const response = (await walletSignTransactionMethod(
-          signTransactionV1_1StandardInput,
+          signTransactionV1_1StandardInput
         )) as UserResponse<AptosSignTransactionOutputV1_1>;
         if (response.status === UserResponseStatus.REJECTED) {
           throw new WalletConnectionError("User has rejected the request")
@@ -921,7 +919,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
           "aptos:signTransaction"
         ].signTransaction(
           transaction,
-          asFeePayer,
+          asFeePayer
         )) as UserResponse<AccountAuthenticator>;
         if (response.status === UserResponseStatus.REJECTED) {
           throw new WalletConnectionError("User has rejected the request")
@@ -948,7 +946,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
    * @throws WalletSignMessageError
    */
   async signMessage(
-    message: AptosSignMessageInput,
+    message: AptosSignMessageInput
   ): Promise<AptosSignMessageOutput> {
     try {
       this.ensureWalletExists(this._wallet);
@@ -974,7 +972,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
    * @returns PendingTransactionResponse
    */
   async submitTransaction(
-    transaction: InputSubmitTransactionData,
+    transaction: InputSubmitTransactionData
   ): Promise<PendingTransactionResponse> {
     // The standard does not support submitTransaction, so we use the adapter to submit the transaction
     try {
@@ -1020,7 +1018,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
           await this.setAnsName();
           this.recordEvent("account_change");
           this.emit("accountChange", this._account);
-        },
+        }
       );
     } catch (error: any) {
       const errMsg = generalizedErrorMessage(error);
@@ -1041,7 +1039,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
           this.setNetwork(data);
           await this.setAnsName();
           this.emit("networkChange", this._network);
-        },
+        }
       );
     } catch (error: any) {
       const errMsg = generalizedErrorMessage(error);
@@ -1075,7 +1073,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
       if (this._wallet.features["aptos:changeNetwork"]) {
         const response =
           await this._wallet.features["aptos:changeNetwork"].changeNetwork(
-            networkInfo,
+            networkInfo
           );
         if (response.status === UserResponseStatus.REJECTED) {
           throw new WalletConnectionError("User has rejected the request")
@@ -1085,7 +1083,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
       }
 
       throw new WalletChangeNetworkError(
-        `${this._wallet.name} does not support changing network request`,
+        `${this._wallet.name} does not support changing network request`
       ).message;
     } catch (error: any) {
       const errMsg = generalizedErrorMessage(error);
@@ -1115,7 +1113,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
 
       const aptosConfig = getAptosConfig(this._network, this._dappConfig);
       const signingMessage = new TextEncoder().encode(
-        response.args.fullMessage,
+        response.args.fullMessage
       );
       if ("verifySignatureAsync" in (this._account.publicKey as Object)) {
         return await this._account.publicKey.verifySignatureAsync({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/derived-wallet-solana
       '@aptos-labs/ts-sdk':
-        specifier: ^5.0.0
-        version: 5.0.0(got@11.8.6)
+        specifier: ^5.1.1
+        version: 5.1.1(got@11.8.6)
       '@aptos-labs/wallet-adapter-ant-design':
         specifier: workspace:*
         version: link:../../packages/wallet-adapter-ant-design
@@ -61,7 +61,7 @@ importers:
         version: link:../../packages/wallet-adapter-react
       '@aptos-labs/wallet-standard':
         specifier: ^0.5.2
-        version: 0.5.2(@aptos-labs/ts-sdk@5.0.0(got@11.8.6))(@wallet-standard/core@1.1.0)
+        version: 0.5.2(@aptos-labs/ts-sdk@5.1.1(got@11.8.6))(@wallet-standard/core@1.1.0)
       '@radix-ui/react-collapsible':
         specifier: ^1.0.3
         version: 1.1.3(@types/react-dom@18.3.5(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -169,8 +169,8 @@ importers:
         specifier: ^2.0.3
         version: 2.0.3(got@11.8.6)
       '@aptos-labs/ts-sdk':
-        specifier: ^5.0.0
-        version: 5.0.0(got@11.8.6)
+        specifier: ^5.1.1
+        version: 5.1.1(got@11.8.6)
       '@aptos-labs/wallet-adapter-core':
         specifier: workspace:*
         version: link:../../packages/wallet-adapter-core
@@ -179,7 +179,7 @@ importers:
         version: link:../../packages/wallet-adapter-react
       '@aptos-labs/wallet-standard':
         specifier: ^0.5.2
-        version: 0.5.2(@aptos-labs/ts-sdk@5.0.0(got@11.8.6))(@wallet-standard/core@1.1.0)
+        version: 0.5.2(@aptos-labs/ts-sdk@5.1.1(got@11.8.6))(@wallet-standard/core@1.1.0)
       '@radix-ui/react-collapsible':
         specifier: ^1.0.3
         version: 1.1.3(@types/react-dom@18.3.5(@types/react@18.3.20))(@types/react@18.3.20)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -363,14 +363,14 @@ importers:
         specifier: workspace:*
         version: link:../derived-wallet-solana
       '@aptos-labs/ts-sdk':
-        specifier: ^5.0.0
-        version: 5.0.0(got@11.8.6)
+        specifier: ^5.1.1
+        version: 5.1.1(got@11.8.6)
       '@aptos-labs/wallet-adapter-core':
         specifier: workspace:*
         version: link:../wallet-adapter-core
       '@aptos-labs/wallet-standard':
         specifier: ^0.5.2
-        version: 0.5.2(@aptos-labs/ts-sdk@5.0.0(got@11.8.6))(@wallet-standard/core@1.1.0)
+        version: 0.5.2(@aptos-labs/ts-sdk@5.1.1(got@11.8.6))(@wallet-standard/core@1.1.0)
       '@mysten/sui':
         specifier: ^1.21.2
         version: 1.25.0(typescript@5.8.3)
@@ -454,11 +454,11 @@ importers:
   packages/derived-wallet-base:
     dependencies:
       '@aptos-labs/ts-sdk':
-        specifier: ^5.0.0
-        version: 5.0.0(got@11.8.6)
+        specifier: ^5.1.1
+        version: 5.1.1(got@11.8.6)
       '@aptos-labs/wallet-standard':
         specifier: ^0.5.2
-        version: 0.5.2(@aptos-labs/ts-sdk@5.0.0(got@11.8.6))(@wallet-standard/core@1.1.0)
+        version: 0.5.2(@aptos-labs/ts-sdk@5.1.1(got@11.8.6))(@wallet-standard/core@1.1.0)
     devDependencies:
       '@aptos-labs/eslint-config-adapter':
         specifier: workspace:*
@@ -495,13 +495,13 @@ importers:
         version: link:../derived-wallet-base
       '@aptos-labs/siwa':
         specifier: ^0.4.0
-        version: 0.4.0(@aptos-labs/ts-sdk@5.0.0(got@11.8.6))(@wallet-standard/core@1.1.0)
+        version: 0.4.0(@aptos-labs/ts-sdk@5.1.1(got@11.8.6))(@wallet-standard/core@1.1.0)
       '@aptos-labs/ts-sdk':
-        specifier: ^5.0.0
-        version: 5.0.0(got@11.8.6)
+        specifier: ^5.1.1
+        version: 5.1.1(got@11.8.6)
       '@aptos-labs/wallet-standard':
         specifier: ^0.5.2
-        version: 0.5.2(@aptos-labs/ts-sdk@5.0.0(got@11.8.6))(@wallet-standard/core@1.1.0)
+        version: 0.5.2(@aptos-labs/ts-sdk@5.1.1(got@11.8.6))(@wallet-standard/core@1.1.0)
       '@wallet-standard/app':
         specifier: ^1.1.0
         version: 1.1.0
@@ -550,13 +550,13 @@ importers:
         version: link:../derived-wallet-base
       '@aptos-labs/siwa':
         specifier: ^0.4.0
-        version: 0.4.0(@aptos-labs/ts-sdk@5.0.0(got@11.8.6))(@wallet-standard/core@1.1.0)
+        version: 0.4.0(@aptos-labs/ts-sdk@5.1.1(got@11.8.6))(@wallet-standard/core@1.1.0)
       '@aptos-labs/ts-sdk':
-        specifier: ^5.0.0
-        version: 5.0.0(got@11.8.6)
+        specifier: ^5.1.1
+        version: 5.1.1(got@11.8.6)
       '@aptos-labs/wallet-standard':
         specifier: ^0.5.2
-        version: 0.5.2(@aptos-labs/ts-sdk@5.0.0(got@11.8.6))(@wallet-standard/core@1.1.0)
+        version: 0.5.2(@aptos-labs/ts-sdk@5.1.1(got@11.8.6))(@wallet-standard/core@1.1.0)
       '@solana/wallet-adapter-base':
         specifier: ^0.9.23
         version: 0.9.24(@solana/web3.js@1.98.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
@@ -666,13 +666,13 @@ importers:
     dependencies:
       '@aptos-connect/wallet-adapter-plugin':
         specifier: ^2.6.2
-        version: 2.6.2(@aptos-labs/ts-sdk@5.0.0(got@11.8.6))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(got@11.8.6))
+        version: 2.6.2(@aptos-labs/ts-sdk@5.1.1(got@11.8.6))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(got@11.8.6))
       '@aptos-labs/ts-sdk':
-        specifier: ^5.0.0
-        version: 5.0.0(got@11.8.6)
+        specifier: ^5.1.1
+        version: 5.1.1(got@11.8.6)
       '@aptos-labs/wallet-standard':
         specifier: ^0.5.2
-        version: 0.5.2(@aptos-labs/ts-sdk@5.0.0(got@11.8.6))(@wallet-standard/core@1.1.0)
+        version: 0.5.2(@aptos-labs/ts-sdk@5.1.1(got@11.8.6))(@wallet-standard/core@1.1.0)
       buffer:
         specifier: ^6.0.3
         version: 6.0.3
@@ -979,6 +979,10 @@ packages:
 
   '@aptos-labs/ts-sdk@5.0.0':
     resolution: {integrity: sha512-s0vfH9Yduaosv+1eKsHjf5W0Fc02BlEpPL68488D7e4XsGQuzpVMxQPjjajYtSyyd9Bmmjat+wxM3mH5QBZkYg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aptos-labs/ts-sdk@5.1.1':
+    resolution: {integrity: sha512-2QhQzcbVa9o7uQTIfjAGFkWFgddg+R/Ftbo39ZPbNrs1L2b+oMhdB9/uZ0QStN25/h8HPCvH4h4aaPus2jabXQ==}
     engines: {node: '>=20.0.0'}
 
   '@aptos-labs/wallet-adapter-core@5.0.0':
@@ -2389,6 +2393,10 @@ packages:
     resolution: {integrity: sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==}
     engines: {node: ^14.21.3 || >=16}
 
+  '@noble/curves@1.9.7':
+    resolution: {integrity: sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==}
+    engines: {node: ^14.21.3 || >=16}
+
   '@noble/hashes@1.3.2':
     resolution: {integrity: sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==}
     engines: {node: '>= 16'}
@@ -2399,6 +2407,10 @@ packages:
 
   '@noble/hashes@1.7.1':
     resolution: {integrity: sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
 
   '@nodelib/fs.scandir@2.1.5':
@@ -10577,13 +10589,13 @@ snapshots:
       - aptos
       - debug
 
-  '@aptos-connect/wallet-adapter-plugin@2.6.2(@aptos-labs/ts-sdk@5.0.0(got@11.8.6))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(got@11.8.6))':
+  '@aptos-connect/wallet-adapter-plugin@2.6.2(@aptos-labs/ts-sdk@5.1.1(got@11.8.6))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(got@11.8.6))':
     dependencies:
-      '@aptos-connect/wallet-api': 0.5.0(@aptos-labs/ts-sdk@5.0.0(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(got@11.8.6))
-      '@aptos-labs/ts-sdk': 5.0.0(got@11.8.6)
-      '@aptos-labs/wallet-standard': 0.5.2(@aptos-labs/ts-sdk@5.0.0(got@11.8.6))(@wallet-standard/core@1.1.0)
-      '@identity-connect/crypto': 0.2.11(@aptos-labs/ts-sdk@5.0.0(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(got@11.8.6))
-      '@identity-connect/dapp-sdk': 0.13.0(@aptos-labs/ts-sdk@5.0.0(got@11.8.6))(@aptos-labs/wallet-standard@0.5.2(@aptos-labs/ts-sdk@5.0.0(got@11.8.6))(@wallet-standard/core@1.1.0))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(got@11.8.6))
+      '@aptos-connect/wallet-api': 0.5.0(@aptos-labs/ts-sdk@5.1.1(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(got@11.8.6))
+      '@aptos-labs/ts-sdk': 5.1.1(got@11.8.6)
+      '@aptos-labs/wallet-standard': 0.5.2(@aptos-labs/ts-sdk@5.1.1(got@11.8.6))(@wallet-standard/core@1.1.0)
+      '@identity-connect/crypto': 0.2.11(@aptos-labs/ts-sdk@5.1.1(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(got@11.8.6))
+      '@identity-connect/dapp-sdk': 0.13.0(@aptos-labs/ts-sdk@5.1.1(got@11.8.6))(@aptos-labs/wallet-standard@0.5.2(@aptos-labs/ts-sdk@5.1.1(got@11.8.6))(@wallet-standard/core@1.1.0))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(got@11.8.6))
     transitivePeerDependencies:
       - '@telegram-apps/bridge'
       - '@wallet-standard/core'
@@ -10599,10 +10611,10 @@ snapshots:
     transitivePeerDependencies:
       - '@wallet-standard/core'
 
-  '@aptos-connect/wallet-api@0.5.0(@aptos-labs/ts-sdk@5.0.0(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(got@11.8.6))':
+  '@aptos-connect/wallet-api@0.5.0(@aptos-labs/ts-sdk@5.1.1(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(got@11.8.6))':
     dependencies:
-      '@aptos-labs/ts-sdk': 5.0.0(got@11.8.6)
-      '@aptos-labs/wallet-standard': 0.5.2(@aptos-labs/ts-sdk@5.0.0(got@11.8.6))(@wallet-standard/core@1.1.0)
+      '@aptos-labs/ts-sdk': 5.1.1(got@11.8.6)
+      '@aptos-labs/wallet-standard': 0.5.2(@aptos-labs/ts-sdk@5.1.1(got@11.8.6))(@wallet-standard/core@1.1.0)
       '@identity-connect/api': 0.7.0
       aptos: 1.21.0(got@11.8.6)
     transitivePeerDependencies:
@@ -10619,11 +10631,11 @@ snapshots:
     transitivePeerDependencies:
       - '@wallet-standard/core'
 
-  '@aptos-connect/web-transport@0.4.1(@aptos-labs/ts-sdk@5.0.0(got@11.8.6))(@aptos-labs/wallet-standard@0.5.2(@aptos-labs/ts-sdk@5.0.0(got@11.8.6))(@wallet-standard/core@1.1.0))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(got@11.8.6))':
+  '@aptos-connect/web-transport@0.4.1(@aptos-labs/ts-sdk@5.1.1(got@11.8.6))(@aptos-labs/wallet-standard@0.5.2(@aptos-labs/ts-sdk@5.1.1(got@11.8.6))(@wallet-standard/core@1.1.0))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(got@11.8.6))':
     dependencies:
-      '@aptos-connect/wallet-api': 0.5.0(@aptos-labs/ts-sdk@5.0.0(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(got@11.8.6))
-      '@aptos-labs/ts-sdk': 5.0.0(got@11.8.6)
-      '@aptos-labs/wallet-standard': 0.5.2(@aptos-labs/ts-sdk@5.0.0(got@11.8.6))(@wallet-standard/core@1.1.0)
+      '@aptos-connect/wallet-api': 0.5.0(@aptos-labs/ts-sdk@5.1.1(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(got@11.8.6))
+      '@aptos-labs/ts-sdk': 5.1.1(got@11.8.6)
+      '@aptos-labs/wallet-standard': 0.5.2(@aptos-labs/ts-sdk@5.1.1(got@11.8.6))(@wallet-standard/core@1.1.0)
       '@telegram-apps/bridge': 1.9.2
       aptos: 1.21.0(got@11.8.6)
       uuid: 9.0.1
@@ -10642,7 +10654,7 @@ snapshots:
 
   '@aptos-labs/gas-station-client@2.0.3(got@11.8.6)':
     dependencies:
-      '@aptos-labs/ts-sdk': 5.0.0(got@11.8.6)
+      '@aptos-labs/ts-sdk': 5.1.1(got@11.8.6)
     transitivePeerDependencies:
       - got
 
@@ -10650,10 +10662,10 @@ snapshots:
     dependencies:
       '@aptos-labs/aptos-dynamic-transaction-composer': 0.1.3
 
-  '@aptos-labs/siwa@0.4.0(@aptos-labs/ts-sdk@5.0.0(got@11.8.6))(@wallet-standard/core@1.1.0)':
+  '@aptos-labs/siwa@0.4.0(@aptos-labs/ts-sdk@5.1.1(got@11.8.6))(@wallet-standard/core@1.1.0)':
     dependencies:
-      '@aptos-labs/ts-sdk': 5.0.0(got@11.8.6)
-      '@aptos-labs/wallet-standard': 0.5.2(@aptos-labs/ts-sdk@5.0.0(got@11.8.6))(@wallet-standard/core@1.1.0)
+      '@aptos-labs/ts-sdk': 5.1.1(got@11.8.6)
+      '@aptos-labs/wallet-standard': 0.5.2(@aptos-labs/ts-sdk@5.1.1(got@11.8.6))(@wallet-standard/core@1.1.0)
       '@noble/hashes': 1.7.1
     transitivePeerDependencies:
       - '@wallet-standard/core'
@@ -10680,6 +10692,22 @@ snapshots:
       '@aptos-labs/aptos-cli': 1.0.2
       '@aptos-labs/aptos-client': 2.0.0(got@11.8.6)
       '@noble/curves': 1.8.1
+      '@noble/hashes': 1.7.1
+      '@scure/bip32': 1.6.2
+      '@scure/bip39': 1.5.4
+      eventemitter3: 5.0.1
+      form-data: 4.0.4
+      js-base64: 3.7.7
+      jwt-decode: 4.0.0
+      poseidon-lite: 0.2.1
+    transitivePeerDependencies:
+      - got
+
+  '@aptos-labs/ts-sdk@5.1.1(got@11.8.6)':
+    dependencies:
+      '@aptos-labs/aptos-cli': 1.0.2
+      '@aptos-labs/aptos-client': 2.0.0(got@11.8.6)
+      '@noble/curves': 1.9.7
       '@noble/hashes': 1.7.1
       '@scure/bip32': 1.6.2
       '@scure/bip39': 1.5.4
@@ -10735,6 +10763,11 @@ snapshots:
   '@aptos-labs/wallet-standard@0.5.2(@aptos-labs/ts-sdk@5.0.0(got@11.8.6))(@wallet-standard/core@1.1.0)':
     dependencies:
       '@aptos-labs/ts-sdk': 5.0.0(got@11.8.6)
+      '@wallet-standard/core': 1.1.0
+
+  '@aptos-labs/wallet-standard@0.5.2(@aptos-labs/ts-sdk@5.1.1(got@11.8.6))(@wallet-standard/core@1.1.0)':
+    dependencies:
+      '@aptos-labs/ts-sdk': 5.1.1(got@11.8.6)
       '@wallet-standard/core': 1.1.0
 
   '@atomrigslab/aptos-wallet-adapter@0.1.21(@aptos-labs/ts-sdk@1.38.0(got@11.8.6))(got@11.8.6)':
@@ -11953,10 +11986,10 @@ snapshots:
 
   '@identity-connect/api@0.7.0': {}
 
-  '@identity-connect/crypto@0.2.11(@aptos-labs/ts-sdk@5.0.0(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(got@11.8.6))':
+  '@identity-connect/crypto@0.2.11(@aptos-labs/ts-sdk@5.1.1(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(got@11.8.6))':
     dependencies:
-      '@aptos-connect/wallet-api': 0.5.0(@aptos-labs/ts-sdk@5.0.0(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(got@11.8.6))
-      '@aptos-labs/ts-sdk': 5.0.0(got@11.8.6)
+      '@aptos-connect/wallet-api': 0.5.0(@aptos-labs/ts-sdk@5.1.1(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(got@11.8.6))
+      '@aptos-labs/ts-sdk': 5.1.1(got@11.8.6)
       '@noble/hashes': 1.7.1
       ed2curve: 0.3.0
       tweetnacl: 1.0.3
@@ -11992,15 +12025,15 @@ snapshots:
       - aptos
       - debug
 
-  '@identity-connect/dapp-sdk@0.13.0(@aptos-labs/ts-sdk@5.0.0(got@11.8.6))(@aptos-labs/wallet-standard@0.5.2(@aptos-labs/ts-sdk@5.0.0(got@11.8.6))(@wallet-standard/core@1.1.0))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(got@11.8.6))':
+  '@identity-connect/dapp-sdk@0.13.0(@aptos-labs/ts-sdk@5.1.1(got@11.8.6))(@aptos-labs/wallet-standard@0.5.2(@aptos-labs/ts-sdk@5.1.1(got@11.8.6))(@wallet-standard/core@1.1.0))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(got@11.8.6))':
     dependencies:
-      '@aptos-connect/wallet-api': 0.5.0(@aptos-labs/ts-sdk@5.0.0(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(got@11.8.6))
-      '@aptos-connect/web-transport': 0.4.1(@aptos-labs/ts-sdk@5.0.0(got@11.8.6))(@aptos-labs/wallet-standard@0.5.2(@aptos-labs/ts-sdk@5.0.0(got@11.8.6))(@wallet-standard/core@1.1.0))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(got@11.8.6))
-      '@aptos-labs/ts-sdk': 5.0.0(got@11.8.6)
-      '@aptos-labs/wallet-standard': 0.5.2(@aptos-labs/ts-sdk@5.0.0(got@11.8.6))(@wallet-standard/core@1.1.0)
+      '@aptos-connect/wallet-api': 0.5.0(@aptos-labs/ts-sdk@5.1.1(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(got@11.8.6))
+      '@aptos-connect/web-transport': 0.4.1(@aptos-labs/ts-sdk@5.1.1(got@11.8.6))(@aptos-labs/wallet-standard@0.5.2(@aptos-labs/ts-sdk@5.1.1(got@11.8.6))(@wallet-standard/core@1.1.0))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)(aptos@1.21.0(got@11.8.6))
+      '@aptos-labs/ts-sdk': 5.1.1(got@11.8.6)
+      '@aptos-labs/wallet-standard': 0.5.2(@aptos-labs/ts-sdk@5.1.1(got@11.8.6))(@wallet-standard/core@1.1.0)
       '@identity-connect/api': 0.7.0
-      '@identity-connect/crypto': 0.2.11(@aptos-labs/ts-sdk@5.0.0(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(got@11.8.6))
-      '@identity-connect/wallet-api': 0.1.4(@aptos-labs/ts-sdk@5.0.0(got@11.8.6))(aptos@1.21.0(got@11.8.6))
+      '@identity-connect/crypto': 0.2.11(@aptos-labs/ts-sdk@5.1.1(got@11.8.6))(@wallet-standard/core@1.1.0)(aptos@1.21.0(got@11.8.6))
+      '@identity-connect/wallet-api': 0.1.4(@aptos-labs/ts-sdk@5.1.1(got@11.8.6))(aptos@1.21.0(got@11.8.6))
       axios: 1.12.2
       uuid: 9.0.1
     transitivePeerDependencies:
@@ -12014,9 +12047,9 @@ snapshots:
       '@aptos-labs/ts-sdk': 1.38.0(got@11.8.6)
       aptos: 1.21.0(got@11.8.6)
 
-  '@identity-connect/wallet-api@0.1.4(@aptos-labs/ts-sdk@5.0.0(got@11.8.6))(aptos@1.21.0(got@11.8.6))':
+  '@identity-connect/wallet-api@0.1.4(@aptos-labs/ts-sdk@5.1.1(got@11.8.6))(aptos@1.21.0(got@11.8.6))':
     dependencies:
-      '@aptos-labs/ts-sdk': 5.0.0(got@11.8.6)
+      '@aptos-labs/ts-sdk': 5.1.1(got@11.8.6)
       aptos: 1.21.0(got@11.8.6)
 
   '@injectivelabs/abacus-proto-ts@1.14.0':
@@ -12743,11 +12776,17 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.7.1
 
+  '@noble/curves@1.9.7':
+    dependencies:
+      '@noble/hashes': 1.8.0
+
   '@noble/hashes@1.3.2': {}
 
   '@noble/hashes@1.3.3': {}
 
   '@noble/hashes@1.7.1': {}
+
+  '@noble/hashes@1.8.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:


### PR DESCRIPTION
- Update Aptos ts-sdk package version, to support shelbynet api key
```
<AptosWalletAdapterProvider
      dappConfig={{
        network: Network.SHELBYNET,
        aptosApiKeys: {
           shelbynet: process.env.SHELBY_API_KE,
        }
      }}
      ....
    >
      {children}
    </AptosWalletAdapterProvider>
```
- Remove usage of msafe from demo apps
- Clean up unused imports
- Mark `msafeWalletConfig` as (soon to be) deprecated