### PR TITLE
feat(derived-wallet-ethereum): add Vitest tests

### DIFF
--- a/packages/derived-wallet-ethereum/package.json
+++ b/packages/derived-wallet-ethereum/package.json
@@ -20,7 +20,7 @@
     "build:bundle": "tsup --sourcemap",
     "build:declarations": "tsc --emitDeclarationOnly --declaration --declarationMap",
     "dev": "tsup src/index.ts --format esm,cjs --watch",
-    "test": "jest",
+    "test": "vitest run",
     "lint": "TIMING=1 eslint \"src/**/*.ts*\""
   },
   "tsup": {
@@ -46,18 +46,15 @@
   "devDependencies": {
     "@aptos-labs/eslint-config-adapter": "workspace:*",
     "@aptos-labs/wallet-adapter-tsconfig": "workspace:*",
-    "@types/jest": "^29.2.4",
     "@types/node": "^20.10.4",
     "eslint": "^8.57.1",
-    "jest": "^29.3.1",
-    "ts-jest": "^29.0.3",
+    "happy-dom": "^15.11.7",
     "tsup": "^8.4.0",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "vitest": "^2.1.8"
   },
   "files": [
     "dist",
-    "src",
-    "!src/**.test.ts",
-    "!src/**/__tests__"
+    "src"
   ]
 }

--- a/packages/derived-wallet-ethereum/tests/EIP1193DerivedAccount.test.ts
+++ b/packages/derived-wallet-ethereum/tests/EIP1193DerivedAccount.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect } from "vitest";
+import { Wallet } from "ethers";
+import { AbstractedAccount } from "@aptos-labs/ts-sdk";
+import { EIP1193DerivedAccount } from "../src/EIP1193DerivedAccount";
+import { EIP1193DerivedPublicKey } from "../src/EIP1193DerivedPublicKey";
+import { defaultEthereumAuthenticationFunction } from "../src/shared";
+import { TEST_PRIVATE_KEY, TEST_ETHEREUM_ADDRESS } from "./mocks/eip1193Provider";
+
+describe("EIP1193DerivedAccount", () => {
+  const testDomain = "test.example.com";
+
+  describe("constructor", () => {
+    it("should create account from ethereum wallet", () => {
+      const ethereumWallet = new Wallet(TEST_PRIVATE_KEY);
+
+      const account = new EIP1193DerivedAccount({
+        ethereumWallet,
+        domain: testDomain,
+      });
+
+      expect(account).toBeDefined();
+      expect(account).toBeInstanceOf(AbstractedAccount);
+    });
+
+    it("should store ethereum wallet", () => {
+      const ethereumWallet = new Wallet(TEST_PRIVATE_KEY);
+
+      const account = new EIP1193DerivedAccount({
+        ethereumWallet,
+        domain: testDomain,
+      });
+
+      expect(account.ethereumWallet).toBe(ethereumWallet);
+    });
+
+    it("should store domain", () => {
+      const ethereumWallet = new Wallet(TEST_PRIVATE_KEY);
+
+      const account = new EIP1193DerivedAccount({
+        ethereumWallet,
+        domain: testDomain,
+      });
+
+      expect(account.domain).toBe(testDomain);
+    });
+
+    it("should default scheme to https", () => {
+      const ethereumWallet = new Wallet(TEST_PRIVATE_KEY);
+
+      const account = new EIP1193DerivedAccount({
+        ethereumWallet,
+        domain: testDomain,
+      });
+
+      expect(account.scheme).toBe("https");
+    });
+
+    it("should allow custom scheme", () => {
+      const ethereumWallet = new Wallet(TEST_PRIVATE_KEY);
+
+      const account = new EIP1193DerivedAccount({
+        ethereumWallet,
+        domain: testDomain,
+        scheme: "http",
+      });
+
+      expect(account.scheme).toBe("http");
+    });
+
+    it("should default to ethereum authentication function", () => {
+      const ethereumWallet = new Wallet(TEST_PRIVATE_KEY);
+
+      const account = new EIP1193DerivedAccount({
+        ethereumWallet,
+        domain: testDomain,
+      });
+
+      expect(account.authenticationFunction).toBe(
+        defaultEthereumAuthenticationFunction
+      );
+    });
+
+    it("should allow custom authentication function", () => {
+      const ethereumWallet = new Wallet(TEST_PRIVATE_KEY);
+      const customAuthFunction = "0x1::custom::authenticate";
+
+      const account = new EIP1193DerivedAccount({
+        ethereumWallet,
+        domain: testDomain,
+        authenticationFunction: customAuthFunction,
+      });
+
+      expect(account.authenticationFunction).toBe(customAuthFunction);
+    });
+
+    it("should create derived public key", () => {
+      const ethereumWallet = new Wallet(TEST_PRIVATE_KEY);
+
+      const account = new EIP1193DerivedAccount({
+        ethereumWallet,
+        domain: testDomain,
+      });
+
+      expect(account.derivedPublicKey).toBeInstanceOf(EIP1193DerivedPublicKey);
+      expect(account.derivedPublicKey.domain).toBe(testDomain);
+      expect(account.derivedPublicKey.ethereumAddress.toLowerCase()).toBe(
+        TEST_ETHEREUM_ADDRESS.toLowerCase()
+      );
+    });
+  });
+
+  describe("accountAddress", () => {
+    it("should derive Aptos address from ethereum address and domain", () => {
+      const ethereumWallet = new Wallet(TEST_PRIVATE_KEY);
+
+      const account = new EIP1193DerivedAccount({
+        ethereumWallet,
+        domain: testDomain,
+      });
+
+      // Should be a valid 32-byte Aptos address
+      expect(account.accountAddress.toString()).toMatch(/^0x[a-f0-9]{64}$/i);
+    });
+
+    it("should produce consistent addresses for same inputs", () => {
+      const ethereumWallet = new Wallet(TEST_PRIVATE_KEY);
+
+      const account1 = new EIP1193DerivedAccount({
+        ethereumWallet,
+        domain: testDomain,
+      });
+
+      const account2 = new EIP1193DerivedAccount({
+        ethereumWallet,
+        domain: testDomain,
+      });
+
+      expect(account1.accountAddress.toString()).toBe(
+        account2.accountAddress.toString()
+      );
+    });
+
+    it("should produce different addresses for different domains", () => {
+      const ethereumWallet = new Wallet(TEST_PRIVATE_KEY);
+
+      const account1 = new EIP1193DerivedAccount({
+        ethereumWallet,
+        domain: "domain1.com",
+      });
+
+      const account2 = new EIP1193DerivedAccount({
+        ethereumWallet,
+        domain: "domain2.com",
+      });
+
+      expect(account1.accountAddress.toString()).not.toBe(
+        account2.accountAddress.toString()
+      );
+    });
+
+    it("should produce different addresses for different ethereum wallets", () => {
+      const wallet1 = new Wallet(TEST_PRIVATE_KEY);
+      const wallet2 = new Wallet(
+        "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
+      );
+
+      const account1 = new EIP1193DerivedAccount({
+        ethereumWallet: wallet1,
+        domain: testDomain,
+      });
+
+      const account2 = new EIP1193DerivedAccount({
+        ethereumWallet: wallet2,
+        domain: testDomain,
+      });
+
+      expect(account1.accountAddress.toString()).not.toBe(
+        account2.accountAddress.toString()
+      );
+    });
+
+    it("should derive deterministic address for known inputs", () => {
+      const ethereumWallet = new Wallet(TEST_PRIVATE_KEY);
+
+      const account = new EIP1193DerivedAccount({
+        ethereumWallet,
+        domain: "test.example.com",
+      });
+
+      // This is the expected derived address for the test private key and domain
+      expect(account.accountAddress.toString()).toBe(
+        "0xb5de999e1865abd8503ffa88f58159f7540d1fd8427786a8df14c9d60577c9b5"
+      );
+    });
+  });
+
+  // Note: signTransactionWithAuthenticator tests require network access
+  // to build transactions. These are tested via integration tests.
+});
+

