### PR TITLE
fix(derived-wallet-ethereum): Fix account change detection for EVM wallets

### DIFF
--- a/.changeset/happy-papers-report.md
+++ b/.changeset/happy-papers-report.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/derived-wallet-ethereum": patch
+---
+
+Fix account change detection for EVM wallets

--- a/apps/nextjs-x-chain/src/app/page.tsx
+++ b/apps/nextjs-x-chain/src/app/page.tsx
@@ -93,7 +93,7 @@ export default function Home() {
       setOriginWalletDetails(details);
     };
     void fetchOriginWalletDetails();
-  }, [wallet]);
+  }, [wallet, account]);
 
   return (
     <main className="flex flex-col w-full md:w-1/2 p-6 pb-12 md:px-8 gap-6">

--- a/packages/derived-wallet-ethereum/src/EIP1193DerivedWallet.ts
+++ b/packages/derived-wallet-ethereum/src/EIP1193DerivedWallet.ts
@@ -168,15 +168,15 @@ export class EIP1193DerivedWallet implements AptosWallet {
       }
       this.onAccountsChangedListeners = [];
     } else {
-      const listener = ([ethereumAddress]: EthereumAddress[]) => {
-        if (!ethereumAddress) {
+      // Query the active account directly to ensure we get the currently selected account
+      const listener = async () => {
+        try {
+          const account = await this.getActiveAccount();
+          callback(account);
+        } catch {
+          // No account connected (user disconnected all accounts)
           callback(undefined as any as AccountInfo);
-          return;
         }
-        const publicKey = this.derivePublicKey(ethereumAddress);
-        const aptosAddress = publicKey.authKey().derivedAddress();
-        const account = new AccountInfo({ publicKey, address: aptosAddress });
-        callback(account);
       };
       this.onAccountsChangedListeners.push(listener);
       this.eip1193Provider.on("accountsChanged", listener);


### PR DESCRIPTION
## Summary

Fixes an issue where switching accounts in MetaMask (or other EVM wallets) would result in incorrect derived Aptos addresses, causing transaction failures.

## Problem

When switching accounts within MetaMask, the `accountsChanged` event returns an array of all authorized accounts. The previous implementation assumed the first element was the newly selected account, but the array order is not guaranteed to reflect the currently active account. This caused:

1. Incorrect derived Aptos address
2. Transaction signing failures due to address mismatch

## Solution

- **`EIP1193DerivedWallet.ts`**: Changed `onActiveAccountChange` to query the active account directly via `getActiveAccount()` instead of relying on the event's accounts array order
- **`page.tsx`** (nextjs-x-chain): Added `account` to the useEffect dependency array so `originWalletDetails` updates when the account changes

## Testing

- [x] Connect with Account 1 → sign and submit transaction ✅
- [x] Switch to Account 2 → sign and submit transaction ✅  
- [x] Switch back to Account 1 → sign and submit transaction ✅
- [x] Disconnect and reconnect → sign and submit transaction ✅