### PR TITLE
[core][react] Add support for Petra web fallback

### DIFF
--- a/.changeset/bitter-cows-look.md
+++ b/.changeset/bitter-cows-look.md
@@ -2,5 +2,6 @@
 "@aptos-labs/wallet-adapter-core": minor
 ---
 
-Add `hideWallets` and `fallbacks` to `groupAndSortWallets`. `hideWallets` will now allow users optionally hide certain wallets from the results.
-`fallbacks` will allow users to specify fallback wallets for wallets that are not installed. This is used to support alternative connection methods for installed wallets, wallets with fallbacks will be moved to a new `availableWalletsWithFallbacks` list.
+Added `hideWallets` to `WalletCore` which will allow users optionally hide certain wallets from the default lists of wallets but will be available through the `hiddenWallets` property.
+
+Also added `fallbacks` to `groupAndSortWallets` which will allow users to specify fallback wallets for wallets that are not installed. This is used to support alternative connection methods for installed wallets, wallets with fallbacks will be moved to a new `availableWalletsWithFallbacks` list.

--- a/.changeset/bitter-cows-look.md
+++ b/.changeset/bitter-cows-look.md
@@ -1,0 +1,6 @@
+---
+"@aptos-labs/wallet-adapter-core": minor
+---
+
+Add `hideWallets` and `fallbacks` to `groupAndSortWallets`. `hideWallets` will now allow users optionally hide certain wallets from the results.
+`fallbacks` will allow users to specify fallback wallets for wallets that are not installed. This is used to support alternative connection methods for installed wallets, wallets with fallbacks will be moved to a new `availableWalletsWithFallbacks` list.

--- a/.changeset/fancy-tables-fetch.md
+++ b/.changeset/fancy-tables-fetch.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/wallet-adapter-react": patch
+---
+
+Add support for fallback wallets in `WalletItem`

