### PR TITLE
Add shelbynet to known Aptos networks + Support domain when creating transaction statement, export functions

### DIFF
--- a/.changeset/cuddly-kings-enter.md
+++ b/.changeset/cuddly-kings-enter.md
@@ -1,0 +1,6 @@
+---
+"@aptos-labs/derived-wallet-base": minor
+"@aptos-labs/derived-wallet-solana": patch
+---
+
+Support domain when creating transaction statement, export functions

--- a/.changeset/twenty-drinks-clap.md
+++ b/.changeset/twenty-drinks-clap.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/wallet-adapter-core": minor
+---
+
+Add shelbynet to known Aptos networks

--- a/packages/derived-wallet-base/src/envelope.ts
+++ b/packages/derived-wallet-base/src/envelope.ts
@@ -56,7 +56,7 @@ export function createStructuredMessageStatement({
  */
 export function createTransactionStatement(
   rawTransaction: AnyRawTransaction,
-  domain?: string
+  domain?: string,
 ) {
   const entryFunctionName = getEntryFunctionName(
     rawTransaction.rawTransaction.payload,

--- a/packages/derived-wallet-solana/src/createSiwsEnvelope.ts
+++ b/packages/derived-wallet-solana/src/createSiwsEnvelope.ts
@@ -16,7 +16,7 @@ export interface CreateSiwsEnvelopeInput {
 export function createSiwsEnvelope(
   input: CreateSiwsEnvelopeInput & {
     statement: string;
-  }
+  },
 ): SolanaSignInInputWithRequiredFields {
   const { solanaPublicKey, signingMessageDigest, statement, domain } = input;
   const digestHex = Hex.fromHexInput(signingMessageDigest).toString();
@@ -34,7 +34,7 @@ export function createSiwsEnvelope(
  * considered as valid signature on the Aptos blockchain for the provided message.
  */
 export function createSiwsEnvelopeForAptosStructuredMessage(
-  input: CreateSiwsEnvelopeInput & { structuredMessage: StructuredMessage }
+  input: CreateSiwsEnvelopeInput & { structuredMessage: StructuredMessage },
 ): SolanaSignInInputWithRequiredFields {
   const { structuredMessage, ...rest } = input;
   const statement = createStructuredMessageStatement(structuredMessage);
@@ -47,9 +47,11 @@ export function createSiwsEnvelopeForAptosStructuredMessage(
  * considered as valid signature on the Aptos blockchain for the provided transaction.
  */
 export function createSiwsEnvelopeForAptosTransaction(
-  input: CreateSiwsEnvelopeInput & { rawTransaction: AnyRawTransaction }
+  input: CreateSiwsEnvelopeInput & {
+    rawTransaction: AnyRawTransaction;
+  },
 ): SolanaSignInInputWithRequiredFields {
-  const { rawTransaction, ...rest } = input;
-  const statement = createTransactionStatement(rawTransaction);
-  return createSiwsEnvelope({ ...rest, statement });
+  const { rawTransaction, domain, ...rest } = input;
+  const statement = createTransactionStatement(rawTransaction, domain);
+  return createSiwsEnvelope({ ...rest, statement, domain });
 }

--- a/packages/wallet-adapter-core/src/utils/helpers.ts
+++ b/packages/wallet-adapter-core/src/utils/helpers.ts
@@ -183,6 +183,8 @@ export function convertNetwork(networkInfo: NetworkInfo | null): Network {
       return Network.DEVNET;
     case "local" as Network:
       return Network.LOCAL;
+    case "shelbynet" as Network:
+      return Network.SHELBYNET;
     default:
       throw new Error("Invalid Aptos network name");
   }


### PR DESCRIPTION
- Add shelbynet to known Aptos networks
- Support domain when creating transaction statement
- Update return type of `createAccountAuthenticatorForSolanaTransaction` to `AccountAuthenticatorAbstraction`
- Export function from the `derived-wallet-solana` package