--- a/packages/derived-wallet-ethereum/tests/EIP1193DerivedPublicKey.test.ts
+++ b/packages/derived-wallet-ethereum/tests/EIP1193DerivedPublicKey.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect } from "vitest";
+import { Deserializer, Serializer } from "@aptos-labs/ts-sdk";
+import { EIP1193DerivedPublicKey } from "../src/EIP1193DerivedPublicKey";
+import { defaultEthereumAuthenticationFunction } from "../src/shared";
+import type { EthereumAddress } from "../src/shared";
+
+describe("EIP1193DerivedPublicKey", () => {
+  // Test Ethereum address (20 bytes)
+  const testEthereumAddress: EthereumAddress =
+    "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
+  const testDomain = "test.example.com";
+  const testAuthFunction = defaultEthereumAuthenticationFunction;
+
+  describe("constructor", () => {
+    it("should store domain, ethereumAddress, and authenticationFunction", () => {
+      const pubKey = new EIP1193DerivedPublicKey({
+        domain: testDomain,
+        ethereumAddress: testEthereumAddress,
+        authenticationFunction: testAuthFunction,
+      });
+
+      expect(pubKey.domain).toBe(testDomain);
+      expect(pubKey.ethereumAddress).toBe(testEthereumAddress);
+      expect(pubKey.authenticationFunction).toBe(testAuthFunction);
+    });
+
+    it("should work with different domains", () => {
+      const pubKey1 = new EIP1193DerivedPublicKey({
+        domain: "app1.com",
+        ethereumAddress: testEthereumAddress,
+        authenticationFunction: testAuthFunction,
+      });
+
+      const pubKey2 = new EIP1193DerivedPublicKey({
+        domain: "app2.com",
+        ethereumAddress: testEthereumAddress,
+        authenticationFunction: testAuthFunction,
+      });
+
+      expect(pubKey1.domain).toBe("app1.com");
+      expect(pubKey2.domain).toBe("app2.com");
+    });
+  });
+
+  describe("authKey", () => {
+    it("should return an AuthenticationKey", () => {
+      const pubKey = new EIP1193DerivedPublicKey({
+        domain: testDomain,
+        ethereumAddress: testEthereumAddress,
+        authenticationFunction: testAuthFunction,
+      });
+
+      const authKey = pubKey.authKey();
+
+      expect(authKey).toBeDefined();
+      // AuthenticationKey can derive an address
+      const address = authKey.derivedAddress();
+      expect(address.toString()).toMatch(/^0x[a-f0-9]{64}$/i);
+    });
+
+    it("should produce consistent authentication key for same inputs", () => {
+      const pubKey1 = new EIP1193DerivedPublicKey({
+        domain: testDomain,
+        ethereumAddress: testEthereumAddress,
+        authenticationFunction: testAuthFunction,
+      });
+
+      const pubKey2 = new EIP1193DerivedPublicKey({
+        domain: testDomain,
+        ethereumAddress: testEthereumAddress,
+        authenticationFunction: testAuthFunction,
+      });
+
+      expect(pubKey1.authKey().data).toEqual(pubKey2.authKey().data);
+    });
+
+    it("should produce different auth keys for different ethereum addresses", () => {
+      const pubKey1 = new EIP1193DerivedPublicKey({
+        domain: testDomain,
+        ethereumAddress: "0x1111111111111111111111111111111111111111",
+        authenticationFunction: testAuthFunction,
+      });
+
+      const pubKey2 = new EIP1193DerivedPublicKey({
+        domain: testDomain,
+        ethereumAddress: "0x2222222222222222222222222222222222222222",
+        authenticationFunction: testAuthFunction,
+      });
+
+      expect(pubKey1.authKey().data).not.toEqual(pubKey2.authKey().data);
+    });
+
+    it("should produce different auth keys for different domains", () => {
+      const pubKey1 = new EIP1193DerivedPublicKey({
+        domain: "domain1.com",
+        ethereumAddress: testEthereumAddress,
+        authenticationFunction: testAuthFunction,
+      });
+
+      const pubKey2 = new EIP1193DerivedPublicKey({
+        domain: "domain2.com",
+        ethereumAddress: testEthereumAddress,
+        authenticationFunction: testAuthFunction,
+      });
+
+      expect(pubKey1.authKey().data).not.toEqual(pubKey2.authKey().data);
+    });
+
+    it("should derive a valid Aptos address", () => {
+      const pubKey = new EIP1193DerivedPublicKey({
+        domain: testDomain,
+        ethereumAddress: testEthereumAddress,
+        authenticationFunction: testAuthFunction,
+      });
+
+      const address = pubKey.authKey().derivedAddress();
+
+      // Aptos addresses are 32 bytes (64 hex chars + 0x prefix)
+      expect(address.toString()).toMatch(/^0x[a-f0-9]{64}$/i);
+    });
+
+    it("should produce deterministic derived address", () => {
+      const pubKey = new EIP1193DerivedPublicKey({
+        domain: "test.example.com",
+        ethereumAddress: "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
+        authenticationFunction:
+          "0x1::ethereum_derivable_account::authenticate",
+      });
+
+      const address = pubKey.authKey().derivedAddress();
+      // This is deterministic based on the inputs
+      expect(address.toString()).toBe(
+        "0xb5de999e1865abd8503ffa88f58159f7540d1fd8427786a8df14c9d60577c9b5"
+      );
+    });
+  });
+
+  describe("serialization", () => {
+    it("should serialize correctly", () => {
+      const pubKey = new EIP1193DerivedPublicKey({
+        domain: testDomain,
+        ethereumAddress: testEthereumAddress,
+        authenticationFunction: testAuthFunction,
+      });
+
+      const serializer = new Serializer();
+      pubKey.serialize(serializer);
+
+      const bytes = serializer.toUint8Array();
+      expect(bytes.length).toBeGreaterThan(0);
+    });
+
+    it("should serialize and deserialize roundtrip", () => {
+      const original = new EIP1193DerivedPublicKey({
+        domain: testDomain,
+        ethereumAddress: testEthereumAddress,
+        authenticationFunction: testAuthFunction,
+      });
+
+      // Serialize
+      const serializer = new Serializer();
+      original.serialize(serializer);
+      const bytes = serializer.toUint8Array();
+
+      // Deserialize
+      const deserializer = new Deserializer(bytes);
+      const deserialized = EIP1193DerivedPublicKey.deserialize(deserializer);
+
+      expect(deserialized.domain).toBe(original.domain);
+      expect(deserialized.ethereumAddress.toLowerCase()).toBe(
+        original.ethereumAddress.toLowerCase()
+      );
+      expect(deserialized.authenticationFunction).toBe(
+        original.authenticationFunction
+      );
+    });
+
+    it("should preserve auth key through serialization", () => {
+      // Use lowercase address to ensure consistency after deserialization
+      // (deserialization returns lowercase address from Hex)
+      const lowercaseAddress = testEthereumAddress.toLowerCase() as EthereumAddress;
+      const original = new EIP1193DerivedPublicKey({
+        domain: testDomain,
+        ethereumAddress: lowercaseAddress,
+        authenticationFunction: testAuthFunction,
+      });
+
+      const serializer = new Serializer();
+      original.serialize(serializer);
+      const bytes = serializer.toUint8Array();
+
+      const deserializer = new Deserializer(bytes);
+      const deserialized = EIP1193DerivedPublicKey.deserialize(deserializer);
+
+      // Compare derived addresses (which are deterministic)
+      expect(deserialized.authKey().derivedAddress().toString()).toBe(
+        original.authKey().derivedAddress().toString()
+      );
+    });
+  });
+
+  describe("isInstance", () => {
+    it("should return true for EIP1193DerivedPublicKey instances", () => {
+      const pubKey = new EIP1193DerivedPublicKey({
+        domain: testDomain,
+        ethereumAddress: testEthereumAddress,
+        authenticationFunction: testAuthFunction,
+      });
+
+      expect(EIP1193DerivedPublicKey.isInstance(pubKey)).toBe(true);
+    });
+
+    it("should return false for objects missing required properties", () => {
+      const fakePubKey = {
+        domain: testDomain,
+        // Missing ethereumAddress and authenticationFunction
+      };
+
+      expect(
+        EIP1193DerivedPublicKey.isInstance(fakePubKey as any)
+      ).toBe(false);
+    });
+
+    it("should return false for objects with only some properties", () => {
+      const partialPubKey = {
+        domain: testDomain,
+        ethereumAddress: testEthereumAddress,
+        // Missing authenticationFunction
+      };
+
+      expect(
+        EIP1193DerivedPublicKey.isInstance(partialPubKey as any)
+      ).toBe(false);
+    });
+  });
+});
+

