### PR TITLE
Fix npm publish authentication for OIDC trusted publishers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,14 +7,11 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
-permissions:
-  id-token: write # Required for OIDC
-  contents: read
-
 jobs:
   build:
     name: Build
     permissions:
+      id-token: write # Required for npm OIDC trusted publishers
       actions: write
       pull-requests: write
       contents: write
@@ -56,6 +53,7 @@ jobs:
           publish: pnpm run publish-packages
         env:
           GITHUB_TOKEN: ${{ steps.authenticate.outputs.token }}
+          NPM_CONFIG_PROVENANCE: true
           NEXT_PUBLIC_SWAP_CCTP_SPONSOR_ACCOUNT_PRIVATE_KEY: ${{ secrets.NEXT_PUBLIC_SWAP_CCTP_SPONSOR_ACCOUNT_PRIVATE_KEY }}
           NEXT_PUBLIC_SWAP_CCTP_MAIN_SIGNER_PRIVATE_KEY: ${{ secrets.NEXT_PUBLIC_SWAP_CCTP_MAIN_SIGNER_PRIVATE_KEY }}
           NEXT_PUBLIC_GAS_STATION_API_KEY: ${{ secrets.NEXT_PUBLIC_GAS_STATION_API_KEY }}


### PR DESCRIPTION
Fixes CI publish failures caused by npm's deprecation of classic access tokens.

Changes:
- Added `id-token: write` permission to the build job (required for npm OIDC authentication)
- Added `NPM_CONFIG_PROVENANCE: true` to enable provenance attestations
- Removed redundant workflow-level permissions