### PR TITLE
Cross chain initialization fix

### DIFF
--- a/.changeset/poor-brooms-camp.md
+++ b/.changeset/poor-brooms-camp.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/wallet-adapter-react": patch
+---
+
+Cross chain initialization fix

--- a/apps/nextjs-example/src/components/WalletSelector.tsx
+++ b/apps/nextjs-example/src/components/WalletSelector.tsx
@@ -191,7 +191,7 @@ function ConnectWalletDialog({
           {[...availableWallets, ...availableWalletsWithFallbacks].map(
             (wallet) => (
               <WalletRow key={wallet.name} wallet={wallet} onConnect={close} />
-            )
+            ),
           )}
           {!!installableWallets.length && (
             <Collapsible className="flex flex-col gap-3">

--- a/apps/nextjs-example/src/components/ui/button.tsx
+++ b/apps/nextjs-example/src/components/ui/button.tsx
@@ -34,7 +34,8 @@ const buttonVariants = cva(
 );
 
 export interface ButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+  extends
+    React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
   asChild?: boolean;
 }

--- a/apps/nextjs-x-chain/src/components/ui/button.tsx
+++ b/apps/nextjs-x-chain/src/components/ui/button.tsx
@@ -34,7 +34,8 @@ const buttonVariants = cva(
 );
 
 export interface ButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+  extends
+    React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
   asChild?: boolean;
 }

--- a/packages/cross-chain-core/src/providers/wormhole/signers/AptosLocalSigner.ts
+++ b/packages/cross-chain-core/src/providers/wormhole/signers/AptosLocalSigner.ts
@@ -20,9 +20,10 @@ import {
 } from "@wormhole-foundation/sdk-aptos";
 import { GasStationApiKey } from "../types";
 
-export class AptosLocalSigner<N extends Network, C extends Chain>
-  implements SignAndSendSigner<N, C>
-{
+export class AptosLocalSigner<
+  N extends Network,
+  C extends Chain,
+> implements SignAndSendSigner<N, C> {
   _chain: C;
   _options: any;
   _wallet: Account;

--- a/packages/cross-chain-core/src/providers/wormhole/signers/Signer.ts
+++ b/packages/cross-chain-core/src/providers/wormhole/signers/Signer.ts
@@ -27,9 +27,10 @@ import { AptosChains } from "@wormhole-foundation/sdk-aptos/dist/cjs/types";
 import { AptosUnsignedTransaction } from "@wormhole-foundation/sdk-aptos/dist/cjs/unsignedTransaction";
 import { GasStationApiKey } from "../types";
 import { Account } from "@aptos-labs/ts-sdk";
-export class Signer<N extends Network, C extends Chain>
-  implements SignAndSendSigner<N, C>
-{
+export class Signer<
+  N extends Network,
+  C extends Chain,
+> implements SignAndSendSigner<N, C> {
   _chain: ChainConfig;
   _address: string;
   _options: any;

--- a/packages/cross-chain-core/src/providers/wormhole/wormhole.ts
+++ b/packages/cross-chain-core/src/providers/wormhole/wormhole.ts
@@ -37,17 +37,14 @@ import {
 import { SolanaDerivedWallet } from "@aptos-labs/derived-wallet-solana";
 import { EIP1193DerivedWallet } from "@aptos-labs/derived-wallet-ethereum";
 
-export class WormholeProvider
-  implements
-    CrossChainProvider<
-      WormholeQuoteRequest,
-      WormholeQuoteResponse,
-      WormholeTransferRequest,
-      WormholeTransferResponse,
-      WormholeWithdrawRequest,
-      WormholeWithdrawResponse
-    >
-{
+export class WormholeProvider implements CrossChainProvider<
+  WormholeQuoteRequest,
+  WormholeQuoteResponse,
+  WormholeTransferRequest,
+  WormholeTransferResponse,
+  WormholeWithdrawRequest,
+  WormholeWithdrawResponse
+> {
   private crossChainCore: CrossChainCore;
 
   private _wormholeContext: Wormhole<"Mainnet" | "Testnet"> | undefined;

--- a/packages/derived-wallet-solana/src/signAptosMessage.ts
+++ b/packages/derived-wallet-solana/src/signAptosMessage.ts
@@ -10,8 +10,7 @@ import { StandardWalletAdapter as SolanaWalletAdapter } from "@solana/wallet-sta
 import { wrapSolanaUserResponse } from "./shared";
 import { SolanaDerivedPublicKey } from "./SolanaDerivedPublicKey";
 
-export interface StructuredMessageInputWithChainId
-  extends StructuredMessageInput {
+export interface StructuredMessageInputWithChainId extends StructuredMessageInput {
   chainId?: number;
 }
 

--- a/packages/wallet-adapter-core/src/utils/walletSelector.ts
+++ b/packages/wallet-adapter-core/src/utils/walletSelector.ts
@@ -16,8 +16,8 @@ import { isRedirectable } from "./helpers";
 export function partitionWallets(
   wallets: ReadonlyArray<AdapterWallet | AdapterNotDetectedWallet>,
   partitionFunction: (
-    wallet: AdapterWallet | AdapterNotDetectedWallet
-  ) => boolean = isInstalledOrLoadable
+    wallet: AdapterWallet | AdapterNotDetectedWallet,
+  ) => boolean = isInstalledOrLoadable,
 ) {
   const defaultWallets: Array<AdapterWallet> = [];
   const moreWallets: Array<AdapterNotDetectedWallet> = [];
@@ -35,7 +35,7 @@ export function partitionWallets(
 
 /** Returns true if the wallet is installed or loadable. */
 export function isInstalledOrLoadable(
-  wallet: AdapterWallet | AdapterNotDetectedWallet
+  wallet: AdapterWallet | AdapterNotDetectedWallet,
 ): wallet is AdapterWallet {
   return wallet.readyState === WalletReadyState.Installed;
 }
@@ -45,7 +45,7 @@ export function isInstalledOrLoadable(
  * This can be used to decide whether to show a "Connect" button or "Install" link in the UI.
  */
 export function isInstallRequired(
-  wallet: AdapterWallet | AdapterNotDetectedWallet
+  wallet: AdapterWallet | AdapterNotDetectedWallet,
 ) {
   const isWalletReady = isInstalledOrLoadable(wallet);
   const isMobile = !isWalletReady && isRedirectable();
@@ -54,7 +54,7 @@ export function isInstallRequired(
 }
 
 export function shouldUseFallbackWallet(
-  wallet: AdapterWallet | AdapterNotDetectedWallet
+  wallet: AdapterWallet | AdapterNotDetectedWallet,
 ): boolean {
   return (
     !!wallet.fallbackWallet &&
@@ -81,7 +81,7 @@ export function isAptosConnectWallet(wallet: WalletInfo | AdapterWallet) {
 /** Returns `true` if the provided wallet is a Petra Web wallet. This will automatically exclude the generic wallet. */
 export function isPetraWebWallet(
   wallet: WalletInfo | AdapterWallet,
-  ignoreGenericWallet: boolean = true
+  ignoreGenericWallet: boolean = true,
 ) {
   if (!wallet.url) return false;
   if (ignoreGenericWallet && isPetraWebGenericWallet(wallet)) {
@@ -95,7 +95,7 @@ export function isPetraWebWallet(
 
 /** Returns true if the wallet is a generic wallet. */
 export function isPetraWebGenericWallet(
-  wallet: AdapterWallet | AdapterNotDetectedWallet | WalletInfo
+  wallet: AdapterWallet | AdapterNotDetectedWallet | WalletInfo,
 ) {
   return wallet.name === PETRA_WEB_GENERIC_WALLET_NAME;
 }
@@ -107,11 +107,11 @@ export function isPetraWebGenericWallet(
  * @deprecated Use {@link getPetraWebWallets} instead.
  */
 export function getAptosConnectWallets(
-  wallets: ReadonlyArray<AdapterWallet | AdapterNotDetectedWallet>
+  wallets: ReadonlyArray<AdapterWallet | AdapterNotDetectedWallet>,
 ) {
   const { defaultWallets, moreWallets } = partitionWallets(
     wallets,
-    isAptosConnectWallet
+    isAptosConnectWallet,
   );
   return {
     aptosConnectWallets: defaultWallets,
@@ -124,11 +124,11 @@ export function getAptosConnectWallets(
  * Petra Web is a web wallet that uses social login to create accounts on the blockchain.
  */
 export function getPetraWebWallets(
-  wallets: ReadonlyArray<AdapterWallet | AdapterNotDetectedWallet>
+  wallets: ReadonlyArray<AdapterWallet | AdapterNotDetectedWallet>,
 ) {
   const { defaultWallets, moreWallets } = partitionWallets(
     wallets,
-    isPetraWebWallet
+    isPetraWebWallet,
   );
   return {
     petraWebWallets: defaultWallets,
@@ -148,12 +148,12 @@ export interface WalletSortingOptions {
   /** An optional function for sorting wallets that are currently installed or loadable. */
   sortAvailableWallets?: (
     a: AdapterWallet | AdapterNotDetectedWallet,
-    b: AdapterWallet | AdapterNotDetectedWallet
+    b: AdapterWallet | AdapterNotDetectedWallet,
   ) => number;
   /** An optional function for sorting wallets that are NOT currently installed or loadable. */
   sortInstallableWallets?: (
     a: AdapterWallet | AdapterNotDetectedWallet,
-    b: AdapterWallet | AdapterNotDetectedWallet
+    b: AdapterWallet | AdapterNotDetectedWallet,
   ) => number;
   /**
    * A map of wallet names to fallback wallet names.
@@ -194,7 +194,7 @@ export interface WalletSortingOptions {
  */
 export function groupAndSortWallets(
   wallets: ReadonlyArray<AdapterWallet | AdapterNotDetectedWallet>,
-  options?: WalletSortingOptions
+  options?: WalletSortingOptions,
 ) {
   const {
     fallbacks: {

--- a/packages/wallet-adapter-mui-design/src/WalletModel.tsx
+++ b/packages/wallet-adapter-mui-design/src/WalletModel.tsx
@@ -38,7 +38,8 @@ import { SyntheticEvent, useState } from "react";
 import { WalletConnectorProps } from "./types";
 
 interface WalletsModalProps
-  extends Pick<WalletConnectorProps, "networkSupport" | "modalMaxWidth">,
+  extends
+    Pick<WalletConnectorProps, "networkSupport" | "modalMaxWidth">,
     WalletSortingOptions {
   handleClose: () => void;
   modalOpen: boolean;

--- a/packages/wallet-adapter-react/src/WalletProvider.tsx
+++ b/packages/wallet-adapter-react/src/WalletProvider.tsx
@@ -156,10 +156,6 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
     // Initialize cross-chain wallet support based on dappConfig flags.
     // Dynamically imports the packages to avoid bundling them when not used.
     if (!derivationInitialized.current) {
-      // Use a wrapper function to prevent bundlers from statically analyzing the import
-      const dynamicImport = (moduleName: string) =>
-        new Function("m", "return import(m)")(moduleName) as Promise<any>;
-
       if (dappConfig?.crossChainWallets?.solana) {
         import("@aptos-labs/derived-wallet-solana").then(
           ({ setupAutomaticSolanaWalletDerivation }) => {
@@ -170,7 +166,7 @@ export const AptosWalletAdapterProvider: FC<AptosWalletProviderProps> = ({
         );
       }
       if (dappConfig?.crossChainWallets?.evm) {
-        dynamicImport("@aptos-labs/derived-wallet-ethereum").then(
+        import("@aptos-labs/derived-wallet-ethereum").then(
           ({ setupAutomaticEthereumWalletDerivation }) => {
             setupAutomaticEthereumWalletDerivation({
               defaultNetwork: dappConfig?.network,

--- a/packages/wallet-adapter-react/src/components/WalletItem.tsx
+++ b/packages/wallet-adapter-react/src/components/WalletItem.tsx
@@ -61,7 +61,7 @@ const Root = forwardRef<HTMLDivElement, WalletItemProps>(
         </Component>
       </WalletItemContext.Provider>
     );
-  }
+  },
 );
 Root.displayName = "WalletItem";
 
@@ -75,7 +75,7 @@ const Icon = createHeadlessComponent(
       src: context.wallet.icon,
       alt: `${context.wallet.name} icon`,
     };
-  }
+  },
 );
 
 const Name = createHeadlessComponent(
@@ -87,7 +87,7 @@ const Name = createHeadlessComponent(
     return {
       children: context.wallet.name,
     };
-  }
+  },
 );
 
 const ConnectButton = createHeadlessComponent(
@@ -100,7 +100,7 @@ const ConnectButton = createHeadlessComponent(
       onClick: context.connectWallet,
       children: "Connect",
     };
-  }
+  },
 );
 
 const InstallLink = createHeadlessComponent(
@@ -115,7 +115,7 @@ const InstallLink = createHeadlessComponent(
       rel: "noopener noreferrer",
       children: "Install",
     };
-  }
+  },
 );
 
 /** A headless component for rendering a wallet option's name, icon, and either connect button or install link. */


### PR DESCRIPTION
PR https://github.com/aptos-labs/aptos-wallet-adapter/pull/693 introduced a new way to initialize cross chain wallets and was recently released with a bug. It imports the `eth` package using an dynamic import instead of regular import.
This PR fixes it

https://github.com/aptos-labs/aptos-wallet-adapter/pull/696/files#diff-976f6ce28f5861155298dbb0cfae197c7ba5f62c12fb8d6c51f603841b8bbcfdL173