--- a/packages/derived-wallet-ethereum/tests/EIP1193DerivedSignature.test.ts
+++ b/packages/derived-wallet-ethereum/tests/EIP1193DerivedSignature.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect } from "vitest";
+import { Deserializer, Serializer } from "@aptos-labs/ts-sdk";
+import {
+  EIP1193PersonalSignature,
+  EIP1193SiweSignature,
+} from "../src/EIP1193DerivedSignature";
+
+describe("EIP1193DerivedSignature", () => {
+  // Example 65-byte Ethereum signature
+  const testSignatureHex =
+    "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef12";
+
+  describe("EIP1193PersonalSignature", () => {
+    it("should have LENGTH constant of 65", () => {
+      expect(EIP1193PersonalSignature.LENGTH).toBe(65);
+    });
+
+    it("should construct from hex string", () => {
+      const signature = new EIP1193PersonalSignature(testSignatureHex);
+      expect(signature.siweSignature).toBe(testSignatureHex);
+    });
+
+    it("should construct from Uint8Array", () => {
+      const bytes = new Uint8Array(65).fill(0xab);
+      const signature = new EIP1193PersonalSignature(bytes);
+
+      // The getter returns hex string
+      expect(signature.siweSignature).toMatch(/^0x[a-f0-9]+$/i);
+    });
+
+    it("should serialize correctly", () => {
+      const signature = new EIP1193PersonalSignature(testSignatureHex);
+      const serializer = new Serializer();
+      signature.serialize(serializer);
+
+      const bytes = serializer.toUint8Array();
+      expect(bytes.length).toBeGreaterThan(0);
+    });
+
+    it("should serialize and deserialize roundtrip", () => {
+      const original = new EIP1193PersonalSignature(testSignatureHex);
+
+      // Serialize
+      const serializer = new Serializer();
+      original.serialize(serializer);
+      const bytes = serializer.toUint8Array();
+
+      // Deserialize
+      const deserializer = new Deserializer(bytes);
+      const deserialized = EIP1193PersonalSignature.deserialize(deserializer);
+
+      expect(deserialized.siweSignature).toBe(original.siweSignature);
+    });
+
+    it("should handle different hex formats", () => {
+      // With 0x prefix
+      const sig1 = new EIP1193PersonalSignature(testSignatureHex);
+      // Without 0x prefix
+      const sig2 = new EIP1193PersonalSignature(testSignatureHex.slice(2));
+
+      expect(sig1.siweSignature).toBe(sig2.siweSignature);
+    });
+  });
+
+  describe("EIP1193SiweSignature", () => {
+    const testScheme = "https";
+    const testIssuedAt = new Date("2024-01-15T12:00:00.000Z");
+
+    it("should construct with scheme, issuedAt, and signature", () => {
+      const signature = new EIP1193SiweSignature(
+        testScheme,
+        testIssuedAt,
+        testSignatureHex
+      );
+
+      expect(signature.scheme).toBe(testScheme);
+      expect(signature.issuedAt).toEqual(testIssuedAt);
+      expect(signature.siweSignature).toBe(testSignatureHex);
+    });
+
+    it("should serialize with scheme and issuedAt", () => {
+      const signature = new EIP1193SiweSignature(
+        testScheme,
+        testIssuedAt,
+        testSignatureHex
+      );
+
+      const serializer = new Serializer();
+      signature.serialize(serializer);
+
+      const bytes = serializer.toUint8Array();
+      expect(bytes.length).toBeGreaterThan(65); // Should include scheme and date strings
+    });
+
+    it("should serialize and deserialize roundtrip", () => {
+      const original = new EIP1193SiweSignature(
+        testScheme,
+        testIssuedAt,
+        testSignatureHex
+      );
+
+      // Serialize
+      const serializer = new Serializer();
+      original.serialize(serializer);
+      const bytes = serializer.toUint8Array();
+
+      // Deserialize
+      const deserializer = new Deserializer(bytes);
+      const deserialized = EIP1193SiweSignature.deserialize(deserializer);
+
+      expect(deserialized.scheme).toBe(original.scheme);
+      expect(deserialized.issuedAt.toISOString()).toBe(
+        original.issuedAt.toISOString()
+      );
+      expect(deserialized.siweSignature).toBe(original.siweSignature);
+    });
+
+    it("should handle different schemes", () => {
+      const httpSig = new EIP1193SiweSignature(
+        "http",
+        testIssuedAt,
+        testSignatureHex
+      );
+      const httpsSig = new EIP1193SiweSignature(
+        "https",
+        testIssuedAt,
+        testSignatureHex
+      );
+
+      expect(httpSig.scheme).toBe("http");
+      expect(httpsSig.scheme).toBe("https");
+    });
+
+    it("should preserve date precision through serialization", () => {
+      const preciseDate = new Date("2024-06-15T14:30:45.123Z");
+      const signature = new EIP1193SiweSignature(
+        testScheme,
+        preciseDate,
+        testSignatureHex
+      );
+
+      const serializer = new Serializer();
+      signature.serialize(serializer);
+      const bytes = serializer.toUint8Array();
+
+      const deserializer = new Deserializer(bytes);
+      const deserialized = EIP1193SiweSignature.deserialize(deserializer);
+
+      expect(deserialized.issuedAt.toISOString()).toBe(
+        preciseDate.toISOString()
+      );
+    });
+
+    it("should extend EIP1193PersonalSignature", () => {
+      const signature = new EIP1193SiweSignature(
+        testScheme,
+        testIssuedAt,
+        testSignatureHex
+      );
+
+      expect(signature).toBeInstanceOf(EIP1193PersonalSignature);
+    });
+  });
+});
+

