### PR TITLE
fix: use checksum address when derving aptos account from ethreum add…

### DIFF
--- a/packages/derived-wallet-ethereum/src/EIP1193DerivedPublicKey.ts
+++ b/packages/derived-wallet-ethereum/src/EIP1193DerivedPublicKey.ts
@@ -23,6 +23,7 @@ import {
   EIP1193PersonalSignature,
 } from "./EIP1193DerivedSignature";
 import { EthereumAddress } from "./shared";
+import { checksumAddress } from "viem";
 
 export interface EIP1193DerivedPublicKeyParams {
   domain: string;
@@ -44,12 +45,12 @@ export class EIP1193DerivedPublicKey extends AccountPublicKey {
   }: EIP1193DerivedPublicKeyParams) {
     super();
     this.domain = domain;
-    this.ethereumAddress = ethereumAddress;
+    this.ethereumAddress = checksumAddress(ethereumAddress);
     this.authenticationFunction = authenticationFunction;
 
     this._authKey = computeDerivableAuthenticationKey(
       authenticationFunction,
-      ethereumAddress,
+      this.ethereumAddress,
       domain,
     );
   }


### PR DESCRIPTION
when the account changed event was fired on EIP1193, it didnt returned a checksummed address so on account change, the derived aptos wallet was wrong, this fixes it and uses checksum address always