--- a/apps/nextjs-example/src/components/WalletSelector.tsx
+++ b/apps/nextjs-example/src/components/WalletSelector.tsx
@@ -6,7 +6,7 @@ import {
   AdapterNotDetectedWallet,
   AdapterWallet,
   AptosPrivacyPolicy,
-  DEFAULT_WALLET_FALLBACKS,
+  DEFAULT_WALLET_CONNECTION_FALLBACKS,
   groupAndSortWallets,
   shouldUseFallbackWallet,
   isInstallRequired,
@@ -119,7 +119,11 @@ function ConnectWalletDialog({
   close,
   ...walletSortingOptions
 }: ConnectWalletDialogProps) {
-  const { wallets = [], notDetectedWallets = [] } = useWallet();
+  const {
+    wallets = [],
+    notDetectedWallets = [],
+    hiddenWallets = [],
+  } = useWallet();
 
   const {
     petraWebWallets,
@@ -127,7 +131,10 @@ function ConnectWalletDialog({
     availableWalletsWithFallbacks,
     installableWallets,
   } = groupAndSortWallets([...wallets, ...notDetectedWallets], {
-    fallbacks: DEFAULT_WALLET_FALLBACKS,
+    fallbacks: {
+      connections: DEFAULT_WALLET_CONNECTION_FALLBACKS,
+      additionalFallbackWallets: hiddenWallets,
+    },
     ...walletSortingOptions,
   });
 
@@ -184,7 +191,7 @@ function ConnectWalletDialog({
           {[...availableWallets, ...availableWalletsWithFallbacks].map(
             (wallet) => (
               <WalletRow key={wallet.name} wallet={wallet} onConnect={close} />
-            ),
+            )
           )}
           {!!installableWallets.length && (
             <Collapsible className="flex flex-col gap-3">

--- a/apps/nextjs-example/src/components/WalletSelector.tsx
+++ b/apps/nextjs-example/src/components/WalletSelector.tsx
@@ -191,7 +191,7 @@ function ConnectWalletDialog({
           {[...availableWallets, ...availableWalletsWithFallbacks].map(
             (wallet) => (
               <WalletRow key={wallet.name} wallet={wallet} onConnect={close} />
-            )
+            ),
           )}
           {!!installableWallets.length && (
             <Collapsible className="flex flex-col gap-3">

--- a/apps/nextjs-example/src/components/WalletSelector.tsx
+++ b/apps/nextjs-example/src/components/WalletSelector.tsx
@@ -191,7 +191,7 @@ function ConnectWalletDialog({
           {[...availableWallets, ...availableWalletsWithFallbacks].map(
             (wallet) => (
               <WalletRow key={wallet.name} wallet={wallet} onConnect={close} />
-            ),
+            )
           )}
           {!!installableWallets.length && (
             <Collapsible className="flex flex-col gap-3">
@@ -226,7 +226,6 @@ function WalletRow({ wallet, onConnect }: WalletRowProps) {
   return (
     <WalletItem
       wallet={wallet}
-      fallbackWallet={wallet.fallbackWallet}
       onConnect={onConnect}
       className="flex items-center justify-between px-4 py-3 gap-4 border rounded-md"
     >

--- a/packages/wallet-adapter-core/package.json
+++ b/packages/wallet-adapter-core/package.json
@@ -51,7 +51,7 @@
     "typescript": "^5.8.3"
   },
   "dependencies": {
-    "@aptos-connect/wallet-adapter-plugin": "^3.0.1",
+    "@aptos-connect/wallet-adapter-plugin": "^3.0.2",
     "@aptos-labs/wallet-standard": "^0.5.2",
     "buffer": "^6.0.3",
     "eventemitter3": "^4.0.7",

--- a/packages/wallet-adapter-core/src/WalletCore.ts
+++ b/packages/wallet-adapter-core/src/WalletCore.ts
@@ -209,7 +209,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
     optInWallets?: ReadonlyArray<AvailableWallets>,
     dappConfig?: DappConfig,
     disableTelemetry?: boolean,
-    hideWallets: ReadonlyArray<AvailableWallets> = ["Petra Web"]
+    hideWallets: ReadonlyArray<AvailableWallets> = ["Petra Web"],
   ) {
     super();
     this._optInWallets = optInWallets || [];
@@ -257,7 +257,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
    * @param extensionwWallets
    */
   private setExtensionAIP62Wallets(
-    extensionwWallets: readonly AptosWallet[]
+    extensionwWallets: readonly AptosWallet[],
   ): void {
     extensionwWallets.map((wallet: AdapterWallet) => {
       if (this.excludeWallet(wallet)) {
@@ -274,7 +274,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
       if (isValid) {
         // check if we already have this wallet as a not detected wallet
         const index = this._standard_not_detected_wallets.findIndex(
-          (notDetctedWallet) => notDetctedWallet.name == wallet.name
+          (notDetctedWallet) => notDetctedWallet.name == wallet.name,
         );
         // if we do, remove it from the not detected wallets array as it is now become detected
         if (index !== -1) {
@@ -344,10 +344,10 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
       // Check if we already have this wallet as a detected AIP-62 wallet standard
       const existingStandardWallet =
         this._standard_wallets.find(
-          (wallet) => wallet.name == supportedWallet.name
+          (wallet) => wallet.name == supportedWallet.name,
         ) ||
         this._standard_wallets_hidden.find(
-          (wallet) => wallet.name == supportedWallet.name
+          (wallet) => wallet.name == supportedWallet.name,
         );
       // If it is detected, it means the user has the wallet installed, so dont add it to the wallets array
       if (existingStandardWallet) {
@@ -418,7 +418,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
    * @param wallet A wallet
    */
   private ensureWalletExists(
-    wallet: AdapterWallet | null
+    wallet: AdapterWallet | null,
   ): asserts wallet is AdapterWallet {
     if (!wallet) {
       throw new WalletNotConnectedError().name;
@@ -433,7 +433,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
    * @param account An account
    */
   private ensureAccountExists(
-    account: AccountInfo | null
+    account: AccountInfo | null,
   ): asserts account is AccountInfo {
     if (!account) {
       throw new WalletAccountError("Account is not set").name;
@@ -591,7 +591,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
     // Check if we are in a redirectable view (i.e on mobile AND not in an in-app browser)
     if (isRedirectable()) {
       const selectedWallet = this._standard_not_detected_wallets.find(
-        (wallet: AdapterNotDetectedWallet) => wallet.name === walletName
+        (wallet: AdapterNotDetectedWallet) => wallet.name === walletName,
       );
 
       if (selectedWallet) {
@@ -626,7 +626,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
     ];
 
     const selectedWallet = allDetectedWallets.find(
-      (wallet: AdapterWallet) => wallet.name === walletName
+      (wallet: AdapterWallet) => wallet.name === walletName,
     );
 
     if (!selectedWallet) return;
@@ -636,7 +636,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
       // if the selected wallet is already connected, we don't need to connect again
       if (this._wallet?.name === walletName)
         throw new WalletConnectionError(
-          `${walletName} wallet is already connected`
+          `${walletName} wallet is already connected`,
         ).message;
     }
 
@@ -669,7 +669,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
 
     const allDetectedWallets = this._standard_wallets;
     const selectedWallet = allDetectedWallets.find(
-      (wallet: AdapterWallet) => wallet.name === walletName
+      (wallet: AdapterWallet) => wallet.name === walletName,
     );
 
     if (!selectedWallet) {
@@ -678,14 +678,14 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
 
     if (!selectedWallet.features["aptos:signIn"]) {
       throw new WalletNotSupportedMethod(
-        `aptos:signIn is not supported by ${walletName}`
+        `aptos:signIn is not supported by ${walletName}`,
       ).message;
     }
 
     return await this.connectWallet(selectedWallet, async () => {
       if (!selectedWallet.features["aptos:signIn"]) {
         throw new WalletNotSupportedMethod(
-          `aptos:signIn is not supported by ${selectedWallet.name}`
+          `aptos:signIn is not supported by ${selectedWallet.name}`,
         ).message;
       }
 
@@ -711,7 +711,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
    */
   private async connectWallet<T>(
     selectedWallet: AdapterWallet,
-    onConnect: () => Promise<{ account: AccountInfo; output: T }>
+    onConnect: () => Promise<{ account: AccountInfo; output: T }>,
   ): Promise<T> {
     try {
       this._connecting = true;
@@ -762,7 +762,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
    * @returns AptosSignAndSubmitTransactionOutput
    */
   async signAndSubmitTransaction(
-    transactionInput: InputTransactionData
+    transactionInput: InputTransactionData,
   ): Promise<AptosSignAndSubmitTransactionOutput> {
     try {
       if ("function" in transactionInput.data) {
@@ -813,7 +813,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
           });
 
           type AptosSignAndSubmitTransactionV1Method = (
-            transaction: AnyRawTransaction
+            transaction: AnyRawTransaction,
           ) => Promise<UserResponse<AptosSignAndSubmitTransactionOutput>>;
 
           const signAndSubmitTransactionMethod = this._wallet.features[
@@ -822,7 +822,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
             .signAndSubmitTransaction as unknown as AptosSignAndSubmitTransactionV1Method;
 
           const response = (await signAndSubmitTransactionMethod(
-            transaction
+            transaction,
           )) as UserResponse<AptosSignAndSubmitTransactionOutput>;
 
           if (response.status === UserResponseStatus.REJECTED) {
@@ -918,7 +918,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
           "aptos:signTransaction"
         ].signTransaction(
           transactionOrPayload,
-          asFeePayer
+          asFeePayer,
         )) as UserResponse<AccountAuthenticator>;
         if (response.status === UserResponseStatus.REJECTED) {
           throw new WalletConnectionError("User has rejected the request")
@@ -954,7 +954,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
           AptosSignTransactionMethodV1_1;
 
         const response = (await walletSignTransactionMethod(
-          signTransactionV1_1StandardInput
+          signTransactionV1_1StandardInput,
         )) as UserResponse<AptosSignTransactionOutputV1_1>;
         if (response.status === UserResponseStatus.REJECTED) {
           throw new WalletConnectionError("User has rejected the request")
@@ -980,7 +980,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
           "aptos:signTransaction"
         ].signTransaction(
           transaction,
-          asFeePayer
+          asFeePayer,
         )) as UserResponse<AccountAuthenticator>;
         if (response.status === UserResponseStatus.REJECTED) {
           throw new WalletConnectionError("User has rejected the request")
@@ -1007,7 +1007,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
    * @throws WalletSignMessageError
    */
   async signMessage(
-    message: AptosSignMessageInput
+    message: AptosSignMessageInput,
   ): Promise<AptosSignMessageOutput> {
     try {
       this.ensureWalletExists(this._wallet);
@@ -1033,7 +1033,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
    * @returns PendingTransactionResponse
    */
   async submitTransaction(
-    transaction: InputSubmitTransactionData
+    transaction: InputSubmitTransactionData,
   ): Promise<PendingTransactionResponse> {
     // The standard does not support submitTransaction, so we use the adapter to submit the transaction
     try {
@@ -1079,7 +1079,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
           await this.setAnsName();
           this.recordEvent("account_change");
           this.emit("accountChange", this._account);
-        }
+        },
       );
     } catch (error: any) {
       const errMsg = generalizedErrorMessage(error);
@@ -1100,7 +1100,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
           this.setNetwork(data);
           await this.setAnsName();
           this.emit("networkChange", this._network);
-        }
+        },
       );
     } catch (error: any) {
       const errMsg = generalizedErrorMessage(error);
@@ -1134,7 +1134,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
       if (this._wallet.features["aptos:changeNetwork"]) {
         const response =
           await this._wallet.features["aptos:changeNetwork"].changeNetwork(
-            networkInfo
+            networkInfo,
           );
         if (response.status === UserResponseStatus.REJECTED) {
           throw new WalletConnectionError("User has rejected the request")
@@ -1144,7 +1144,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
       }
 
       throw new WalletChangeNetworkError(
-        `${this._wallet.name} does not support changing network request`
+        `${this._wallet.name} does not support changing network request`,
       ).message;
     } catch (error: any) {
       const errMsg = generalizedErrorMessage(error);
@@ -1174,7 +1174,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
 
       const aptosConfig = getAptosConfig(this._network, this._dappConfig);
       const signingMessage = new TextEncoder().encode(
-        response.args.fullMessage
+        response.args.fullMessage,
       );
       if ("verifySignatureAsync" in (this._account.publicKey as Object)) {
         return await this._account.publicKey.verifySignatureAsync({

--- a/packages/wallet-adapter-core/src/WalletCore.ts
+++ b/packages/wallet-adapter-core/src/WalletCore.ts
@@ -100,6 +100,8 @@ import {
 export type AdapterWallet = AptosWallet & {
   readyState?: WalletReadyState;
   isAptosNativeWallet?: boolean;
+  /** A fallback wallet to use when this wallet is not installed */
+  fallbackWallet?: AdapterWallet;
 };
 
 // An adapter not detected wallet types is a wallet that is compatible with the wallet standard but not detected

--- a/packages/wallet-adapter-core/src/WalletCore.ts
+++ b/packages/wallet-adapter-core/src/WalletCore.ts
@@ -344,10 +344,10 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
       // Check if we already have this wallet as a detected AIP-62 wallet standard
       const existingStandardWallet =
         this._standard_wallets.find(
-          (wallet) => wallet.name == supportedWallet.name,
+          (wallet) => wallet.name === supportedWallet.name,
         ) ||
         this._standard_wallets_hidden.find(
-          (wallet) => wallet.name == supportedWallet.name,
+          (wallet) => wallet.name === supportedWallet.name,
         );
       // If it is detected, it means the user has the wallet installed, so dont add it to the wallets array
       if (existingStandardWallet) {

--- a/packages/wallet-adapter-core/src/WalletCore.ts
+++ b/packages/wallet-adapter-core/src/WalletCore.ts
@@ -209,11 +209,11 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
     optInWallets?: ReadonlyArray<AvailableWallets>,
     dappConfig?: DappConfig,
     disableTelemetry?: boolean,
-    hideWallets: ReadonlyArray<AvailableWallets> = ['Petra Web'],
+    hideWallets: ReadonlyArray<AvailableWallets> = ["Petra Web"]
   ) {
     super();
     this._optInWallets = optInWallets || [];
-    this._hideWallets = hideWallets ;
+    this._hideWallets = hideWallets;
     this._dappConfig = dappConfig;
     this._disableTelemetry = disableTelemetry ?? false;
     this._sdkWallets = getSDKWallets(this._dappConfig);
@@ -257,7 +257,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
    * @param extensionwWallets
    */
   private setExtensionAIP62Wallets(
-    extensionwWallets: readonly AptosWallet[],
+    extensionwWallets: readonly AptosWallet[]
   ): void {
     extensionwWallets.map((wallet: AdapterWallet) => {
       if (this.excludeWallet(wallet)) {
@@ -274,7 +274,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
       if (isValid) {
         // check if we already have this wallet as a not detected wallet
         const index = this._standard_not_detected_wallets.findIndex(
-          (notDetctedWallet) => notDetctedWallet.name == wallet.name,
+          (notDetctedWallet) => notDetctedWallet.name == wallet.name
         );
         // if we do, remove it from the not detected wallets array as it is now become detected
         if (index !== -1) {
@@ -344,10 +344,10 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
       // Check if we already have this wallet as a detected AIP-62 wallet standard
       const existingStandardWallet =
         this._standard_wallets.find(
-          (wallet) => wallet.name == supportedWallet.name,
+          (wallet) => wallet.name == supportedWallet.name
         ) ||
         this._standard_wallets_hidden.find(
-          (wallet) => wallet.name == supportedWallet.name,
+          (wallet) => wallet.name == supportedWallet.name
         );
       // If it is detected, it means the user has the wallet installed, so dont add it to the wallets array
       if (existingStandardWallet) {
@@ -418,7 +418,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
    * @param wallet A wallet
    */
   private ensureWalletExists(
-    wallet: AdapterWallet | null,
+    wallet: AdapterWallet | null
   ): asserts wallet is AdapterWallet {
     if (!wallet) {
       throw new WalletNotConnectedError().name;
@@ -433,7 +433,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
    * @param account An account
    */
   private ensureAccountExists(
-    account: AccountInfo | null,
+    account: AccountInfo | null
   ): asserts account is AccountInfo {
     if (!account) {
       throw new WalletAccountError("Account is not set").name;
@@ -591,7 +591,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
     // Check if we are in a redirectable view (i.e on mobile AND not in an in-app browser)
     if (isRedirectable()) {
       const selectedWallet = this._standard_not_detected_wallets.find(
-        (wallet: AdapterNotDetectedWallet) => wallet.name === walletName,
+        (wallet: AdapterNotDetectedWallet) => wallet.name === walletName
       );
 
       if (selectedWallet) {
@@ -620,10 +620,13 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
     }
 
     // Checks the wallet exists in the detected wallets array
-    const allDetectedWallets = this._standard_wallets;
+    const allDetectedWallets = [
+      ...this._standard_wallets,
+      ...this._standard_wallets_hidden,
+    ];
 
     const selectedWallet = allDetectedWallets.find(
-      (wallet: AdapterWallet) => wallet.name === walletName,
+      (wallet: AdapterWallet) => wallet.name === walletName
     );
 
     if (!selectedWallet) return;
@@ -633,7 +636,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
       // if the selected wallet is already connected, we don't need to connect again
       if (this._wallet?.name === walletName)
         throw new WalletConnectionError(
-          `${walletName} wallet is already connected`,
+          `${walletName} wallet is already connected`
         ).message;
     }
 
@@ -666,7 +669,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
 
     const allDetectedWallets = this._standard_wallets;
     const selectedWallet = allDetectedWallets.find(
-      (wallet: AdapterWallet) => wallet.name === walletName,
+      (wallet: AdapterWallet) => wallet.name === walletName
     );
 
     if (!selectedWallet) {
@@ -675,14 +678,14 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
 
     if (!selectedWallet.features["aptos:signIn"]) {
       throw new WalletNotSupportedMethod(
-        `aptos:signIn is not supported by ${walletName}`,
+        `aptos:signIn is not supported by ${walletName}`
       ).message;
     }
 
     return await this.connectWallet(selectedWallet, async () => {
       if (!selectedWallet.features["aptos:signIn"]) {
         throw new WalletNotSupportedMethod(
-          `aptos:signIn is not supported by ${selectedWallet.name}`,
+          `aptos:signIn is not supported by ${selectedWallet.name}`
         ).message;
       }
 
@@ -708,7 +711,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
    */
   private async connectWallet<T>(
     selectedWallet: AdapterWallet,
-    onConnect: () => Promise<{ account: AccountInfo; output: T }>,
+    onConnect: () => Promise<{ account: AccountInfo; output: T }>
   ): Promise<T> {
     try {
       this._connecting = true;
@@ -759,7 +762,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
    * @returns AptosSignAndSubmitTransactionOutput
    */
   async signAndSubmitTransaction(
-    transactionInput: InputTransactionData,
+    transactionInput: InputTransactionData
   ): Promise<AptosSignAndSubmitTransactionOutput> {
     try {
       if ("function" in transactionInput.data) {
@@ -810,7 +813,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
           });
 
           type AptosSignAndSubmitTransactionV1Method = (
-            transaction: AnyRawTransaction,
+            transaction: AnyRawTransaction
           ) => Promise<UserResponse<AptosSignAndSubmitTransactionOutput>>;
 
           const signAndSubmitTransactionMethod = this._wallet.features[
@@ -819,7 +822,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
             .signAndSubmitTransaction as unknown as AptosSignAndSubmitTransactionV1Method;
 
           const response = (await signAndSubmitTransactionMethod(
-            transaction,
+            transaction
           )) as UserResponse<AptosSignAndSubmitTransactionOutput>;
 
           if (response.status === UserResponseStatus.REJECTED) {
@@ -915,7 +918,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
           "aptos:signTransaction"
         ].signTransaction(
           transactionOrPayload,
-          asFeePayer,
+          asFeePayer
         )) as UserResponse<AccountAuthenticator>;
         if (response.status === UserResponseStatus.REJECTED) {
           throw new WalletConnectionError("User has rejected the request")
@@ -951,7 +954,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
           AptosSignTransactionMethodV1_1;
 
         const response = (await walletSignTransactionMethod(
-          signTransactionV1_1StandardInput,
+          signTransactionV1_1StandardInput
         )) as UserResponse<AptosSignTransactionOutputV1_1>;
         if (response.status === UserResponseStatus.REJECTED) {
           throw new WalletConnectionError("User has rejected the request")
@@ -977,7 +980,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
           "aptos:signTransaction"
         ].signTransaction(
           transaction,
-          asFeePayer,
+          asFeePayer
         )) as UserResponse<AccountAuthenticator>;
         if (response.status === UserResponseStatus.REJECTED) {
           throw new WalletConnectionError("User has rejected the request")
@@ -1004,7 +1007,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
    * @throws WalletSignMessageError
    */
   async signMessage(
-    message: AptosSignMessageInput,
+    message: AptosSignMessageInput
   ): Promise<AptosSignMessageOutput> {
     try {
       this.ensureWalletExists(this._wallet);
@@ -1030,7 +1033,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
    * @returns PendingTransactionResponse
    */
   async submitTransaction(
-    transaction: InputSubmitTransactionData,
+    transaction: InputSubmitTransactionData
   ): Promise<PendingTransactionResponse> {
     // The standard does not support submitTransaction, so we use the adapter to submit the transaction
     try {
@@ -1076,7 +1079,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
           await this.setAnsName();
           this.recordEvent("account_change");
           this.emit("accountChange", this._account);
-        },
+        }
       );
     } catch (error: any) {
       const errMsg = generalizedErrorMessage(error);
@@ -1097,7 +1100,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
           this.setNetwork(data);
           await this.setAnsName();
           this.emit("networkChange", this._network);
-        },
+        }
       );
     } catch (error: any) {
       const errMsg = generalizedErrorMessage(error);
@@ -1131,7 +1134,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
       if (this._wallet.features["aptos:changeNetwork"]) {
         const response =
           await this._wallet.features["aptos:changeNetwork"].changeNetwork(
-            networkInfo,
+            networkInfo
           );
         if (response.status === UserResponseStatus.REJECTED) {
           throw new WalletConnectionError("User has rejected the request")
@@ -1141,7 +1144,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
       }
 
       throw new WalletChangeNetworkError(
-        `${this._wallet.name} does not support changing network request`,
+        `${this._wallet.name} does not support changing network request`
       ).message;
     } catch (error: any) {
       const errMsg = generalizedErrorMessage(error);
@@ -1171,7 +1174,7 @@ export class WalletCore extends EventEmitter<WalletCoreEvents> {
 
       const aptosConfig = getAptosConfig(this._network, this._dappConfig);
       const signingMessage = new TextEncoder().encode(
-        response.args.fullMessage,
+        response.args.fullMessage
       );
       if ("verifySignatureAsync" in (this._account.publicKey as Object)) {
         return await this._account.publicKey.verifySignatureAsync({

--- a/packages/wallet-adapter-core/src/constants.ts
+++ b/packages/wallet-adapter-core/src/constants.ts
@@ -35,8 +35,8 @@ export const PETRA_WEB_GENERIC_WALLET_NAME = "Petra Web";
 /** The name of the Petra wallet. */
 export const PETRA_WALLET_NAME = "Petra";
 
-/** The default fallbacks for wallets that are not installed. */
-export const DEFAULT_WALLET_FALLBACKS = {
+/** The default connection fallbacks for wallets that are not installed. */
+export const DEFAULT_WALLET_CONNECTION_FALLBACKS = {
   [PETRA_WALLET_NAME]: PETRA_WEB_GENERIC_WALLET_NAME,
 };
 

--- a/packages/wallet-adapter-core/src/constants.ts
+++ b/packages/wallet-adapter-core/src/constants.ts
@@ -29,6 +29,17 @@ export const APTOS_CONNECT_BASE_URL = "https://aptosconnect.app";
 /** The base URL for all Petra Web wallets. */
 export const PETRA_WEB_BASE_URL = "https://web.petra.app";
 
+/** The name of the generic wallet for Petra Web. */
+export const PETRA_WEB_GENERIC_WALLET_NAME = "Petra Web";
+
+/** The name of the Petra wallet. */
+export const PETRA_WALLET_NAME = "Petra";
+
+/** The default fallbacks for wallets that are not installed. */
+export const DEFAULT_WALLET_FALLBACKS = {
+  [PETRA_WALLET_NAME]: PETRA_WEB_GENERIC_WALLET_NAME,
+};
+
 /**
  * The URL to the Aptos Connect account page if the user is signed in to Aptos Connect.
  *

--- a/packages/wallet-adapter-core/src/sdkWallets.ts
+++ b/packages/wallet-adapter-core/src/sdkWallets.ts
@@ -1,5 +1,6 @@
 import {
   AptosConnectAppleWallet,
+  AptosConnectGenericWallet,
   AptosConnectGoogleWallet,
 } from "@aptos-connect/wallet-adapter-plugin";
 import { DappConfig, AdapterWallet } from "./WalletCore";
@@ -16,6 +17,11 @@ export function getSDKWallets(dappConfig?: DappConfig) {
         ...dappConfig?.aptosConnect,
       }),
       new AptosConnectAppleWallet({
+        network: dappConfig?.network,
+        dappId: dappConfig?.aptosConnectDappId,
+        ...dappConfig?.aptosConnect,
+      }),
+      new AptosConnectGenericWallet({
         network: dappConfig?.network,
         dappId: dappConfig?.aptosConnectDappId,
         ...dappConfig?.aptosConnect,

--- a/packages/wallet-adapter-core/src/utils/types.ts
+++ b/packages/wallet-adapter-core/src/utils/types.ts
@@ -30,6 +30,7 @@ export interface AptosStandardSupportedWallet {
 export type AvailableWallets =
   | "Continue with Apple"
   | "Continue with Google"
+  | "Petra Web"
   | "OKX Wallet"
   | "Petra"
   | "Nightly"

--- a/packages/wallet-adapter-core/src/utils/walletSelector.ts
+++ b/packages/wallet-adapter-core/src/utils/walletSelector.ts
@@ -16,8 +16,8 @@ import { isRedirectable } from "./helpers";
 export function partitionWallets(
   wallets: ReadonlyArray<AdapterWallet | AdapterNotDetectedWallet>,
   partitionFunction: (
-    wallet: AdapterWallet | AdapterNotDetectedWallet,
-  ) => boolean = isInstalledOrLoadable,
+    wallet: AdapterWallet | AdapterNotDetectedWallet
+  ) => boolean = isInstalledOrLoadable
 ) {
   const defaultWallets: Array<AdapterWallet> = [];
   const moreWallets: Array<AdapterNotDetectedWallet> = [];
@@ -35,7 +35,7 @@ export function partitionWallets(
 
 /** Returns true if the wallet is installed or loadable. */
 export function isInstalledOrLoadable(
-  wallet: AdapterWallet | AdapterNotDetectedWallet,
+  wallet: AdapterWallet | AdapterNotDetectedWallet
 ): wallet is AdapterWallet {
   return wallet.readyState === WalletReadyState.Installed;
 }
@@ -45,7 +45,7 @@ export function isInstalledOrLoadable(
  * This can be used to decide whether to show a "Connect" button or "Install" link in the UI.
  */
 export function isInstallRequired(
-  wallet: AdapterWallet | AdapterNotDetectedWallet,
+  wallet: AdapterWallet | AdapterNotDetectedWallet
 ) {
   const isWalletReady = isInstalledOrLoadable(wallet);
   const isMobile = !isWalletReady && isRedirectable();
@@ -54,7 +54,7 @@ export function isInstallRequired(
 }
 
 export function shouldUseFallbackWallet(
-  wallet: AdapterWallet | AdapterNotDetectedWallet,
+  wallet: AdapterWallet | AdapterNotDetectedWallet
 ): boolean {
   return (
     !!wallet.fallbackWallet &&
@@ -81,7 +81,7 @@ export function isAptosConnectWallet(wallet: WalletInfo | AdapterWallet) {
 /** Returns `true` if the provided wallet is a Petra Web wallet. This will automatically exclude the generic wallet. */
 export function isPetraWebWallet(
   wallet: WalletInfo | AdapterWallet,
-  ignoreGenericWallet: boolean = true,
+  ignoreGenericWallet: boolean = true
 ) {
   if (!wallet.url) return false;
   if (ignoreGenericWallet && isPetraWebGenericWallet(wallet)) {
@@ -95,7 +95,7 @@ export function isPetraWebWallet(
 
 /** Returns true if the wallet is a generic wallet. */
 export function isPetraWebGenericWallet(
-  wallet: AdapterWallet | AdapterNotDetectedWallet | WalletInfo,
+  wallet: AdapterWallet | AdapterNotDetectedWallet | WalletInfo
 ) {
   return wallet.name === PETRA_WEB_GENERIC_WALLET_NAME;
 }
@@ -107,11 +107,11 @@ export function isPetraWebGenericWallet(
  * @deprecated Use {@link getPetraWebWallets} instead.
  */
 export function getAptosConnectWallets(
-  wallets: ReadonlyArray<AdapterWallet | AdapterNotDetectedWallet>,
+  wallets: ReadonlyArray<AdapterWallet | AdapterNotDetectedWallet>
 ) {
   const { defaultWallets, moreWallets } = partitionWallets(
     wallets,
-    isAptosConnectWallet,
+    isAptosConnectWallet
   );
   return {
     aptosConnectWallets: defaultWallets,
@@ -124,11 +124,11 @@ export function getAptosConnectWallets(
  * Petra Web is a web wallet that uses social login to create accounts on the blockchain.
  */
 export function getPetraWebWallets(
-  wallets: ReadonlyArray<AdapterWallet | AdapterNotDetectedWallet>,
+  wallets: ReadonlyArray<AdapterWallet | AdapterNotDetectedWallet>
 ) {
   const { defaultWallets, moreWallets } = partitionWallets(
     wallets,
-    isPetraWebWallet,
+    isPetraWebWallet
   );
   return {
     petraWebWallets: defaultWallets,
@@ -148,15 +148,13 @@ export interface WalletSortingOptions {
   /** An optional function for sorting wallets that are currently installed or loadable. */
   sortAvailableWallets?: (
     a: AdapterWallet | AdapterNotDetectedWallet,
-    b: AdapterWallet | AdapterNotDetectedWallet,
+    b: AdapterWallet | AdapterNotDetectedWallet
   ) => number;
   /** An optional function for sorting wallets that are NOT currently installed or loadable. */
   sortInstallableWallets?: (
     a: AdapterWallet | AdapterNotDetectedWallet,
-    b: AdapterWallet | AdapterNotDetectedWallet,
+    b: AdapterWallet | AdapterNotDetectedWallet
   ) => number;
-  /** An optional array of wallets that are available but not intended for display. These wallets will only be shown if there is logic to explictly show them (e.g. `fallbacks`) */
-  hiddenWallets?: ReadonlyArray<AdapterWallet>;
   /**
    * A map of wallet names to fallback wallet names.
    * If a wallet is not installed and has a fallback wallet that IS installed,
@@ -172,7 +170,7 @@ export interface WalletSortingOptions {
   fallbacks?: {
     /** A map of wallet names to fallback wallet names. */
     connections: Record<string | AvailableWallets, string | AvailableWallets>;
-    /** An optional array of wallets that are available but not intended for display. These wallets will only be shown if there is logic to explictly show them (e.g. `fallbacks`) */
+    /** An optional array of wallets that are available but not intended for display. These wallets will only be shown if there is logic to explicitly show them (e.g. `fallbacks`) */
     additionalFallbackWallets?: ReadonlyArray<AdapterWallet>;
   };
 }
@@ -196,7 +194,7 @@ export interface WalletSortingOptions {
  */
 export function groupAndSortWallets(
   wallets: ReadonlyArray<AdapterWallet | AdapterNotDetectedWallet>,
-  options?: WalletSortingOptions,
+  options?: WalletSortingOptions
 ) {
   const {
     fallbacks: {

--- a/packages/wallet-adapter-core/src/utils/walletSelector.ts
+++ b/packages/wallet-adapter-core/src/utils/walletSelector.ts
@@ -16,11 +16,11 @@ import { isRedirectable } from "./helpers";
 export function partitionWallets(
   wallets: ReadonlyArray<AdapterWallet | AdapterNotDetectedWallet>,
   partitionFunction: (
-    wallet: AdapterWallet | AdapterNotDetectedWallet
+    wallet: AdapterWallet | AdapterNotDetectedWallet,
   ) => boolean = isInstalledOrLoadable,
   hideWallets: (
-    wallet: AdapterWallet | AdapterNotDetectedWallet
-  ) => boolean = isPetraWebGenericWallet
+    wallet: AdapterWallet | AdapterNotDetectedWallet,
+  ) => boolean = isPetraWebGenericWallet,
 ) {
   const defaultWallets: Array<AdapterWallet> = [];
   const moreWallets: Array<AdapterNotDetectedWallet> = [];
@@ -41,7 +41,7 @@ export function partitionWallets(
 
 /** Returns true if the wallet is installed or loadable. */
 export function isInstalledOrLoadable(
-  wallet: AdapterWallet | AdapterNotDetectedWallet
+  wallet: AdapterWallet | AdapterNotDetectedWallet,
 ): wallet is AdapterWallet {
   return wallet.readyState === WalletReadyState.Installed;
 }
@@ -51,7 +51,7 @@ export function isInstalledOrLoadable(
  * This can be used to decide whether to show a "Connect" button or "Install" link in the UI.
  */
 export function isInstallRequired(
-  wallet: AdapterWallet | AdapterNotDetectedWallet
+  wallet: AdapterWallet | AdapterNotDetectedWallet,
 ) {
   const isWalletReady = isInstalledOrLoadable(wallet);
   const isMobile = !isWalletReady && isRedirectable();
@@ -60,7 +60,7 @@ export function isInstallRequired(
 }
 
 export function shouldUseFallbackWallet(
-  wallet: AdapterWallet | AdapterNotDetectedWallet
+  wallet: AdapterWallet | AdapterNotDetectedWallet,
 ): boolean {
   return (
     !!wallet.fallbackWallet &&
@@ -87,7 +87,7 @@ export function isAptosConnectWallet(wallet: WalletInfo | AdapterWallet) {
 /** Returns `true` if the provided wallet is a Petra Web wallet. This will automatically exclude the generic wallet. */
 export function isPetraWebWallet(
   wallet: WalletInfo | AdapterWallet,
-  ignoreGenericWallet: boolean = true
+  ignoreGenericWallet: boolean = true,
 ) {
   if (!wallet.url) return false;
   if (ignoreGenericWallet && isPetraWebGenericWallet(wallet)) {
@@ -101,7 +101,7 @@ export function isPetraWebWallet(
 
 /** Returns true if the wallet is a generic wallet. */
 export function isPetraWebGenericWallet(
-  wallet: AdapterWallet | AdapterNotDetectedWallet | WalletInfo
+  wallet: AdapterWallet | AdapterNotDetectedWallet | WalletInfo,
 ) {
   return wallet.name === PETRA_WEB_GENERIC_WALLET_NAME;
 }
@@ -113,11 +113,11 @@ export function isPetraWebGenericWallet(
  * @deprecated Use {@link getPetraWebWallets} instead.
  */
 export function getAptosConnectWallets(
-  wallets: ReadonlyArray<AdapterWallet | AdapterNotDetectedWallet>
+  wallets: ReadonlyArray<AdapterWallet | AdapterNotDetectedWallet>,
 ) {
   const { defaultWallets, moreWallets } = partitionWallets(
     wallets,
-    isAptosConnectWallet
+    isAptosConnectWallet,
   );
   return {
     aptosConnectWallets: defaultWallets,
@@ -130,11 +130,11 @@ export function getAptosConnectWallets(
  * Petra Web is a web wallet that uses social login to create accounts on the blockchain.
  */
 export function getPetraWebWallets(
-  wallets: ReadonlyArray<AdapterWallet | AdapterNotDetectedWallet>
+  wallets: ReadonlyArray<AdapterWallet | AdapterNotDetectedWallet>,
 ) {
   const { defaultWallets, moreWallets } = partitionWallets(
     wallets,
-    isPetraWebWallet
+    isPetraWebWallet,
   );
   return {
     petraWebWallets: defaultWallets,
@@ -154,12 +154,12 @@ export interface WalletSortingOptions {
   /** An optional function for sorting wallets that are currently installed or loadable. */
   sortAvailableWallets?: (
     a: AdapterWallet | AdapterNotDetectedWallet,
-    b: AdapterWallet | AdapterNotDetectedWallet
+    b: AdapterWallet | AdapterNotDetectedWallet,
   ) => number;
   /** An optional function for sorting wallets that are NOT currently installed or loadable. */
   sortInstallableWallets?: (
     a: AdapterWallet | AdapterNotDetectedWallet,
-    b: AdapterWallet | AdapterNotDetectedWallet
+    b: AdapterWallet | AdapterNotDetectedWallet,
   ) => number;
   /** An optional function for hiding wallets from the UI. */
   hideWallets?: (wallet: AdapterWallet | AdapterNotDetectedWallet) => boolean;
@@ -197,7 +197,7 @@ export interface WalletSortingOptions {
  */
 export function groupAndSortWallets(
   wallets: ReadonlyArray<AdapterWallet | AdapterNotDetectedWallet>,
-  options?: WalletSortingOptions
+  options?: WalletSortingOptions,
 ) {
   const { fallbacks } = options ?? {};
   const { aptosConnectWallets } = getAptosConnectWallets(wallets);
@@ -205,7 +205,7 @@ export function groupAndSortWallets(
   const { defaultWallets, moreWallets } = partitionWallets(
     otherWallets,
     undefined,
-    options?.hideWallets
+    options?.hideWallets,
   );
 
   // Attach fallback wallets to not-installed wallets and move them to available wallets if the fallback is installed
@@ -221,7 +221,7 @@ export function groupAndSortWallets(
 
       if (fallbackName) {
         const fallbackWallet = wallets.find(
-          (w) => w.name === fallbackName && isInstalledOrLoadable(w)
+          (w) => w.name === fallbackName && isInstalledOrLoadable(w),
         ) as AdapterWallet | undefined;
 
         // If we found an installed fallback, attach it and move to available wallets

--- a/packages/wallet-adapter-core/src/utils/walletSelector.ts
+++ b/packages/wallet-adapter-core/src/utils/walletSelector.ts
@@ -16,8 +16,8 @@ import { isRedirectable } from "./helpers";
 export function partitionWallets(
   wallets: ReadonlyArray<AdapterWallet | AdapterNotDetectedWallet>,
   partitionFunction: (
-    wallet: AdapterWallet | AdapterNotDetectedWallet
-  ) => boolean = isInstalledOrLoadable
+    wallet: AdapterWallet | AdapterNotDetectedWallet,
+  ) => boolean = isInstalledOrLoadable,
 ) {
   const defaultWallets: Array<AdapterWallet> = [];
   const moreWallets: Array<AdapterNotDetectedWallet> = [];
@@ -35,7 +35,7 @@ export function partitionWallets(
 
 /** Returns true if the wallet is installed or loadable. */
 export function isInstalledOrLoadable(
-  wallet: AdapterWallet | AdapterNotDetectedWallet
+  wallet: AdapterWallet | AdapterNotDetectedWallet,
 ): wallet is AdapterWallet {
   return wallet.readyState === WalletReadyState.Installed;
 }
@@ -45,7 +45,7 @@ export function isInstalledOrLoadable(
  * This can be used to decide whether to show a "Connect" button or "Install" link in the UI.
  */
 export function isInstallRequired(
-  wallet: AdapterWallet | AdapterNotDetectedWallet
+  wallet: AdapterWallet | AdapterNotDetectedWallet,
 ) {
   const isWalletReady = isInstalledOrLoadable(wallet);
   const isMobile = !isWalletReady && isRedirectable();
@@ -54,7 +54,7 @@ export function isInstallRequired(
 }
 
 export function shouldUseFallbackWallet(
-  wallet: AdapterWallet | AdapterNotDetectedWallet
+  wallet: AdapterWallet | AdapterNotDetectedWallet,
 ): boolean {
   return (
     !!wallet.fallbackWallet &&
@@ -81,7 +81,7 @@ export function isAptosConnectWallet(wallet: WalletInfo | AdapterWallet) {
 /** Returns `true` if the provided wallet is a Petra Web wallet. This will automatically exclude the generic wallet. */
 export function isPetraWebWallet(
   wallet: WalletInfo | AdapterWallet,
-  ignoreGenericWallet: boolean = true
+  ignoreGenericWallet: boolean = true,
 ) {
   if (!wallet.url) return false;
   if (ignoreGenericWallet && isPetraWebGenericWallet(wallet)) {
@@ -95,7 +95,7 @@ export function isPetraWebWallet(
 
 /** Returns true if the wallet is a generic wallet. */
 export function isPetraWebGenericWallet(
-  wallet: AdapterWallet | AdapterNotDetectedWallet | WalletInfo
+  wallet: AdapterWallet | AdapterNotDetectedWallet | WalletInfo,
 ) {
   return wallet.name === PETRA_WEB_GENERIC_WALLET_NAME;
 }
@@ -107,11 +107,11 @@ export function isPetraWebGenericWallet(
  * @deprecated Use {@link getPetraWebWallets} instead.
  */
 export function getAptosConnectWallets(
-  wallets: ReadonlyArray<AdapterWallet | AdapterNotDetectedWallet>
+  wallets: ReadonlyArray<AdapterWallet | AdapterNotDetectedWallet>,
 ) {
   const { defaultWallets, moreWallets } = partitionWallets(
     wallets,
-    isAptosConnectWallet
+    isAptosConnectWallet,
   );
   return {
     aptosConnectWallets: defaultWallets,
@@ -124,11 +124,11 @@ export function getAptosConnectWallets(
  * Petra Web is a web wallet that uses social login to create accounts on the blockchain.
  */
 export function getPetraWebWallets(
-  wallets: ReadonlyArray<AdapterWallet | AdapterNotDetectedWallet>
+  wallets: ReadonlyArray<AdapterWallet | AdapterNotDetectedWallet>,
 ) {
   const { defaultWallets, moreWallets } = partitionWallets(
     wallets,
-    isPetraWebWallet
+    isPetraWebWallet,
   );
   return {
     petraWebWallets: defaultWallets,
@@ -148,12 +148,12 @@ export interface WalletSortingOptions {
   /** An optional function for sorting wallets that are currently installed or loadable. */
   sortAvailableWallets?: (
     a: AdapterWallet | AdapterNotDetectedWallet,
-    b: AdapterWallet | AdapterNotDetectedWallet
+    b: AdapterWallet | AdapterNotDetectedWallet,
   ) => number;
   /** An optional function for sorting wallets that are NOT currently installed or loadable. */
   sortInstallableWallets?: (
     a: AdapterWallet | AdapterNotDetectedWallet,
-    b: AdapterWallet | AdapterNotDetectedWallet
+    b: AdapterWallet | AdapterNotDetectedWallet,
   ) => number;
   /** An optional array of wallets that are available but not intended for display. These wallets will only be shown if there is logic to explictly show them (e.g. `fallbacks`) */
   hiddenWallets?: ReadonlyArray<AdapterWallet>;
@@ -196,7 +196,7 @@ export interface WalletSortingOptions {
  */
 export function groupAndSortWallets(
   wallets: ReadonlyArray<AdapterWallet | AdapterNotDetectedWallet>,
-  options?: WalletSortingOptions
+  options?: WalletSortingOptions,
 ) {
   const {
     fallbacks: {

--- a/packages/wallet-adapter-core/src/utils/walletSelector.ts
+++ b/packages/wallet-adapter-core/src/utils/walletSelector.ts
@@ -16,11 +16,11 @@ import { isRedirectable } from "./helpers";
 export function partitionWallets(
   wallets: ReadonlyArray<AdapterWallet | AdapterNotDetectedWallet>,
   partitionFunction: (
-    wallet: AdapterWallet | AdapterNotDetectedWallet,
+    wallet: AdapterWallet | AdapterNotDetectedWallet
   ) => boolean = isInstalledOrLoadable,
   hideWallets: (
-    wallet: AdapterWallet | AdapterNotDetectedWallet,
-  ) => boolean = isPetraWebGenericWallet,
+    wallet: AdapterWallet | AdapterNotDetectedWallet
+  ) => boolean = isPetraWebGenericWallet
 ) {
   const defaultWallets: Array<AdapterWallet> = [];
   const moreWallets: Array<AdapterNotDetectedWallet> = [];
@@ -41,7 +41,7 @@ export function partitionWallets(
 
 /** Returns true if the wallet is installed or loadable. */
 export function isInstalledOrLoadable(
-  wallet: AdapterWallet | AdapterNotDetectedWallet,
+  wallet: AdapterWallet | AdapterNotDetectedWallet
 ): wallet is AdapterWallet {
   return wallet.readyState === WalletReadyState.Installed;
 }
@@ -51,7 +51,7 @@ export function isInstalledOrLoadable(
  * This can be used to decide whether to show a "Connect" button or "Install" link in the UI.
  */
 export function isInstallRequired(
-  wallet: AdapterWallet | AdapterNotDetectedWallet,
+  wallet: AdapterWallet | AdapterNotDetectedWallet
 ) {
   const isWalletReady = isInstalledOrLoadable(wallet);
   const isMobile = !isWalletReady && isRedirectable();
@@ -60,7 +60,7 @@ export function isInstallRequired(
 }
 
 export function shouldUseFallbackWallet(
-  wallet: AdapterWallet | AdapterNotDetectedWallet,
+  wallet: AdapterWallet | AdapterNotDetectedWallet
 ): boolean {
   return (
     !!wallet.fallbackWallet &&
@@ -87,7 +87,7 @@ export function isAptosConnectWallet(wallet: WalletInfo | AdapterWallet) {
 /** Returns `true` if the provided wallet is a Petra Web wallet. This will automatically exclude the generic wallet. */
 export function isPetraWebWallet(
   wallet: WalletInfo | AdapterWallet,
-  ignoreGenericWallet: boolean = true,
+  ignoreGenericWallet: boolean = true
 ) {
   if (!wallet.url) return false;
   if (ignoreGenericWallet && isPetraWebGenericWallet(wallet)) {
@@ -101,7 +101,7 @@ export function isPetraWebWallet(
 
 /** Returns true if the wallet is a generic wallet. */
 export function isPetraWebGenericWallet(
-  wallet: AdapterWallet | AdapterNotDetectedWallet | WalletInfo,
+  wallet: AdapterWallet | AdapterNotDetectedWallet | WalletInfo
 ) {
   return wallet.name === PETRA_WEB_GENERIC_WALLET_NAME;
 }
@@ -113,11 +113,11 @@ export function isPetraWebGenericWallet(
  * @deprecated Use {@link getPetraWebWallets} instead.
  */
 export function getAptosConnectWallets(
-  wallets: ReadonlyArray<AdapterWallet | AdapterNotDetectedWallet>,
+  wallets: ReadonlyArray<AdapterWallet | AdapterNotDetectedWallet>
 ) {
   const { defaultWallets, moreWallets } = partitionWallets(
     wallets,
-    isAptosConnectWallet,
+    isAptosConnectWallet
   );
   return {
     aptosConnectWallets: defaultWallets,
@@ -130,11 +130,11 @@ export function getAptosConnectWallets(
  * Petra Web is a web wallet that uses social login to create accounts on the blockchain.
  */
 export function getPetraWebWallets(
-  wallets: ReadonlyArray<AdapterWallet | AdapterNotDetectedWallet>,
+  wallets: ReadonlyArray<AdapterWallet | AdapterNotDetectedWallet>
 ) {
   const { defaultWallets, moreWallets } = partitionWallets(
     wallets,
-    isPetraWebWallet,
+    isPetraWebWallet
   );
   return {
     petraWebWallets: defaultWallets,
@@ -154,12 +154,12 @@ export interface WalletSortingOptions {
   /** An optional function for sorting wallets that are currently installed or loadable. */
   sortAvailableWallets?: (
     a: AdapterWallet | AdapterNotDetectedWallet,
-    b: AdapterWallet | AdapterNotDetectedWallet,
+    b: AdapterWallet | AdapterNotDetectedWallet
   ) => number;
   /** An optional function for sorting wallets that are NOT currently installed or loadable. */
   sortInstallableWallets?: (
     a: AdapterWallet | AdapterNotDetectedWallet,
-    b: AdapterWallet | AdapterNotDetectedWallet,
+    b: AdapterWallet | AdapterNotDetectedWallet
   ) => number;
   /** An optional function for hiding wallets from the UI. */
   hideWallets?: (wallet: AdapterWallet | AdapterNotDetectedWallet) => boolean;
@@ -197,7 +197,7 @@ export interface WalletSortingOptions {
  */
 export function groupAndSortWallets(
   wallets: ReadonlyArray<AdapterWallet | AdapterNotDetectedWallet>,
-  options?: WalletSortingOptions,
+  options?: WalletSortingOptions
 ) {
   const { fallbacks } = options ?? {};
   const { aptosConnectWallets } = getAptosConnectWallets(wallets);
@@ -205,7 +205,7 @@ export function groupAndSortWallets(
   const { defaultWallets, moreWallets } = partitionWallets(
     otherWallets,
     undefined,
-    options?.hideWallets,
+    options?.hideWallets
   );
 
   // Attach fallback wallets to not-installed wallets and move them to available wallets if the fallback is installed
@@ -221,7 +221,7 @@ export function groupAndSortWallets(
 
       if (fallbackName) {
         const fallbackWallet = wallets.find(
-          (w) => w.name === fallbackName && isInstalledOrLoadable(w),
+          (w) => w.name === fallbackName && isInstalledOrLoadable(w)
         ) as AdapterWallet | undefined;
 
         // If we found an installed fallback, attach it and move to available wallets
@@ -259,7 +259,7 @@ export function groupAndSortWallets(
     aptosConnectWallets,
     /** Wallets that use social login to create an account on the blockchain */
     petraWebWallets,
-    /** Wallets that are currently installed or loadable or have a fallback wallet. */
+    /** Wallets that are currently installed or loadable. */
     availableWallets: defaultWallets,
     /** Wallets that are currently uninstalled that have a fallback wallet. */
     availableWalletsWithFallbacks,

--- a/packages/wallet-adapter-react/docs/BYO-wallet-selector.md
+++ b/packages/wallet-adapter-react/docs/BYO-wallet-selector.md
@@ -274,6 +274,7 @@ A function that partitions the `wallets` array into three distinct groups:
 - `petraWebWallets` - Wallets that use social login to create accounts on
   the blockchain via Petra Web.
 - `availableWallets` - Wallets that are currently installed or loadable by the client.
+- `availableWalletsWithFallbacks` - Wallets that are currently uninstalled that have a fallback wallet.
 - `installableWallets` - Wallets that are NOT current installed or loadable and
   require the client to install a browser extension first.
 
@@ -282,8 +283,13 @@ Additionally, these wallet groups can be sorted by passing the following sort fu
 - `sortPetraWebWallets`
 - `sortAvailableWallets`
 - `sortInstallableWallets`
+- `fallbacks`
 
 ```ts
-const { petraWebWallets, availableWallets, installableWallets } =
-  groupAndSortWallets(wallets, walletSortingOptions);
+const {
+  petraWebWallets,
+  availableWallets,
+  availableWalletsWithFallbacks,
+  installableWallets,
+} = groupAndSortWallets(wallets, walletSortingOptions);
 ```

--- a/packages/wallet-adapter-react/docs/BYO-wallet-selector.md
+++ b/packages/wallet-adapter-react/docs/BYO-wallet-selector.md
@@ -269,7 +269,7 @@ const { petraWebWallets, otherWallets } = getPetraWebWallets(wallets);
 
 ### `groupAndSortWallets`
 
-A function that partitions the `wallets` array into three distinct groups:
+A function that partitions the `wallets` array into four distinct groups:
 
 - `petraWebWallets` - Wallets that use social login to create accounts on
   the blockchain via Petra Web.
@@ -283,7 +283,6 @@ Additionally, these wallet groups can be sorted by passing the following sort fu
 - `sortPetraWebWallets`
 - `sortAvailableWallets`
 - `sortInstallableWallets`
-- `fallbacks`
 
 ```ts
 const {
@@ -292,4 +291,19 @@ const {
   availableWalletsWithFallbacks,
   installableWallets,
 } = groupAndSortWallets(wallets, walletSortingOptions);
+```
+
+Additionally, you can specify fallback wallets for wallets that are not installed by passing the following `fallbacks` property via the `options` argument:
+
+```ts
+const {
+  petraWebWallets,
+  availableWallets,
+  availableWalletsWithFallbacks,
+  installableWallets,
+} = groupAndSortWallets(wallets, {
+  fallbacks: {
+    connections: { Petra: "Petra Web", OtherWallet: "OtherFallback" },
+  },
+});
 ```

--- a/packages/wallet-adapter-react/src/WalletProvider.tsx
+++ b/packages/wallet-adapter-react/src/WalletProvider.tsx
@@ -80,7 +80,7 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
       optInWallets,
       dappConfig,
       disableTelemetry,
-      hideWallets,
+      hideWallets ? hideWallets : ["Petra Web"],
     );
     setWalletCore(walletCore);
   }, []);

--- a/packages/wallet-adapter-react/src/WalletProvider.tsx
+++ b/packages/wallet-adapter-react/src/WalletProvider.tsx
@@ -26,6 +26,7 @@ import { WalletContext } from "./useWallet";
 export interface AptosWalletProviderProps {
   children: ReactNode;
   optInWallets?: ReadonlyArray<AvailableWallets>;
+  hideWallets?: ReadonlyArray<AvailableWallets>;
   autoConnect?:
     | boolean
     | ((core: WalletCore, adapter: AdapterWallet) => Promise<boolean>);
@@ -49,6 +50,7 @@ const initialState: {
 export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
   children,
   optInWallets,
+  hideWallets,
   autoConnect = false,
   dappConfig,
   disableTelemetry = false,
@@ -63,6 +65,9 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
   const [walletCore, setWalletCore] = useState<WalletCore>();
 
   const [wallets, setWallets] = useState<ReadonlyArray<AdapterWallet>>([]);
+  const [hiddenWallets, setHiddenWallets] = useState<
+    ReadonlyArray<AdapterWallet>
+  >([]);
   const [notDetectedWallets, setNotDetectedWallets] = useState<
     ReadonlyArray<AdapterNotDetectedWallet>
   >([]);
@@ -74,7 +79,8 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
     const walletCore = new WalletCore(
       optInWallets,
       dappConfig,
-      disableTelemetry
+      disableTelemetry,
+      hideWallets,
     );
     setWalletCore(walletCore);
   }, []);
@@ -82,6 +88,7 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
   // Update initial Wallets state once WalletCore has been initialized
   useEffect(() => {
     setWallets(walletCore?.wallets ?? []);
+    setHiddenWallets(walletCore?.hiddenWallets ?? []);
     setNotDetectedWallets(walletCore?.notDetectedWallets ?? []);
   }, [walletCore]);
 
@@ -107,7 +114,7 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
 
     // Make sure the wallet is installed
     const selectedWallet = walletCore.wallets.find(
-      (e) => e.name === walletName
+      (e) => e.name === walletName,
     ) as AdapterWallet | undefined;
     if (
       !selectedWallet ||
@@ -159,7 +166,7 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
             setupAutomaticSolanaWalletDerivation({
               defaultNetwork: dappConfig?.network,
             });
-          }
+          },
         );
       }
       if (dappConfig?.crossChainWallets?.evm) {
@@ -168,7 +175,7 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
             setupAutomaticEthereumWalletDerivation({
               defaultNetwork: dappConfig?.network,
             });
-          }
+          },
         );
       }
       derivationInitialized.current = true;
@@ -216,7 +223,7 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
   };
 
   const signAndSubmitTransaction = async (
-    transaction: InputTransactionData
+    transaction: InputTransactionData,
   ): Promise<AptosSignAndSubmitTransactionOutput> => {
     try {
       if (!walletCore) {
@@ -256,7 +263,7 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
   };
 
   const submitTransaction = async (
-    transaction: InputSubmitTransactionData
+    transaction: InputSubmitTransactionData,
   ): Promise<PendingTransactionResponse> => {
     if (!walletCore) {
       throw new Error("WalletCore is not initialized");
@@ -270,7 +277,7 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
   };
 
   const signMessage = async (
-    message: AptosSignMessageInput
+    message: AptosSignMessageInput,
   ): Promise<AptosSignMessageOutput> => {
     if (!walletCore) {
       throw new Error("WalletCore is not initialized");
@@ -284,7 +291,7 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
   };
 
   const signMessageAndVerify = async (
-    message: AptosSignMessageInput
+    message: AptosSignMessageInput,
   ): Promise<boolean> => {
     if (!walletCore) {
       throw new Error("WalletCore is not initialized");
@@ -371,7 +378,7 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
     // Manage current wallet state by removing optional duplications
     // as new wallets are coming
     const existingWalletIndex = wallets.findIndex(
-      (wallet) => wallet.name == standardWallet.name
+      (wallet) => wallet.name == standardWallet.name,
     );
     if (existingWalletIndex !== -1) {
       // If wallet exists, replace it with the new wallet
@@ -386,13 +393,34 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
     }
   };
 
+  const handleStandardWalletsHiddenAdded = (
+    standardWallet: AdapterWallet,
+  ): void => {
+    // Manage hidden wallet state by removing optional duplications
+    // as new wallets are coming
+    const existingWalletIndex = hiddenWallets.findIndex(
+      (wallet) => wallet.name == standardWallet.name,
+    );
+    if (existingWalletIndex !== -1) {
+      // If wallet exists, replace it with the new wallet
+      setHiddenWallets((hiddenWallets) => [
+        ...hiddenWallets.slice(0, existingWalletIndex),
+        standardWallet,
+        ...hiddenWallets.slice(existingWalletIndex + 1),
+      ]);
+    } else {
+      // If wallet doesn't exist, add it to the array
+      setHiddenWallets((hiddenWallets) => [...hiddenWallets, standardWallet]);
+    }
+  };
+
   const handleStandardNotDetectedWalletsAdded = (
-    notDetectedWallet: AdapterNotDetectedWallet
+    notDetectedWallet: AdapterNotDetectedWallet,
   ): void => {
     // Manage current wallet state by removing optional duplications
     // as new wallets are coming
     const existingWalletIndex = wallets.findIndex(
-      (wallet) => wallet.name == notDetectedWallet.name
+      (wallet) => wallet.name == notDetectedWallet.name,
     );
     if (existingWalletIndex !== -1) {
       // If wallet exists, replace it with the new wallet
@@ -414,8 +442,12 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
     walletCore?.on("disconnect", handleDisconnect);
     walletCore?.on("standardWalletsAdded", handleStandardWalletsAdded);
     walletCore?.on(
+      "standardWalletsHiddenAdded",
+      handleStandardWalletsHiddenAdded,
+    );
+    walletCore?.on(
       "standardNotDetectedWalletAdded",
-      handleStandardNotDetectedWalletsAdded
+      handleStandardNotDetectedWalletsAdded,
     );
     return () => {
       walletCore?.off("connect", handleConnect);
@@ -424,8 +456,12 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
       walletCore?.off("disconnect", handleDisconnect);
       walletCore?.off("standardWalletsAdded", handleStandardWalletsAdded);
       walletCore?.off(
+        "standardWalletsHiddenAdded",
+        handleStandardWalletsHiddenAdded,
+      );
+      walletCore?.off(
         "standardNotDetectedWalletAdded",
-        handleStandardNotDetectedWalletsAdded
+        handleStandardNotDetectedWalletsAdded,
       );
     };
   }, [wallets, account]);
@@ -448,6 +484,7 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
         wallet,
         wallets,
         notDetectedWallets,
+        hiddenWallets,
         isLoading,
       }}
     >

--- a/packages/wallet-adapter-react/src/WalletProvider.tsx
+++ b/packages/wallet-adapter-react/src/WalletProvider.tsx
@@ -399,7 +399,7 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
     // Manage hidden wallet state by removing optional duplications
     // as new wallets are coming
     const existingWalletIndex = hiddenWallets.findIndex(
-      (wallet) => wallet.name == standardWallet.name,
+      (wallet) => wallet.name === standardWallet.name,
     );
     if (existingWalletIndex !== -1) {
       // If wallet exists, replace it with the new wallet

--- a/packages/wallet-adapter-react/src/components/WalletItem.tsx
+++ b/packages/wallet-adapter-react/src/components/WalletItem.tsx
@@ -63,7 +63,7 @@ const Root = forwardRef<HTMLDivElement, WalletItemProps>(
         </Component>
       </WalletItemContext.Provider>
     );
-  }
+  },
 );
 Root.displayName = "WalletItem";
 
@@ -77,7 +77,7 @@ const Icon = createHeadlessComponent(
       src: context.wallet.icon,
       alt: `${context.wallet.name} icon`,
     };
-  }
+  },
 );
 
 const Name = createHeadlessComponent(
@@ -89,7 +89,7 @@ const Name = createHeadlessComponent(
     return {
       children: context.wallet.name,
     };
-  }
+  },
 );
 
 const ConnectButton = createHeadlessComponent(
@@ -102,7 +102,7 @@ const ConnectButton = createHeadlessComponent(
       onClick: context.connectWallet,
       children: "Connect",
     };
-  }
+  },
 );
 
 const InstallLink = createHeadlessComponent(
@@ -117,7 +117,7 @@ const InstallLink = createHeadlessComponent(
       rel: "noopener noreferrer",
       children: "Install",
     };
-  }
+  },
 );
 
 /** A headless component for rendering a wallet option's name, icon, and either connect button or install link. */

--- a/packages/wallet-adapter-react/src/components/WalletItem.tsx
+++ b/packages/wallet-adapter-react/src/components/WalletItem.tsx
@@ -15,6 +15,8 @@ export interface WalletItemProps extends HeadlessComponentProps {
   wallet: AdapterWallet | AdapterNotDetectedWallet;
   /** A callback to be invoked when the wallet is connected. */
   onConnect?: () => void;
+  /** An alternative connection method to use when `wallet` is not installed */
+  fallbackWallet?: AdapterWallet | AdapterNotDetectedWallet;
 }
 
 function useWalletItemContext(displayName: string) {
@@ -30,7 +32,6 @@ function useWalletItemContext(displayName: string) {
 const WalletItemContext = createContext<{
   wallet: AdapterWallet | AdapterNotDetectedWallet;
   connectWallet: () => void;
-  fallbackWallet?: AdapterWallet | AdapterNotDetectedWallet;
 } | null>(null);
 
 const Root = forwardRef<HTMLDivElement, WalletItemProps>(
@@ -62,7 +63,7 @@ const Root = forwardRef<HTMLDivElement, WalletItemProps>(
         </Component>
       </WalletItemContext.Provider>
     );
-  },
+  }
 );
 Root.displayName = "WalletItem";
 
@@ -76,7 +77,7 @@ const Icon = createHeadlessComponent(
       src: context.wallet.icon,
       alt: `${context.wallet.name} icon`,
     };
-  },
+  }
 );
 
 const Name = createHeadlessComponent(
@@ -88,7 +89,7 @@ const Name = createHeadlessComponent(
     return {
       children: context.wallet.name,
     };
-  },
+  }
 );
 
 const ConnectButton = createHeadlessComponent(
@@ -101,7 +102,7 @@ const ConnectButton = createHeadlessComponent(
       onClick: context.connectWallet,
       children: "Connect",
     };
-  },
+  }
 );
 
 const InstallLink = createHeadlessComponent(
@@ -116,7 +117,7 @@ const InstallLink = createHeadlessComponent(
       rel: "noopener noreferrer",
       children: "Install",
     };
-  },
+  }
 );
 
 /** A headless component for rendering a wallet option's name, icon, and either connect button or install link. */

--- a/packages/wallet-adapter-react/src/components/WalletItem.tsx
+++ b/packages/wallet-adapter-react/src/components/WalletItem.tsx
@@ -15,8 +15,6 @@ export interface WalletItemProps extends HeadlessComponentProps {
   wallet: AdapterWallet | AdapterNotDetectedWallet;
   /** A callback to be invoked when the wallet is connected. */
   onConnect?: () => void;
-  /** An alternative connection method to use when `wallet` is not installed */
-  fallbackWallet?: AdapterWallet | AdapterNotDetectedWallet;
 }
 
 function useWalletItemContext(displayName: string) {
@@ -63,7 +61,7 @@ const Root = forwardRef<HTMLDivElement, WalletItemProps>(
         </Component>
       </WalletItemContext.Provider>
     );
-  },
+  }
 );
 Root.displayName = "WalletItem";
 
@@ -77,7 +75,7 @@ const Icon = createHeadlessComponent(
       src: context.wallet.icon,
       alt: `${context.wallet.name} icon`,
     };
-  },
+  }
 );
 
 const Name = createHeadlessComponent(
@@ -89,7 +87,7 @@ const Name = createHeadlessComponent(
     return {
       children: context.wallet.name,
     };
-  },
+  }
 );
 
 const ConnectButton = createHeadlessComponent(
@@ -102,7 +100,7 @@ const ConnectButton = createHeadlessComponent(
       onClick: context.connectWallet,
       children: "Connect",
     };
-  },
+  }
 );
 
 const InstallLink = createHeadlessComponent(
@@ -117,7 +115,7 @@ const InstallLink = createHeadlessComponent(
       rel: "noopener noreferrer",
       children: "Install",
     };
-  },
+  }
 );
 
 /** A headless component for rendering a wallet option's name, icon, and either connect button or install link. */

--- a/packages/wallet-adapter-react/src/useWallet.tsx
+++ b/packages/wallet-adapter-react/src/useWallet.tsx
@@ -47,6 +47,7 @@ export interface WalletContextState {
   ): Promise<PendingTransactionResponse>;
   wallet: AdapterWallet | null;
   wallets: ReadonlyArray<AdapterWallet>;
+  hiddenWallets: ReadonlyArray<AdapterWallet>;
   notDetectedWallets: ReadonlyArray<AdapterNotDetectedWallet>;
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -446,7 +446,7 @@ importers:
         version: 29.7.0(@types/node@20.17.27)(babel-plugin-macros@3.1.0)
       ts-jest:
         specifier: ^29.0.3
-        version: 29.3.0(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(esbuild@0.25.1)(jest@29.7.0(@types/node@20.17.27)(babel-plugin-macros@3.1.0))(typescript@5.8.3)
+        version: 29.3.0(@babel/core@7.28.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.4))(jest@29.7.0(@types/node@20.17.27)(babel-plugin-macros@3.1.0))(typescript@5.8.3)
       tsup:
         specifier: ^8.4.0
         version: 8.4.0(@microsoft/api-extractor@7.43.0(@types/node@20.17.27))(@swc/core@1.11.16(@swc/helpers@0.5.15))(jiti@2.5.1)(postcss@8.5.6)(typescript@5.8.3)(yaml@2.8.1)
@@ -483,7 +483,7 @@ importers:
         version: 29.7.0(@types/node@20.17.27)(babel-plugin-macros@3.1.0)
       ts-jest:
         specifier: ^29.0.3
-        version: 29.3.0(@babel/core@7.28.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.4))(jest@29.7.0(@types/node@20.17.27)(babel-plugin-macros@3.1.0))(typescript@5.8.3)
+        version: 29.3.0(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(esbuild@0.25.1)(jest@29.7.0(@types/node@20.17.27)(babel-plugin-macros@3.1.0))(typescript@5.8.3)
       tsup:
         specifier: ^8.4.0
         version: 8.4.0(@microsoft/api-extractor@7.43.0(@types/node@20.17.27))(@swc/core@1.11.16(@swc/helpers@0.5.15))(jiti@2.5.1)(postcss@8.5.6)(typescript@5.8.3)(yaml@2.8.1)
@@ -662,8 +662,8 @@ importers:
   packages/wallet-adapter-core:
     dependencies:
       '@aptos-connect/wallet-adapter-plugin':
-        specifier: ^3.0.1
-        version: 3.0.1(@aptos-labs/ts-sdk@5.1.1(got@11.8.6))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)
+        specifier: ^3.0.2
+        version: 3.0.2(@aptos-labs/ts-sdk@5.1.1(got@11.8.6))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)
       '@aptos-labs/ts-sdk':
         specifier: ^5.1.1
         version: 5.1.1(got@11.8.6)
@@ -919,8 +919,8 @@ packages:
       '@aptos-labs/ts-sdk': 1.26.0
       '@aptos-labs/wallet-standard': 0.2.0
 
-  '@aptos-connect/wallet-adapter-plugin@3.0.1':
-    resolution: {integrity: sha512-skqglrS/Vuawhr9DYFE6LuBe8hRG82UQiZl3quHFn9bwlRW3ZOQ0Ykc6imuSjottGWHGlYBwvQxvxhsyq1ptmQ==}
+  '@aptos-connect/wallet-adapter-plugin@3.0.2':
+    resolution: {integrity: sha512-6CvTUDktqGJFjp4M/FO5MHPHq3GtsL7JIpw5xCJjs19qLfhtRIKE+okjRhv7CrFyqcJroOIhCuZTqzPWEmTl+A==}
     peerDependencies:
       '@aptos-labs/ts-sdk': ^1.33.1 || ^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0
 
@@ -10587,7 +10587,7 @@ snapshots:
       - aptos
       - debug
 
-  '@aptos-connect/wallet-adapter-plugin@3.0.1(@aptos-labs/ts-sdk@5.1.1(got@11.8.6))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)':
+  '@aptos-connect/wallet-adapter-plugin@3.0.2(@aptos-labs/ts-sdk@5.1.1(got@11.8.6))(@telegram-apps/bridge@1.9.2)(@wallet-standard/core@1.1.0)':
     dependencies:
       '@aptos-connect/wallet-api': 0.6.0(@aptos-labs/ts-sdk@5.1.1(got@11.8.6))(@wallet-standard/core@1.1.0)
       '@aptos-labs/ts-sdk': 5.1.1(got@11.8.6)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10663,7 +10663,7 @@ snapshots:
       '@aptos-labs/aptos-client': 2.0.0(got@11.8.6)
       '@aptos-labs/script-composer-pack': 0.0.9
       '@noble/curves': 1.8.1
-      '@noble/hashes': 1.7.1
+      '@noble/hashes': 1.8.0
       '@scure/bip32': 1.6.2
       '@scure/bip39': 1.5.4
       eventemitter3: 5.0.1
@@ -11386,7 +11386,7 @@ snapshots:
   '@coral-xyz/anchor@0.29.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)':
     dependencies:
       '@coral-xyz/borsh': 0.29.0(@solana/web3.js@1.98.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@noble/hashes': 1.7.1
+      '@noble/hashes': 1.8.0
       '@solana/web3.js': 1.98.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       bn.js: 5.2.1
       bs58: 4.0.1
@@ -12644,7 +12644,7 @@ snapshots:
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.10.0)
       '@mysten/bcs': 0.11.1
       '@noble/curves': 1.8.1
-      '@noble/hashes': 1.7.1
+      '@noble/hashes': 1.8.0
       '@scure/bip32': 1.6.2
       '@scure/bip39': 1.5.4
       '@suchipi/femver': 1.0.0
@@ -12663,7 +12663,7 @@ snapshots:
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.10.0)
       '@mysten/bcs': 1.5.0
       '@noble/curves': 1.8.1
-      '@noble/hashes': 1.7.1
+      '@noble/hashes': 1.8.0
       '@scure/base': 1.2.4
       '@scure/bip32': 1.6.2
       '@scure/bip39': 1.5.4
@@ -15442,7 +15442,7 @@ snapshots:
   '@wormhole-foundation/sdk-definitions@1.5.2':
     dependencies:
       '@noble/curves': 1.8.1
-      '@noble/hashes': 1.7.1
+      '@noble/hashes': 1.8.0
       '@wormhole-foundation/sdk-base': 1.5.2
 
   '@wormhole-foundation/sdk-evm-cctp@1.5.2(bufferutil@4.0.9)(utf-8-validate@5.0.10)':
@@ -19863,7 +19863,7 @@ snapshots:
     dependencies:
       '@adraffy/ens-normalize': 1.11.0
       '@noble/curves': 1.8.1
-      '@noble/hashes': 1.7.1
+      '@noble/hashes': 1.8.0
       '@scure/bip32': 1.6.2
       '@scure/bip39': 1.5.4
       abitype: 1.0.8(typescript@5.8.3)


### PR DESCRIPTION
### Description
Add support for `fallback` wallets which allow for alternative connections to wallets that are not installed. This is useful in the case that wallet connections may need multiple wallet adapters to function. For example, the Petra connection can either route through `PetraWallet` (extension/mobile) or Petra web's `AptosConnectGenericWallet` (web).

Also added a `hideWallets` function that defaults to hiding the `AptosConnectGenericWallet` from the results so that it is not shown in the UI.

### Tests

https://github.com/user-attachments/assets/50baa9e6-f8dd-4c7b-9920-01b95623ac32