--- a/packages/derived-wallet-ethereum/tests/EIP1193DerivedWallet.test.ts
+++ b/packages/derived-wallet-ethereum/tests/EIP1193DerivedWallet.test.ts
@@ -1,0 +1,320 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  AccountInfo,
+  APTOS_CHAINS,
+  UserResponseStatus,
+} from "@aptos-labs/wallet-standard";
+import {
+  Network,
+  NetworkToChainId,
+  NetworkToNodeAPI,
+} from "@aptos-labs/ts-sdk";
+import { EIP1193DerivedWallet } from "../src/EIP1193DerivedWallet";
+import { EIP1193DerivedPublicKey } from "../src/EIP1193DerivedPublicKey";
+import { defaultEthereumAuthenticationFunction } from "../src/shared";
+import {
+  createMockEIP6963ProviderDetail,
+  TEST_PRIVATE_KEY,
+  TEST_ETHEREUM_ADDRESS,
+} from "./mocks/eip1193Provider";
+
+describe("EIP1193DerivedWallet", () => {
+  let wallet: EIP1193DerivedWallet;
+  let providerDetail: ReturnType<typeof createMockEIP6963ProviderDetail>;
+
+  beforeEach(() => {
+    providerDetail = createMockEIP6963ProviderDetail({
+      privateKey: TEST_PRIVATE_KEY,
+      name: "Test Wallet",
+      rdns: "com.test.wallet",
+    });
+    wallet = new EIP1193DerivedWallet(providerDetail);
+  });
+
+  describe("constructor", () => {
+    it("should create wallet from EIP6963 provider detail", () => {
+      expect(wallet).toBeDefined();
+      expect(wallet).toBeInstanceOf(EIP1193DerivedWallet);
+    });
+
+    it("should set wallet name with (Ethereum) suffix", () => {
+      expect(wallet.name).toBe("Test Wallet (Ethereum)");
+    });
+
+    it("should set wallet icon from provider info", () => {
+      expect(wallet.icon).toBe(providerDetail.info.icon);
+    });
+
+    it("should set wallet url from provider rdns", () => {
+      expect(wallet.url).toBe("com.test.wallet");
+    });
+
+    it("should set version to 1.0.0", () => {
+      expect(wallet.version).toBe("1.0.0");
+    });
+
+    it("should set chains to APTOS_CHAINS", () => {
+      expect(wallet.chains).toBe(APTOS_CHAINS);
+    });
+
+    it("should default to MAINNET network", () => {
+      expect(wallet.defaultNetwork).toBe(Network.MAINNET);
+    });
+
+    it("should allow custom default network", () => {
+      const testnetWallet = new EIP1193DerivedWallet(providerDetail, {
+        defaultNetwork: Network.TESTNET,
+      });
+      expect(testnetWallet.defaultNetwork).toBe(Network.TESTNET);
+    });
+
+    it("should use default authentication function", () => {
+      expect(wallet.authenticationFunction).toBe(
+        defaultEthereumAuthenticationFunction
+      );
+    });
+
+    it("should allow custom authentication function", () => {
+      const customAuthFunction = "0x1::custom::authenticate";
+      const customWallet = new EIP1193DerivedWallet(providerDetail, {
+        authenticationFunction: customAuthFunction,
+      });
+      expect(customWallet.authenticationFunction).toBe(customAuthFunction);
+    });
+
+    it("should set domain from window.location.host", () => {
+      expect(wallet.domain).toBe("test.example.com");
+    });
+
+    it("should trim icon whitespace", () => {
+      const detailWithWhitespaceIcon = createMockEIP6963ProviderDetail({
+        privateKey: TEST_PRIVATE_KEY,
+        icon: "  \n  data:image/svg+xml,<svg></svg>  \n  ",
+      });
+      const walletWithTrimmedIcon = new EIP1193DerivedWallet(
+        detailWithWhitespaceIcon
+      );
+      expect(walletWithTrimmedIcon.icon).toBe("data:image/svg+xml,<svg></svg>");
+    });
+  });
+
+  describe("features", () => {
+    it("should have all required Aptos features", () => {
+      expect(wallet.features["aptos:connect"]).toBeDefined();
+      expect(wallet.features["aptos:disconnect"]).toBeDefined();
+      expect(wallet.features["aptos:account"]).toBeDefined();
+      expect(wallet.features["aptos:onAccountChange"]).toBeDefined();
+      expect(wallet.features["aptos:network"]).toBeDefined();
+      expect(wallet.features["aptos:changeNetwork"]).toBeDefined();
+      expect(wallet.features["aptos:onNetworkChange"]).toBeDefined();
+      expect(wallet.features["aptos:signMessage"]).toBeDefined();
+      expect(wallet.features["aptos:signTransaction"]).toBeDefined();
+    });
+
+    it("should have correct feature versions", () => {
+      expect(wallet.features["aptos:connect"].version).toBe("1.0.0");
+      expect(wallet.features["aptos:signMessage"].version).toBe("1.0.0");
+      expect(wallet.features["aptos:signTransaction"].version).toBe("1.0.0");
+    });
+  });
+
+  describe("connect", () => {
+    it("should return approved response with account info", async () => {
+      const response = await wallet.connect();
+
+      expect(response.status).toBe(UserResponseStatus.APPROVED);
+      if (response.status === UserResponseStatus.APPROVED) {
+        expect(response.args).toBeInstanceOf(AccountInfo);
+      }
+    });
+
+    it("should return account with derived public key", async () => {
+      const response = await wallet.connect();
+
+      expect(response.status).toBe(UserResponseStatus.APPROVED);
+      if (response.status === UserResponseStatus.APPROVED) {
+        expect(response.args.publicKey).toBeInstanceOf(EIP1193DerivedPublicKey);
+      }
+    });
+
+    it("should derive Aptos address from Ethereum address", async () => {
+      const response = await wallet.connect();
+
+      expect(response.status).toBe(UserResponseStatus.APPROVED);
+      if (response.status === UserResponseStatus.APPROVED) {
+        // Address should be a valid 32-byte Aptos address
+        expect(response.args.address.toString()).toMatch(/^0x[a-f0-9]{64}$/i);
+      }
+    });
+  });
+
+  describe("getActiveAccount", () => {
+    it("should return active account info", async () => {
+      const accountInfo = await wallet.getActiveAccount();
+
+      expect(accountInfo).toBeInstanceOf(AccountInfo);
+      expect(accountInfo.publicKey).toBeInstanceOf(EIP1193DerivedPublicKey);
+    });
+
+    it("should return consistent address for same ethereum account", async () => {
+      const account1 = await wallet.getActiveAccount();
+      const account2 = await wallet.getActiveAccount();
+
+      expect(account1.address.toString()).toBe(account2.address.toString());
+    });
+  });
+
+  describe("getActiveNetwork", () => {
+    it("should return current network info", async () => {
+      const networkInfo = await wallet.getActiveNetwork();
+
+      expect(networkInfo.name).toBe(Network.MAINNET);
+      expect(networkInfo.chainId).toBe(NetworkToChainId[Network.MAINNET]);
+      expect(networkInfo.url).toBe(NetworkToNodeAPI[Network.MAINNET]);
+    });
+
+    it("should reflect default network setting", async () => {
+      const testnetWallet = new EIP1193DerivedWallet(providerDetail, {
+        defaultNetwork: Network.TESTNET,
+      });
+
+      const networkInfo = await testnetWallet.getActiveNetwork();
+
+      expect(networkInfo.name).toBe(Network.TESTNET);
+      expect(networkInfo.chainId).toBe(NetworkToChainId[Network.TESTNET]);
+    });
+  });
+
+  describe("changeNetwork", () => {
+    it("should change network successfully", async () => {
+      const response = await wallet.changeNetwork({
+        name: Network.TESTNET,
+        chainId: NetworkToChainId[Network.TESTNET],
+        url: NetworkToNodeAPI[Network.TESTNET],
+      });
+
+      expect(response.status).toBe(UserResponseStatus.APPROVED);
+      if (response.status === UserResponseStatus.APPROVED) {
+        expect(response.args.success).toBe(true);
+      }
+
+      const newNetwork = await wallet.getActiveNetwork();
+      expect(newNetwork.name).toBe(Network.TESTNET);
+    });
+
+    it("should throw for custom network", async () => {
+      await expect(
+        wallet.changeNetwork({
+          name: Network.CUSTOM,
+          url: "https://custom.node.com",
+        })
+      ).rejects.toThrow("Custom network not currently supported");
+    });
+
+    it("should notify listeners on network change", async () => {
+      let notifiedNetwork: { name: Network } | null = null;
+
+      wallet.onActiveNetworkChange((network) => {
+        notifiedNetwork = network;
+      });
+
+      await wallet.changeNetwork({
+        name: Network.TESTNET,
+        chainId: NetworkToChainId[Network.TESTNET],
+        url: NetworkToNodeAPI[Network.TESTNET],
+      });
+
+      expect(notifiedNetwork).not.toBeNull();
+      expect(notifiedNetwork!.name).toBe(Network.TESTNET);
+    });
+  });
+
+  describe("onActiveAccountChange", () => {
+    it("should register account change listener", async () => {
+      let callbackCalled = false;
+
+      wallet.onActiveAccountChange(() => {
+        callbackCalled = true;
+      });
+
+      // Emit account change event from the mock provider
+      (providerDetail.provider as any).emit("accountsChanged", [
+        TEST_ETHEREUM_ADDRESS,
+      ]);
+
+      // Wait for async callback
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      expect(callbackCalled).toBe(true);
+    });
+
+    it("should unregister listeners when passed null callback marker", () => {
+      const callback = () => {};
+      wallet.onActiveAccountChange(callback);
+      // Create a null callback marker (function with _isNull property)
+      const nullCallback = Object.assign(() => {}, { _isNull: true });
+      // Should not throw
+      wallet.onActiveAccountChange(nullCallback as any);
+    });
+  });
+
+  describe("onActiveNetworkChange", () => {
+    it("should register network change listener", async () => {
+      let receivedNetwork: any = null;
+
+      wallet.onActiveNetworkChange((network) => {
+        receivedNetwork = network;
+      });
+
+      await wallet.changeNetwork({
+        name: Network.TESTNET,
+        chainId: NetworkToChainId[Network.TESTNET],
+        url: NetworkToNodeAPI[Network.TESTNET],
+      });
+
+      expect(receivedNetwork).not.toBeNull();
+      expect(receivedNetwork.name).toBe(Network.TESTNET);
+    });
+
+    it("should unregister listeners when passed null callback marker", () => {
+      const callback = () => {};
+      wallet.onActiveNetworkChange(callback);
+      // Create a null callback marker (function with _isNull property)
+      const nullCallback = Object.assign(() => {}, { _isNull: true });
+      // Should not throw
+      wallet.onActiveNetworkChange(nullCallback as any);
+    });
+  });
+
+  describe("signMessage", () => {
+    it("should sign a message", async () => {
+      const response = await wallet.signMessage({
+        message: "Hello, Aptos!",
+        nonce: "12345678",
+      });
+
+      expect(response.status).toBe(UserResponseStatus.APPROVED);
+      if (response.status === UserResponseStatus.APPROVED) {
+        expect(response.args.message).toBe("Hello, Aptos!");
+        expect(response.args.nonce).toBe("12345678");
+        expect(response.args.prefix).toBe("APTOS");
+      }
+    });
+
+    it("should include signature in response", async () => {
+      const response = await wallet.signMessage({
+        message: "Test",
+        nonce: "nonce",
+      });
+
+      expect(response.status).toBe(UserResponseStatus.APPROVED);
+      if (response.status === UserResponseStatus.APPROVED) {
+        expect(response.args.signature).toBeDefined();
+      }
+    });
+  });
+
+  // Note: signTransaction tests require network access to build transactions.
+  // These are tested via integration tests.
+});
+

