### PR TITLE
Fix npm OIDC Trusted Publishers for CI Publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,9 @@ jobs:
           node-version-file: .node-version
           registry-url: "https://registry.npmjs.org"
 
+      - name: Upgrade npm for OIDC support
+        run: npm install -g npm@latest
+
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         id: pnpm-install

--- a/packages/derived-wallet-base/package.json
+++ b/packages/derived-wallet-base/package.json
@@ -5,6 +5,10 @@
   "module": "./dist/index.mjs",
   "types": "./dist/types/index.d.ts",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/aptos-labs/aptos-wallet-adapter.git"
+  },
   "exports": {
     "types": "./dist/types/index.d.ts",
     "require": "./dist/index.js",

--- a/packages/derived-wallet-ethereum/package.json
+++ b/packages/derived-wallet-ethereum/package.json
@@ -5,6 +5,10 @@
   "module": "./dist/index.mjs",
   "types": "./dist/types/index.d.ts",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/aptos-labs/aptos-wallet-adapter.git"
+  },
   "exports": {
     "types": "./dist/types/index.d.ts",
     "require": "./dist/index.js",

--- a/packages/derived-wallet-solana/package.json
+++ b/packages/derived-wallet-solana/package.json
@@ -5,6 +5,10 @@
   "module": "./dist/index.mjs",
   "types": "./dist/types/index.d.ts",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/aptos-labs/aptos-wallet-adapter.git"
+  },
   "exports": {
     "types": "./dist/types/index.d.ts",
     "require": "./dist/index.js",


### PR DESCRIPTION
Fixes the npm publishing failures in GitHub Actions by properly configuring OIDC trusted publishers support.

### Problem

The release workflow was failing with `Access token expired or revoked` errors when trying to publish packages to npm using OIDC trusted publishers.

### Root Cause

Node.js 20.14.0 ships with npm 10.x, but **npm OIDC trusted publishers require npm CLI version 11.5.1 or later** ([npm docs](https://docs.npmjs.com/trusted-publishers/)).

Additionally, some packages were missing the `repository` field in their `package.json`, which is required for provenance validation ([source](https://codango.com/from-deprecated-npm-classic-tokens-to-oidc-trusted-publishing-a-ci-cd-troubleshooting-journey/)).

### Changes

**Workflow (`release.yml`):**
- Added step to upgrade npm to latest version for OIDC support
- Restored `registry-url` configuration

**Package.json updates:**
- Added `repository` field to `@aptos-labs/derived-wallet-solana`
- Added `repository` field to `@aptos-labs/derived-wallet-ethereum`
- Added `repository` field to `@aptos-labs/derived-wallet-base`

### References

- [npm Trusted Publishers Documentation](https://docs.npmjs.com/trusted-publishers/)
- [GitHub OIDC Configuration](https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/configuring-openid-connect-in-cloud-providers)
- [npm Trusted Publishing Guide](https://remarkablemark.org/blog/2025/12/19/npm-trusted-publishing/)