### PR TITLE
Add cross chain wallet support to MUI wallet selector

### DIFF
--- a/.changeset/thin-gifts-double.md
+++ b/.changeset/thin-gifts-double.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/wallet-adapter-mui-design": minor
+---
+
+Add cross chain wallet support to MUI wallet selector

--- a/apps/nextjs-x-chain/package.json
+++ b/apps/nextjs-x-chain/package.json
@@ -17,6 +17,7 @@
     "@aptos-labs/gas-station-client": "^2.0.3",
     "@aptos-labs/ts-sdk": "^5.1.1",
     "@aptos-labs/wallet-adapter-core": "workspace:*",
+    "@aptos-labs/wallet-adapter-mui-design": "workspace:*",
     "@aptos-labs/wallet-adapter-react": "workspace:*",
     "@aptos-labs/wallet-standard": "^0.5.2",
     "@radix-ui/react-collapsible": "^1.0.3",

--- a/apps/nextjs-x-chain/src/app/components/WalletSelection.tsx
+++ b/apps/nextjs-x-chain/src/app/components/WalletSelection.tsx
@@ -3,6 +3,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { WalletSelector as ShadcnWalletSelector } from "@/components/WalletSelector";
+import { WalletConnector as MuiWalletSelector } from "@aptos-labs/wallet-adapter-mui-design";
 
 export function WalletSelection() {
   const { autoConnect, setAutoConnect } = useAutoConnect();
@@ -13,6 +14,11 @@ export function WalletSelection() {
         <div className="flex flex-wrap gap-6 pt-6 pb-12 justify-between items-center">
           <div className="flex flex-col gap-4 items-center">
             <ShadcnWalletSelector />
+          </div>
+          <div className="flex flex-col gap-4 items-center">
+            <MuiWalletSelector
+              crossChainWallets={{ solana: true, evm: true }}
+            />
           </div>
         </div>
         <label className="flex items-center gap-4 cursor-pointer">

--- a/packages/wallet-adapter-mui-design/src/WalletConnector.tsx
+++ b/packages/wallet-adapter-mui-design/src/WalletConnector.tsx
@@ -1,20 +1,13 @@
-import { WalletSortingOptions } from "@aptos-labs/wallet-adapter-react";
-import { Breakpoint } from "@mui/material";
 import { useState } from "react";
 import WalletButton from "./WalletButton";
 import WalletsModal from "./WalletModel";
-
-export interface WalletConnectorProps extends WalletSortingOptions {
-  networkSupport?: string;
-  handleNavigate?: () => void;
-  /** The max width of the wallet selector modal. Defaults to `xs`. */
-  modalMaxWidth?: Breakpoint;
-}
+import { WalletConnectorProps } from "./types";
 
 export function WalletConnector({
   networkSupport,
   handleNavigate,
   modalMaxWidth,
+  crossChainWallets,
   ...walletSortingOptions
 }: WalletConnectorProps) {
   const [modalOpen, setModalOpen] = useState(false);
@@ -32,6 +25,7 @@ export function WalletConnector({
         modalOpen={modalOpen}
         networkSupport={networkSupport}
         modalMaxWidth={modalMaxWidth}
+        crossChainWallets={crossChainWallets}
         {...walletSortingOptions}
       />
     </>

--- a/packages/wallet-adapter-mui-design/src/types.ts
+++ b/packages/wallet-adapter-mui-design/src/types.ts
@@ -1,0 +1,13 @@
+import { WalletSortingOptions } from "@aptos-labs/wallet-adapter-react";
+import { Breakpoint } from "@mui/material";
+
+export interface WalletConnectorProps extends WalletSortingOptions {
+  networkSupport?: string;
+  handleNavigate?: () => void;
+  /** The max width of the wallet selector modal. Defaults to `xs`. */
+  modalMaxWidth?: Breakpoint;
+  crossChainWallets?: {
+    evm: boolean;
+    solana: boolean;
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,6 +174,9 @@ importers:
       '@aptos-labs/wallet-adapter-core':
         specifier: workspace:*
         version: link:../../packages/wallet-adapter-core
+      '@aptos-labs/wallet-adapter-mui-design':
+        specifier: workspace:*
+        version: link:../../packages/wallet-adapter-mui-design
       '@aptos-labs/wallet-adapter-react':
         specifier: workspace:*
         version: link:../../packages/wallet-adapter-react


### PR DESCRIPTION
Add an optional `crossChainWallets` prop to the MUI wallet selector component to enable cross chain wallets support

Usage

```
<MuiWalletSelector
     ......
     crossChainWallets={{ solana: true, evm: true }}
>
```