--- a/packages/derived-wallet-ethereum/tests/createSiweEnvelope.test.ts
+++ b/packages/derived-wallet-ethereum/tests/createSiweEnvelope.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from "vitest";
+import { Hex } from "@aptos-labs/ts-sdk";
+import { StructuredMessage } from "@aptos-labs/derived-wallet-base";
+import {
+  createSiweEnvelopeForAptosStructuredMessage,
+} from "../src/createSiweEnvelope";
+import type { EthereumAddress } from "../src/shared";
+
+describe("createSiweEnvelope", () => {
+  const testEthereumAddress: EthereumAddress =
+    "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
+  const testChainId = 1;
+  const testIssuedAt = new Date("2024-01-15T12:00:00.000Z");
+  const testDomain = "test.example.com";
+  const testUri = "https://test.example.com";
+
+  // Create a test signing message digest (32 bytes)
+  const testDigest = new Uint8Array(32).fill(0xab);
+
+  describe("createSiweEnvelopeForAptosStructuredMessage", () => {
+    it("should create SIWE message for structured message", () => {
+      const structuredMessage: StructuredMessage = {
+        message: "Hello, Aptos!",
+        nonce: "12345678",
+      };
+
+      const siweMessage = createSiweEnvelopeForAptosStructuredMessage({
+        ethereumAddress: testEthereumAddress,
+        chainId: testChainId,
+        signingMessageDigest: testDigest,
+        issuedAt: testIssuedAt,
+        domain: testDomain,
+        uri: testUri,
+        structuredMessage,
+      });
+
+      expect(typeof siweMessage).toBe("string");
+      expect(siweMessage.length).toBeGreaterThan(0);
+    });
+
+    it("should include ethereum address in message", () => {
+      const structuredMessage: StructuredMessage = {
+        message: "Test message",
+        nonce: "nonce123",
+      };
+
+      const siweMessage = createSiweEnvelopeForAptosStructuredMessage({
+        ethereumAddress: testEthereumAddress,
+        chainId: testChainId,
+        signingMessageDigest: testDigest,
+        issuedAt: testIssuedAt,
+        domain: testDomain,
+        uri: testUri,
+        structuredMessage,
+      });
+
+      expect(siweMessage).toContain(testEthereumAddress);
+    });
+
+    it("should include domain in message", () => {
+      const structuredMessage: StructuredMessage = {
+        message: "Test message",
+        nonce: "nonce123",
+      };
+
+      const siweMessage = createSiweEnvelopeForAptosStructuredMessage({
+        ethereumAddress: testEthereumAddress,
+        chainId: testChainId,
+        signingMessageDigest: testDigest,
+        issuedAt: testIssuedAt,
+        domain: testDomain,
+        uri: testUri,
+        structuredMessage,
+      });
+
+      expect(siweMessage).toContain(testDomain);
+    });
+
+    it("should include structured message content in statement", () => {
+      const structuredMessage: StructuredMessage = {
+        message: "Sign this specific message",
+        nonce: "unique-nonce",
+      };
+
+      const siweMessage = createSiweEnvelopeForAptosStructuredMessage({
+        ethereumAddress: testEthereumAddress,
+        chainId: testChainId,
+        signingMessageDigest: testDigest,
+        issuedAt: testIssuedAt,
+        domain: testDomain,
+        uri: testUri,
+        structuredMessage,
+      });
+
+      // The structured message content should be part of the SIWE statement
+      expect(siweMessage).toContain("Sign this specific message");
+    });
+
+    it("should include nonce as hex digest", () => {
+      const structuredMessage: StructuredMessage = {
+        message: "Test",
+        nonce: "test-nonce",
+      };
+
+      const siweMessage = createSiweEnvelopeForAptosStructuredMessage({
+        ethereumAddress: testEthereumAddress,
+        chainId: testChainId,
+        signingMessageDigest: testDigest,
+        issuedAt: testIssuedAt,
+        domain: testDomain,
+        uri: testUri,
+        structuredMessage,
+      });
+
+      // The nonce in SIWE should be the hex digest
+      const digestHex = Hex.fromHexInput(testDigest).toString();
+      expect(siweMessage).toContain(digestHex);
+    });
+
+    it("should handle structured message with all optional fields", () => {
+      const structuredMessage: StructuredMessage = {
+        message: "Full message",
+        nonce: "full-nonce",
+        address: "0x1234567890abcdef1234567890abcdef12345678",
+        application: "https://myapp.com",
+        chainId: 2,
+      };
+
+      const siweMessage = createSiweEnvelopeForAptosStructuredMessage({
+        ethereumAddress: testEthereumAddress,
+        chainId: testChainId,
+        signingMessageDigest: testDigest,
+        issuedAt: testIssuedAt,
+        domain: testDomain,
+        uri: testUri,
+        structuredMessage,
+      });
+
+      expect(typeof siweMessage).toBe("string");
+      expect(siweMessage.length).toBeGreaterThan(0);
+    });
+
+    it("should use window.location defaults when domain/uri not provided", () => {
+      const structuredMessage: StructuredMessage = {
+        message: "Test",
+        nonce: "nonce",
+      };
+
+      // This will use window.location from setup.ts
+      const siweMessage = createSiweEnvelopeForAptosStructuredMessage({
+        ethereumAddress: testEthereumAddress,
+        chainId: testChainId,
+        signingMessageDigest: testDigest,
+        issuedAt: testIssuedAt,
+        structuredMessage,
+      });
+
+      // Should use the mocked window.location values
+      expect(siweMessage).toContain("test.example.com");
+    });
+  });
+
+  // Note: createSiweEnvelopeForAptosTransaction tests require network access
+  // to build transactions. These are tested via integration tests.
+});
+

--- a/packages/derived-wallet-ethereum/tests/mocks/eip1193Provider.ts
+++ b/packages/derived-wallet-ethereum/tests/mocks/eip1193Provider.ts
@@ -1,0 +1,118 @@
+/**
+ * Mock EIP1193 Provider for testing Ethereum wallet interactions
+ */
+import { Wallet, hashMessage, Signature } from "ethers";
+import type { EIP1193Provider, EIP6963ProviderDetail } from "mipd";
+
+type EventCallback = (...args: unknown[]) => void;
+
+export interface MockEIP1193ProviderOptions {
+  privateKey: string;
+  chainId?: number;
+}
+
+/**
+ * Creates a mock EIP1193 provider that simulates an Ethereum wallet
+ */
+export function createMockEIP1193Provider(
+  options: MockEIP1193ProviderOptions
+): EIP1193Provider {
+  const { privateKey, chainId = 1 } = options;
+  const wallet = new Wallet(privateKey);
+
+  const eventListeners: Map<string, Set<EventCallback>> = new Map();
+
+  const provider: EIP1193Provider = {
+    request: async ({ method, params }: { method: string; params?: unknown[] }) => {
+      switch (method) {
+        case "eth_requestAccounts":
+        case "eth_accounts":
+          return [wallet.address];
+
+        case "eth_chainId":
+          return `0x${chainId.toString(16)}`;
+
+        case "personal_sign": {
+          // personal_sign params: [message, address]
+          const message = (params as string[])[0];
+          // Use the wallet's signMessage which handles personal_sign format
+          const signature = await wallet.signMessage(
+            typeof message === "string" && message.startsWith("0x")
+              ? Buffer.from(message.slice(2), "hex")
+              : message
+          );
+          return signature;
+        }
+
+        case "eth_sign": {
+          // eth_sign params: [address, message]
+          const messageToSign = (params as string[])[1];
+          const messageHash = hashMessage(messageToSign);
+          const sig = wallet.signingKey.sign(messageHash);
+          return Signature.from(sig).serialized;
+        }
+
+        case "wallet_switchEthereumChain":
+          // Simulate successful chain switch
+          return null;
+
+        default:
+          throw new Error(`Unsupported method: ${method}`);
+      }
+    },
+
+    on: (event: string, callback: EventCallback) => {
+      if (!eventListeners.has(event)) {
+        eventListeners.set(event, new Set());
+      }
+      eventListeners.get(event)!.add(callback);
+    },
+
+    removeListener: (event: string, callback: EventCallback) => {
+      eventListeners.get(event)?.delete(callback);
+    },
+
+    // Helper to emit events (for testing account/network changes)
+    emit: (event: string, ...args: unknown[]) => {
+      eventListeners.get(event)?.forEach((cb) => cb(...args));
+    },
+  } as EIP1193Provider & { emit: (event: string, ...args: unknown[]) => void };
+
+  return provider;
+}
+
+/**
+ * Creates a mock EIP6963 provider detail for wallet registration
+ */
+export function createMockEIP6963ProviderDetail(
+  options: MockEIP1193ProviderOptions & {
+    name?: string;
+    rdns?: string;
+    icon?: string;
+  }
+): EIP6963ProviderDetail {
+  const provider = createMockEIP1193Provider(options);
+
+  return {
+    info: {
+      uuid: "mock-wallet-uuid",
+      name: options.name ?? "Mock Wallet",
+      rdns: options.rdns ?? "com.mock.wallet",
+      icon: (options.icon ?? "data:image/svg+xml,<svg></svg>") as `data:image/${string}`,
+    },
+    provider,
+  };
+}
+
+/**
+ * Test private key - DO NOT USE IN PRODUCTION
+ * This is a well-known test private key for testing purposes only
+ */
+export const TEST_PRIVATE_KEY =
+  "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+
+/**
+ * Derived from TEST_PRIVATE_KEY
+ */
+export const TEST_ETHEREUM_ADDRESS = "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
+

--- a/packages/derived-wallet-ethereum/tests/setup.ts
+++ b/packages/derived-wallet-ethereum/tests/setup.ts
@@ -1,0 +1,25 @@
+/**
+ * Vitest setup file for derived-wallet-ethereum tests
+ * Configures happy-dom environment and global mocks
+ */
+
+// Configure window.location for tests that need it
+// happy-dom provides this, but we can override specific values if needed
+if (typeof window !== "undefined") {
+  Object.defineProperty(window, "location", {
+    value: {
+      host: "test.example.com",
+      origin: "https://test.example.com",
+      protocol: "https:",
+      href: "https://test.example.com",
+      hostname: "test.example.com",
+      port: "",
+      pathname: "/",
+      search: "",
+      hash: "",
+    },
+    writable: true,
+    configurable: true,
+  });
+}
+

--- a/packages/derived-wallet-ethereum/tests/shared.test.ts
+++ b/packages/derived-wallet-ethereum/tests/shared.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from "vitest";
+import { UserResponseStatus } from "@aptos-labs/wallet-standard";
+import {
+  defaultEthereumAuthenticationFunction,
+  wrapEthersUserResponse,
+} from "../src/shared";
+
+describe("shared", () => {
+  describe("defaultEthereumAuthenticationFunction", () => {
+    it("should be the correct authentication function", () => {
+      expect(defaultEthereumAuthenticationFunction).toBe(
+        "0x1::ethereum_derivable_account::authenticate"
+      );
+    });
+
+    it("should be a valid Move function identifier format", () => {
+      expect(defaultEthereumAuthenticationFunction).toMatch(
+        /^0x[a-f0-9]+::\w+::\w+$/i
+      );
+    });
+  });
+
+  describe("wrapEthersUserResponse", () => {
+    it("should wrap successful promise as approved user response", async () => {
+      const testValue = { data: "test" };
+      const promise = Promise.resolve(testValue);
+
+      const response = await wrapEthersUserResponse(promise);
+
+      expect(response.status).toBe(UserResponseStatus.APPROVED);
+      if (response.status === UserResponseStatus.APPROVED) {
+        expect(response.args).toEqual(testValue);
+      }
+    });
+
+    it("should wrap string result as approved", async () => {
+      const promise = Promise.resolve("0x1234");
+
+      const response = await wrapEthersUserResponse(promise);
+
+      expect(response.status).toBe(UserResponseStatus.APPROVED);
+      if (response.status === UserResponseStatus.APPROVED) {
+        expect(response.args).toBe("0x1234");
+      }
+    });
+
+    it("should convert ACTION_REJECTED error to rejection", async () => {
+      // Create an ethers-style ACTION_REJECTED error
+      const error = new Error("User rejected the request");
+      (error as any).code = "ACTION_REJECTED";
+
+      const promise = Promise.reject(error);
+
+      const response = await wrapEthersUserResponse(promise);
+
+      expect(response.status).toBe(UserResponseStatus.REJECTED);
+    });
+
+    it("should re-throw non-rejection errors", async () => {
+      const error = new Error("Network error");
+      const promise = Promise.reject(error);
+
+      await expect(wrapEthersUserResponse(promise)).rejects.toThrow(
+        "Network error"
+      );
+    });
+
+    it("should re-throw errors with different codes", async () => {
+      const error = new Error("Invalid params");
+      (error as any).code = "INVALID_ARGUMENT";
+
+      const promise = Promise.reject(error);
+
+      await expect(wrapEthersUserResponse(promise)).rejects.toThrow(
+        "Invalid params"
+      );
+    });
+
+    it("should handle null/undefined results", async () => {
+      const nullPromise = Promise.resolve(null);
+      const undefinedPromise = Promise.resolve(undefined);
+
+      const nullResponse = await wrapEthersUserResponse(nullPromise);
+      const undefinedResponse = await wrapEthersUserResponse(undefinedPromise);
+
+      expect(nullResponse.status).toBe(UserResponseStatus.APPROVED);
+      expect(undefinedResponse.status).toBe(UserResponseStatus.APPROVED);
+    });
+
+    it("should handle array results", async () => {
+      const addresses = ["0x123", "0x456"];
+      const promise = Promise.resolve(addresses);
+
+      const response = await wrapEthersUserResponse(promise);
+
+      expect(response.status).toBe(UserResponseStatus.APPROVED);
+      if (response.status === UserResponseStatus.APPROVED) {
+        expect(response.args).toEqual(addresses);
+      }
+    });
+  });
+});
+

--- a/packages/derived-wallet-ethereum/tests/signAptosMessage.test.ts
+++ b/packages/derived-wallet-ethereum/tests/signAptosMessage.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { BrowserProvider } from "ethers";
+import { UserResponseStatus } from "@aptos-labs/wallet-standard";
+import { signAptosMessageWithEthereum } from "../src/signAptosMessage";
+import { EIP1193PersonalSignature } from "../src/EIP1193DerivedSignature";
+import { defaultEthereumAuthenticationFunction } from "../src/shared";
+import {
+  createMockEIP1193Provider,
+  TEST_PRIVATE_KEY,
+  TEST_ETHEREUM_ADDRESS,
+} from "./mocks/eip1193Provider";
+
+describe("signAptosMessage", () => {
+  let mockProvider: ReturnType<typeof createMockEIP1193Provider>;
+  let browserProvider: BrowserProvider;
+
+  beforeEach(() => {
+    mockProvider = createMockEIP1193Provider({ privateKey: TEST_PRIVATE_KEY });
+    browserProvider = new BrowserProvider(mockProvider);
+  });
+
+  describe("signAptosMessageWithEthereum", () => {
+    it("should sign a simple message", async () => {
+      const response = await signAptosMessageWithEthereum({
+        eip1193Provider: browserProvider,
+        authenticationFunction: defaultEthereumAuthenticationFunction,
+        messageInput: {
+          message: "Hello, Aptos!",
+          nonce: "12345678",
+        },
+      });
+
+      expect(response.status).toBe(UserResponseStatus.APPROVED);
+      if (response.status === UserResponseStatus.APPROVED) {
+        expect(response.args.message).toBe("Hello, Aptos!");
+        expect(response.args.nonce).toBe("12345678");
+        expect(response.args.prefix).toBe("APTOS");
+      }
+    });
+
+    it("should return EIP1193PersonalSignature", async () => {
+      const response = await signAptosMessageWithEthereum({
+        eip1193Provider: browserProvider,
+        authenticationFunction: defaultEthereumAuthenticationFunction,
+        messageInput: {
+          message: "Test message",
+          nonce: "nonce123",
+        },
+      });
+
+      expect(response.status).toBe(UserResponseStatus.APPROVED);
+      if (response.status === UserResponseStatus.APPROVED) {
+        expect(response.args.signature).toBeInstanceOf(EIP1193PersonalSignature);
+      }
+    });
+
+    it("should include full message in response", async () => {
+      const response = await signAptosMessageWithEthereum({
+        eip1193Provider: browserProvider,
+        authenticationFunction: defaultEthereumAuthenticationFunction,
+        messageInput: {
+          message: "My test message",
+          nonce: "abc123",
+        },
+      });
+
+      expect(response.status).toBe(UserResponseStatus.APPROVED);
+      if (response.status === UserResponseStatus.APPROVED) {
+        expect(response.args.fullMessage).toBeDefined();
+        expect(typeof response.args.fullMessage).toBe("string");
+        // Full message should contain the original message
+        expect(response.args.fullMessage).toContain("My test message");
+      }
+    });
+
+    it("should work with raw EIP1193 provider", async () => {
+      const response = await signAptosMessageWithEthereum({
+        eip1193Provider: mockProvider,
+        authenticationFunction: defaultEthereumAuthenticationFunction,
+        messageInput: {
+          message: "Test with raw provider",
+          nonce: "raw-nonce",
+        },
+      });
+
+      expect(response.status).toBe(UserResponseStatus.APPROVED);
+    });
+
+    it("should handle message with address flag", async () => {
+      const response = await signAptosMessageWithEthereum({
+        eip1193Provider: browserProvider,
+        authenticationFunction: defaultEthereumAuthenticationFunction,
+        messageInput: {
+          message: "Message with address",
+          nonce: "addr-nonce",
+          address: true,
+        },
+      });
+
+      expect(response.status).toBe(UserResponseStatus.APPROVED);
+      if (response.status === UserResponseStatus.APPROVED) {
+        // When address flag is true, fullMessage should contain an Aptos address
+        expect(response.args.fullMessage).toContain("0x");
+      }
+    });
+
+    it("should handle message with application flag", async () => {
+      const response = await signAptosMessageWithEthereum({
+        eip1193Provider: browserProvider,
+        authenticationFunction: defaultEthereumAuthenticationFunction,
+        messageInput: {
+          message: "Message with application",
+          nonce: "app-nonce",
+          application: true,
+        },
+      });
+
+      expect(response.status).toBe(UserResponseStatus.APPROVED);
+      if (response.status === UserResponseStatus.APPROVED) {
+        // When application flag is true, fullMessage should contain the origin
+        expect(response.args.fullMessage).toContain("test.example.com");
+      }
+    });
+
+    it("should handle message with chainId", async () => {
+      const response = await signAptosMessageWithEthereum({
+        eip1193Provider: browserProvider,
+        authenticationFunction: defaultEthereumAuthenticationFunction,
+        messageInput: {
+          message: "Message with chain ID",
+          nonce: "chain-nonce",
+          chainId: 2, // Testnet
+        },
+      });
+
+      expect(response.status).toBe(UserResponseStatus.APPROVED);
+      if (response.status === UserResponseStatus.APPROVED) {
+        // Chain ID should be included
+        expect(response.args.fullMessage).toContain("2");
+      }
+    });
+
+    it("should use specified ethereum address when provided", async () => {
+      const response = await signAptosMessageWithEthereum({
+        eip1193Provider: browserProvider,
+        ethereumAddress: TEST_ETHEREUM_ADDRESS as `0x${string}`,
+        authenticationFunction: defaultEthereumAuthenticationFunction,
+        messageInput: {
+          message: "Message for specific address",
+          nonce: "specific-nonce",
+        },
+      });
+
+      expect(response.status).toBe(UserResponseStatus.APPROVED);
+    });
+
+    it("should throw if account not connected", async () => {
+      // Create a provider that returns no accounts
+      const emptyProvider = {
+        request: async ({ method }: { method: string }) => {
+          if (method === "eth_accounts" || method === "eth_requestAccounts") {
+            return [];
+          }
+          if (method === "eth_chainId") {
+            return "0x1";
+          }
+          throw new Error("Unknown method");
+        },
+      };
+
+      await expect(
+        signAptosMessageWithEthereum({
+          eip1193Provider: new BrowserProvider(emptyProvider as any),
+          authenticationFunction: defaultEthereumAuthenticationFunction,
+          messageInput: {
+            message: "Test",
+            nonce: "test",
+          },
+        })
+      ).rejects.toThrow("Account not connected");
+    });
+
+    it("should throw if specified ethereum address not found", async () => {
+      await expect(
+        signAptosMessageWithEthereum({
+          eip1193Provider: browserProvider,
+          ethereumAddress: "0x0000000000000000000000000000000000000000",
+          authenticationFunction: defaultEthereumAuthenticationFunction,
+          messageInput: {
+            message: "Test",
+            nonce: "test",
+          },
+        })
+      ).rejects.toThrow("Account not connected");
+    });
+  });
+});
+

--- a/packages/derived-wallet-ethereum/tests/signAptosTransaction.test.ts
+++ b/packages/derived-wallet-ethereum/tests/signAptosTransaction.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from "vitest";
+import {
+  AccountAuthenticatorAbstraction,
+} from "@aptos-labs/ts-sdk";
+import {
+  SIGNATURE_TYPE,
+  createAccountAuthenticatorForEthereumTransaction,
+} from "../src/signAptosTransaction";
+import { defaultEthereumAuthenticationFunction } from "../src/shared";
+import type { EthereumAddress } from "../src/shared";
+
+describe("signAptosTransaction", () => {
+  const testEthereumAddress: EthereumAddress =
+    "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266";
+  const testDomain = "test.example.com";
+  const testScheme = "https";
+  const testIssuedAt = new Date("2024-01-15T12:00:00.000Z");
+
+  // Test signature (65 bytes)
+  const testSiweSignature =
+    "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef12";
+
+  describe("SIGNATURE_TYPE", () => {
+    it("should be 1", () => {
+      expect(SIGNATURE_TYPE).toBe(1);
+    });
+  });
+
+  describe("createAccountAuthenticatorForEthereumTransaction", () => {
+    it("should create AccountAuthenticatorAbstraction", () => {
+      const signingMessageDigest = new Uint8Array(32).fill(0xab);
+
+      const authenticator = createAccountAuthenticatorForEthereumTransaction(
+        testSiweSignature,
+        testEthereumAddress,
+        testDomain,
+        testScheme,
+        defaultEthereumAuthenticationFunction,
+        signingMessageDigest,
+        testIssuedAt
+      );
+
+      expect(authenticator).toBeInstanceOf(AccountAuthenticatorAbstraction);
+    });
+
+    it("should include correct authentication function", () => {
+      const signingMessageDigest = new Uint8Array(32).fill(0xab);
+
+      const authenticator = createAccountAuthenticatorForEthereumTransaction(
+        testSiweSignature,
+        testEthereumAddress,
+        testDomain,
+        testScheme,
+        defaultEthereumAuthenticationFunction,
+        signingMessageDigest,
+        testIssuedAt
+      );
+
+      // AccountAuthenticatorAbstraction should be serializable
+      const bytes = authenticator.bcsToBytes();
+      expect(bytes).toBeInstanceOf(Uint8Array);
+      expect(bytes.length).toBeGreaterThan(0);
+      // The authentication function string should be embedded in the serialized data
+      expect(authenticator).toBeInstanceOf(AccountAuthenticatorAbstraction);
+    });
+
+    it("should produce serializable authenticator", () => {
+      const signingMessageDigest = new Uint8Array(32).fill(0xab);
+
+      const authenticator = createAccountAuthenticatorForEthereumTransaction(
+        testSiweSignature,
+        testEthereumAddress,
+        testDomain,
+        testScheme,
+        defaultEthereumAuthenticationFunction,
+        signingMessageDigest,
+        testIssuedAt
+      );
+
+      // Should be serializable to bytes
+      const bytes = authenticator.bcsToBytes();
+      expect(bytes).toBeInstanceOf(Uint8Array);
+      expect(bytes.length).toBeGreaterThan(0);
+    });
+
+    it("should work with different schemes", () => {
+      const signingMessageDigest = new Uint8Array(32).fill(0xab);
+
+      const httpAuthenticator = createAccountAuthenticatorForEthereumTransaction(
+        testSiweSignature,
+        testEthereumAddress,
+        testDomain,
+        "http",
+        defaultEthereumAuthenticationFunction,
+        signingMessageDigest,
+        testIssuedAt
+      );
+
+      const httpsAuthenticator = createAccountAuthenticatorForEthereumTransaction(
+        testSiweSignature,
+        testEthereumAddress,
+        testDomain,
+        "https",
+        defaultEthereumAuthenticationFunction,
+        signingMessageDigest,
+        testIssuedAt
+      );
+
+      // Both should be valid authenticators
+      expect(httpAuthenticator).toBeInstanceOf(AccountAuthenticatorAbstraction);
+      expect(httpsAuthenticator).toBeInstanceOf(AccountAuthenticatorAbstraction);
+
+      // But they should produce different bytes due to scheme difference
+      expect(httpAuthenticator.bcsToBytes()).not.toEqual(
+        httpsAuthenticator.bcsToBytes()
+      );
+    });
+  });
+});
+

--- a/packages/derived-wallet-ethereum/tsconfig.json
+++ b/packages/derived-wallet-ethereum/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "@aptos-labs/wallet-adapter-tsconfig/base.json",
-  "include": ["."],
-  "exclude": ["dist", "build", "node_modules"],
+  "include": ["src"],
+  "exclude": ["dist", "build", "node_modules", "tests"],
   "compilerOptions": {
     "target": "es2020",
     "lib": ["es2021", "dom"],

--- a/packages/derived-wallet-ethereum/vitest.config.ts
+++ b/packages/derived-wallet-ethereum/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "happy-dom",
+    include: ["tests/**/*.test.ts"],
+    setupFiles: ["./tests/setup.ts"],
+  },
+});
+

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -489,7 +489,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: ^2.1.8
-        version: 2.1.9(@types/node@20.17.27)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1)
+        version: 2.1.9(@types/node@20.17.27)(happy-dom@15.11.7)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1)
 
   packages/derived-wallet-ethereum:
     dependencies:
@@ -521,27 +521,24 @@ importers:
       '@aptos-labs/wallet-adapter-tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
-      '@types/jest':
-        specifier: ^29.2.4
-        version: 29.5.14
       '@types/node':
         specifier: ^20.10.4
         version: 20.17.27
       eslint:
         specifier: ^8.57.1
         version: 8.57.1
-      jest:
-        specifier: ^29.3.1
-        version: 29.7.0(@types/node@20.17.27)(babel-plugin-macros@3.1.0)
-      ts-jest:
-        specifier: ^29.0.3
-        version: 29.3.0(@babel/core@7.28.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.4))(jest@29.7.0(@types/node@20.17.27)(babel-plugin-macros@3.1.0))(typescript@5.8.3)
+      happy-dom:
+        specifier: ^15.11.7
+        version: 15.11.7
       tsup:
         specifier: ^8.4.0
         version: 8.4.0(@microsoft/api-extractor@7.43.0(@types/node@20.17.27))(@swc/core@1.11.16(@swc/helpers@0.5.15))(jiti@2.5.1)(postcss@8.5.6)(typescript@5.8.3)(yaml@2.8.1)
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@20.17.27)(happy-dom@15.11.7)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1)
 
   packages/derived-wallet-solana:
     dependencies:
@@ -6877,6 +6874,10 @@ packages:
   h3@1.15.4:
     resolution: {integrity: sha512-z5cFQWDffyOe4vQ9xIqNfCZdV4p//vy6fBnr8Q1AWnVZ0teurKMG66rLj++TKwKPUP3u7iMUvrvKaEUiQw2QWQ==}
 
+  happy-dom@15.11.7:
+    resolution: {integrity: sha512-KyrFvnl+J9US63TEzwoiJOQzZBJY7KgBushJA8X61DMbNsH+2ONkDuLDnCnwUiPTF42tLoEmrPyoqbenVA5zrg==}
+    engines: {node: '>=18.0.0'}
+
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
     engines: {node: '>= 0.4'}
@@ -10528,6 +10529,10 @@ packages:
   webidl-conversions@4.0.2:
     resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
 
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
   webpack-sources@3.3.3:
     resolution: {integrity: sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==}
     engines: {node: '>=10.13.0'}
@@ -10544,6 +10549,10 @@ packages:
     peerDependenciesMeta:
       webpack-cli:
         optional: true
+
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -18646,6 +18655,12 @@ snapshots:
       ufo: 1.6.1
       uncrypto: 0.1.3
 
+  happy-dom@15.11.7:
+    dependencies:
+      entities: 4.5.0
+      webidl-conversions: 7.0.0
+      whatwg-mimetype: 3.0.0
+
   has-bigints@1.1.0: {}
 
   has-flag@4.0.0: {}
@@ -23023,7 +23038,7 @@ snapshots:
       terser: 5.44.0
       yaml: 2.8.1
 
-  vitest@2.1.9(@types/node@20.17.27)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1):
+  vitest@2.1.9(@types/node@20.17.27)(happy-dom@15.11.7)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1):
     dependencies:
       '@vitest/expect': 2.1.9
       '@vitest/mocker': 2.1.9(vite@6.3.6(@types/node@20.17.27)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))
@@ -23047,6 +23062,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.17.27
+      happy-dom: 15.11.7
     transitivePeerDependencies:
       - jiti
       - less
@@ -23142,6 +23158,8 @@ snapshots:
 
   webidl-conversions@4.0.2: {}
 
+  webidl-conversions@7.0.0: {}
+
   webpack-sources@3.3.3: {}
 
   webpack-virtual-modules@0.6.2: {}
@@ -23175,6 +23193,8 @@ snapshots:
       - '@swc/core'
       - esbuild
       - uglify-js
+
+  whatwg-mimetype@3.0.0: {}
 
   whatwg-url@5.0.0:
     dependencies:


### PR DESCRIPTION
## Summary
Add comprehensive unit tests for the derived-wallet-ethereum package using Vitest and happy-dom for browser environment simulation.

## Changes
- Replace Jest with Vitest
- Add happy-dom for browser environment testing
- Add mock EIP1193 provider for wallet simulation
- Add 100 tests covering:
  - EIP1193DerivedSignature (serialization)
  - EIP1193DerivedPublicKey (auth key derivation)
  - EIP1193DerivedAccount (account construction)
  - EIP1193DerivedWallet (full wallet implementation)
  - signAptosMessage (message signing)
  - createSiweEnvelope (SIWE envelope creation)
  - shared utilities

## Test Results
All 100 tests passing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a Vitest-based unit test suite for the Ethereum-derived wallet and configures a browser-like environment.
> 
> - Replace Jest with `vitest` and add `happy-dom`; update `package.json` scripts and dev deps
> - Add `vitest.config.ts` and test setup using `happy-dom`
> - Introduce mock EIP1193/EIP6963 providers for wallet simulation
> - New tests cover `EIP1193DerivedWallet`, `EIP1193DerivedAccount`, `EIP1193DerivedPublicKey`, `EIP1193DerivedSignature`, `signAptosMessage`, `signAptosTransaction`, and `createSiweEnvelope`
> - Tweak `tsconfig.json` includes/excludes to focus on `src` and exclude `tests`
> - Update lockfile for new tooling
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 515c213ab3b6b2ad3b9ec08015bff75975a7aba9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->