### PR TITLE
feat(derived-wallet-solana): add Vitest tests

### DIFF
--- a/packages/derived-wallet-solana/package.json
+++ b/packages/derived-wallet-solana/package.json
@@ -20,7 +20,7 @@
     "build:bundle": "tsup --sourcemap",
     "build:declarations": "tsc --emitDeclarationOnly --declaration --declarationMap",
     "dev": "tsup src/index.ts --format esm,cjs --watch",
-    "test": "jest",
+    "test": "vitest run",
     "lint": "TIMING=1 eslint \"src/**/*.ts*\""
   },
   "tsup": {
@@ -48,18 +48,15 @@
   "devDependencies": {
     "@aptos-labs/eslint-config-adapter": "workspace:*",
     "@aptos-labs/wallet-adapter-tsconfig": "workspace:*",
-    "@types/jest": "^29.2.4",
     "@types/node": "^20.10.4",
     "eslint": "^8.57.1",
-    "jest": "^29.3.1",
-    "ts-jest": "^29.0.3",
+    "happy-dom": "^15.11.7",
     "tsup": "^8.4.0",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "vitest": "^2.1.8"
   },
   "files": [
     "dist",
-    "src",
-    "!src/**.test.ts",
-    "!src/**/__tests__"
+    "src"
   ]
 }

--- a/packages/derived-wallet-solana/tests/SolanaDerivedAccount.test.ts
+++ b/packages/derived-wallet-solana/tests/SolanaDerivedAccount.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from "vitest";
+import { Keypair } from "@solana/web3.js";
+import { AbstractedAccount } from "@aptos-labs/ts-sdk";
+import { SolanaDerivedAccount } from "../src/SolanaDerivedAccount";
+import { SolanaDerivedPublicKey } from "../src/SolanaDerivedPublicKey";
+import { defaultSolanaAuthenticationFunction } from "../src/shared";
+import { TEST_SOLANA_KEYPAIR } from "./mocks/solanaWallet";
+
+describe("SolanaDerivedAccount", () => {
+  const testDomain = "test.example.com";
+
+  describe("constructor", () => {
+    it("should create account from solana keypair", () => {
+      const account = new SolanaDerivedAccount({
+        solanaKeypair: TEST_SOLANA_KEYPAIR,
+        domain: testDomain,
+      });
+
+      expect(account).toBeDefined();
+      expect(account).toBeInstanceOf(AbstractedAccount);
+    });
+
+    it("should store solana keypair", () => {
+      const account = new SolanaDerivedAccount({
+        solanaKeypair: TEST_SOLANA_KEYPAIR,
+        domain: testDomain,
+      });
+
+      expect(account.solanaKeypair).toBe(TEST_SOLANA_KEYPAIR);
+    });
+
+    it("should store domain", () => {
+      const account = new SolanaDerivedAccount({
+        solanaKeypair: TEST_SOLANA_KEYPAIR,
+        domain: testDomain,
+      });
+
+      expect(account.domain).toBe(testDomain);
+    });
+
+    it("should default to solana authentication function", () => {
+      const account = new SolanaDerivedAccount({
+        solanaKeypair: TEST_SOLANA_KEYPAIR,
+        domain: testDomain,
+      });
+
+      expect(account.authenticationFunction).toBe(
+        defaultSolanaAuthenticationFunction
+      );
+    });
+
+    it("should allow custom authentication function", () => {
+      const customAuthFunction = "0x1::custom::authenticate";
+
+      const account = new SolanaDerivedAccount({
+        solanaKeypair: TEST_SOLANA_KEYPAIR,
+        domain: testDomain,
+        authenticationFunction: customAuthFunction,
+      });
+
+      expect(account.authenticationFunction).toBe(customAuthFunction);
+    });
+
+    it("should create derived public key", () => {
+      const account = new SolanaDerivedAccount({
+        solanaKeypair: TEST_SOLANA_KEYPAIR,
+        domain: testDomain,
+      });
+
+      expect(account.derivedPublicKey).toBeInstanceOf(SolanaDerivedPublicKey);
+      expect(account.derivedPublicKey.domain).toBe(testDomain);
+      expect(
+        account.derivedPublicKey.solanaPublicKey.equals(
+          TEST_SOLANA_KEYPAIR.publicKey
+        )
+      ).toBe(true);
+    });
+  });
+
+  describe("accountAddress", () => {
+    it("should derive Aptos address from solana keypair and domain", () => {
+      const account = new SolanaDerivedAccount({
+        solanaKeypair: TEST_SOLANA_KEYPAIR,
+        domain: testDomain,
+      });
+
+      // Should be a valid 32-byte Aptos address
+      expect(account.accountAddress.toString()).toMatch(/^0x[a-f0-9]{64}$/i);
+    });
+
+    it("should produce consistent addresses for same inputs", () => {
+      const account1 = new SolanaDerivedAccount({
+        solanaKeypair: TEST_SOLANA_KEYPAIR,
+        domain: testDomain,
+      });
+
+      const account2 = new SolanaDerivedAccount({
+        solanaKeypair: TEST_SOLANA_KEYPAIR,
+        domain: testDomain,
+      });
+
+      expect(account1.accountAddress.toString()).toBe(
+        account2.accountAddress.toString()
+      );
+    });
+
+    it("should produce different addresses for different domains", () => {
+      const account1 = new SolanaDerivedAccount({
+        solanaKeypair: TEST_SOLANA_KEYPAIR,
+        domain: "domain1.com",
+      });
+
+      const account2 = new SolanaDerivedAccount({
+        solanaKeypair: TEST_SOLANA_KEYPAIR,
+        domain: "domain2.com",
+      });
+
+      expect(account1.accountAddress.toString()).not.toBe(
+        account2.accountAddress.toString()
+      );
+    });
+
+    it("should produce different addresses for different solana keypairs", () => {
+      const keypair2 = Keypair.fromSeed(new Uint8Array(32).fill(2));
+
+      const account1 = new SolanaDerivedAccount({
+        solanaKeypair: TEST_SOLANA_KEYPAIR,
+        domain: testDomain,
+      });
+
+      const account2 = new SolanaDerivedAccount({
+        solanaKeypair: keypair2,
+        domain: testDomain,
+      });
+
+      expect(account1.accountAddress.toString()).not.toBe(
+        account2.accountAddress.toString()
+      );
+    });
+
+    it("should derive deterministic address for known inputs", () => {
+      const account = new SolanaDerivedAccount({
+        solanaKeypair: TEST_SOLANA_KEYPAIR,
+        domain: "test.example.com",
+      });
+
+      // The address should be deterministic and valid
+      expect(account.accountAddress.toString()).toMatch(/^0x[a-f0-9]{64}$/i);
+    });
+  });
+
+  // Note: signTransactionWithAuthenticator tests require network access
+  // to build transactions. These are tested via integration tests.
+});
+

--- a/packages/derived-wallet-solana/tests/SolanaDerivedPublicKey.test.ts
+++ b/packages/derived-wallet-solana/tests/SolanaDerivedPublicKey.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect } from "vitest";
+import { Deserializer, Serializer } from "@aptos-labs/ts-sdk";
+import { PublicKey as SolanaPublicKey } from "@solana/web3.js";
+import { SolanaDerivedPublicKey } from "../src/SolanaDerivedPublicKey";
+import { defaultSolanaAuthenticationFunction } from "../src/shared";
+import { TEST_SOLANA_PUBLIC_KEY } from "./mocks/solanaWallet";
+
+describe("SolanaDerivedPublicKey", () => {
+  const testDomain = "test.example.com";
+  const testAuthFunction = defaultSolanaAuthenticationFunction;
+
+  describe("constructor", () => {
+    it("should store domain, solanaPublicKey, and authenticationFunction", () => {
+      const pubKey = new SolanaDerivedPublicKey({
+        domain: testDomain,
+        solanaPublicKey: TEST_SOLANA_PUBLIC_KEY,
+        authenticationFunction: testAuthFunction,
+      });
+
+      expect(pubKey.domain).toBe(testDomain);
+      expect(pubKey.solanaPublicKey.equals(TEST_SOLANA_PUBLIC_KEY)).toBe(true);
+      expect(pubKey.authenticationFunction).toBe(testAuthFunction);
+    });
+
+    it("should work with different domains", () => {
+      const pubKey1 = new SolanaDerivedPublicKey({
+        domain: "app1.com",
+        solanaPublicKey: TEST_SOLANA_PUBLIC_KEY,
+        authenticationFunction: testAuthFunction,
+      });
+
+      const pubKey2 = new SolanaDerivedPublicKey({
+        domain: "app2.com",
+        solanaPublicKey: TEST_SOLANA_PUBLIC_KEY,
+        authenticationFunction: testAuthFunction,
+      });
+
+      expect(pubKey1.domain).toBe("app1.com");
+      expect(pubKey2.domain).toBe("app2.com");
+    });
+  });
+
+  describe("authKey", () => {
+    it("should return an AuthenticationKey", () => {
+      const pubKey = new SolanaDerivedPublicKey({
+        domain: testDomain,
+        solanaPublicKey: TEST_SOLANA_PUBLIC_KEY,
+        authenticationFunction: testAuthFunction,
+      });
+
+      const authKey = pubKey.authKey();
+
+      expect(authKey).toBeDefined();
+      // AuthenticationKey can derive an address
+      const address = authKey.derivedAddress();
+      expect(address.toString()).toMatch(/^0x[a-f0-9]{64}$/i);
+    });
+
+    it("should produce consistent authentication key for same inputs", () => {
+      const pubKey1 = new SolanaDerivedPublicKey({
+        domain: testDomain,
+        solanaPublicKey: TEST_SOLANA_PUBLIC_KEY,
+        authenticationFunction: testAuthFunction,
+      });
+
+      const pubKey2 = new SolanaDerivedPublicKey({
+        domain: testDomain,
+        solanaPublicKey: TEST_SOLANA_PUBLIC_KEY,
+        authenticationFunction: testAuthFunction,
+      });
+
+      expect(pubKey1.authKey().derivedAddress().toString()).toBe(
+        pubKey2.authKey().derivedAddress().toString()
+      );
+    });
+
+    it("should produce different auth keys for different solana public keys", () => {
+      // Create a different public key
+      const differentKey = new SolanaPublicKey(new Uint8Array(32).fill(2));
+
+      const pubKey1 = new SolanaDerivedPublicKey({
+        domain: testDomain,
+        solanaPublicKey: TEST_SOLANA_PUBLIC_KEY,
+        authenticationFunction: testAuthFunction,
+      });
+
+      const pubKey2 = new SolanaDerivedPublicKey({
+        domain: testDomain,
+        solanaPublicKey: differentKey,
+        authenticationFunction: testAuthFunction,
+      });
+
+      expect(pubKey1.authKey().derivedAddress().toString()).not.toBe(
+        pubKey2.authKey().derivedAddress().toString()
+      );
+    });
+
+    it("should produce different auth keys for different domains", () => {
+      const pubKey1 = new SolanaDerivedPublicKey({
+        domain: "domain1.com",
+        solanaPublicKey: TEST_SOLANA_PUBLIC_KEY,
+        authenticationFunction: testAuthFunction,
+      });
+
+      const pubKey2 = new SolanaDerivedPublicKey({
+        domain: "domain2.com",
+        solanaPublicKey: TEST_SOLANA_PUBLIC_KEY,
+        authenticationFunction: testAuthFunction,
+      });
+
+      expect(pubKey1.authKey().derivedAddress().toString()).not.toBe(
+        pubKey2.authKey().derivedAddress().toString()
+      );
+    });
+
+    it("should derive a valid Aptos address", () => {
+      const pubKey = new SolanaDerivedPublicKey({
+        domain: testDomain,
+        solanaPublicKey: TEST_SOLANA_PUBLIC_KEY,
+        authenticationFunction: testAuthFunction,
+      });
+
+      const address = pubKey.authKey().derivedAddress();
+
+      // Aptos addresses are 32 bytes (64 hex chars + 0x prefix)
+      expect(address.toString()).toMatch(/^0x[a-f0-9]{64}$/i);
+    });
+
+    it("should produce deterministic derived address", () => {
+      const pubKey = new SolanaDerivedPublicKey({
+        domain: "test.example.com",
+        solanaPublicKey: TEST_SOLANA_PUBLIC_KEY,
+        authenticationFunction: defaultSolanaAuthenticationFunction,
+      });
+
+      const address = pubKey.authKey().derivedAddress();
+      // This is deterministic based on the inputs - record the actual value
+      expect(address.toString()).toMatch(/^0x[a-f0-9]{64}$/i);
+    });
+  });
+
+  describe("serialization", () => {
+    it("should serialize correctly", () => {
+      const pubKey = new SolanaDerivedPublicKey({
+        domain: testDomain,
+        solanaPublicKey: TEST_SOLANA_PUBLIC_KEY,
+        authenticationFunction: testAuthFunction,
+      });
+
+      const serializer = new Serializer();
+      pubKey.serialize(serializer);
+
+      const bytes = serializer.toUint8Array();
+      expect(bytes.length).toBeGreaterThan(0);
+    });
+
+    it("should serialize and deserialize roundtrip", () => {
+      const original = new SolanaDerivedPublicKey({
+        domain: testDomain,
+        solanaPublicKey: TEST_SOLANA_PUBLIC_KEY,
+        authenticationFunction: testAuthFunction,
+      });
+
+      // Serialize
+      const serializer = new Serializer();
+      original.serialize(serializer);
+      const bytes = serializer.toUint8Array();
+
+      // Deserialize
+      const deserializer = new Deserializer(bytes);
+      const deserialized = SolanaDerivedPublicKey.deserialize(deserializer);
+
+      expect(deserialized.domain).toBe(original.domain);
+      expect(deserialized.solanaPublicKey.toBase58()).toBe(
+        original.solanaPublicKey.toBase58()
+      );
+      expect(deserialized.authenticationFunction).toBe(
+        original.authenticationFunction
+      );
+    });
+
+    it("should preserve auth key through serialization", () => {
+      const original = new SolanaDerivedPublicKey({
+        domain: testDomain,
+        solanaPublicKey: TEST_SOLANA_PUBLIC_KEY,
+        authenticationFunction: testAuthFunction,
+      });
+
+      const serializer = new Serializer();
+      original.serialize(serializer);
+      const bytes = serializer.toUint8Array();
+
+      const deserializer = new Deserializer(bytes);
+      const deserialized = SolanaDerivedPublicKey.deserialize(deserializer);
+
+      // Compare derived addresses (which are deterministic)
+      expect(deserialized.authKey().derivedAddress().toString()).toBe(
+        original.authKey().derivedAddress().toString()
+      );
+    });
+  });
+
+  describe("isInstance", () => {
+    it("should return true for SolanaDerivedPublicKey instances", () => {
+      const pubKey = new SolanaDerivedPublicKey({
+        domain: testDomain,
+        solanaPublicKey: TEST_SOLANA_PUBLIC_KEY,
+        authenticationFunction: testAuthFunction,
+      });
+
+      expect(SolanaDerivedPublicKey.isInstance(pubKey)).toBe(true);
+    });
+
+    it("should return false for objects missing required properties", () => {
+      const fakePubKey = {
+        domain: testDomain,
+        // Missing solanaPublicKey and authenticationFunction
+      };
+
+      expect(SolanaDerivedPublicKey.isInstance(fakePubKey as any)).toBe(false);
+    });
+
+    it("should return false for objects with only some properties", () => {
+      const partialPubKey = {
+        domain: testDomain,
+        solanaPublicKey: TEST_SOLANA_PUBLIC_KEY,
+        // Missing authenticationFunction
+      };
+
+      expect(SolanaDerivedPublicKey.isInstance(partialPubKey as any)).toBe(false);
+    });
+  });
+});
+

--- a/packages/derived-wallet-solana/tests/SolanaDerivedWallet.test.ts
+++ b/packages/derived-wallet-solana/tests/SolanaDerivedWallet.test.ts
@@ -1,0 +1,303 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  APTOS_CHAINS,
+  UserResponseStatus,
+} from "@aptos-labs/wallet-standard";
+import {
+  Network,
+  NetworkToChainId,
+  NetworkToNodeAPI,
+} from "@aptos-labs/ts-sdk";
+import { SolanaDerivedWallet } from "../src/SolanaDerivedWallet";
+import { SolanaDerivedPublicKey } from "../src/SolanaDerivedPublicKey";
+import { defaultSolanaAuthenticationFunction } from "../src/shared";
+import {
+  createConnectedMockSolanaWallet,
+  TEST_SOLANA_KEYPAIR,
+} from "./mocks/solanaWallet";
+import type { StandardWalletAdapter } from "@solana/wallet-standard-wallet-adapter-base";
+
+describe("SolanaDerivedWallet", () => {
+  let mockSolanaWallet: StandardWalletAdapter;
+  let wallet: SolanaDerivedWallet;
+
+  beforeEach(() => {
+    mockSolanaWallet = createConnectedMockSolanaWallet({
+      keypair: TEST_SOLANA_KEYPAIR,
+      name: "Test Solana Wallet",
+    });
+    wallet = new SolanaDerivedWallet(mockSolanaWallet);
+  });
+
+  describe("constructor", () => {
+    it("should create wallet from Solana wallet adapter", () => {
+      expect(wallet).toBeDefined();
+      expect(wallet).toBeInstanceOf(SolanaDerivedWallet);
+    });
+
+    it("should set wallet name with (Solana) suffix", () => {
+      expect(wallet.name).toBe("Test Solana Wallet (Solana)");
+    });
+
+    it("should set wallet icon from solana wallet", () => {
+      expect(wallet.icon).toBe(mockSolanaWallet.icon);
+    });
+
+    it("should set wallet url from solana wallet", () => {
+      expect(wallet.url).toBe(mockSolanaWallet.url);
+    });
+
+    it("should set version to 1.0.0", () => {
+      expect(wallet.version).toBe("1.0.0");
+    });
+
+    it("should set chains to APTOS_CHAINS", () => {
+      expect(wallet.chains).toBe(APTOS_CHAINS);
+    });
+
+    it("should default to MAINNET network", () => {
+      expect(wallet.defaultNetwork).toBe(Network.MAINNET);
+    });
+
+    it("should allow custom default network", () => {
+      const testnetWallet = new SolanaDerivedWallet(mockSolanaWallet, {
+        defaultNetwork: Network.TESTNET,
+      });
+      expect(testnetWallet.defaultNetwork).toBe(Network.TESTNET);
+    });
+
+    it("should use default authentication function", () => {
+      expect(wallet.authenticationFunction).toBe(
+        defaultSolanaAuthenticationFunction
+      );
+    });
+
+    it("should allow custom authentication function", () => {
+      const customAuthFunction = "0x1::custom::authenticate";
+      const customWallet = new SolanaDerivedWallet(mockSolanaWallet, {
+        authenticationFunction: customAuthFunction,
+      });
+      expect(customWallet.authenticationFunction).toBe(customAuthFunction);
+    });
+
+    it("should set domain from window.location.host", () => {
+      expect(wallet.domain).toBe("test.example.com");
+    });
+  });
+
+  describe("features", () => {
+    it("should have all required Aptos features", () => {
+      expect(wallet.features["aptos:connect"]).toBeDefined();
+      expect(wallet.features["aptos:disconnect"]).toBeDefined();
+      expect(wallet.features["aptos:account"]).toBeDefined();
+      expect(wallet.features["aptos:onAccountChange"]).toBeDefined();
+      expect(wallet.features["aptos:network"]).toBeDefined();
+      expect(wallet.features["aptos:changeNetwork"]).toBeDefined();
+      expect(wallet.features["aptos:onNetworkChange"]).toBeDefined();
+      expect(wallet.features["aptos:signMessage"]).toBeDefined();
+      expect(wallet.features["aptos:signTransaction"]).toBeDefined();
+    });
+
+    it("should have correct feature versions", () => {
+      expect(wallet.features["aptos:connect"].version).toBe("1.0.0");
+      expect(wallet.features["aptos:signMessage"].version).toBe("1.0.0");
+      expect(wallet.features["aptos:signTransaction"].version).toBe("1.0.0");
+    });
+  });
+
+  describe("connect", () => {
+    it("should return approved response with account info", async () => {
+      const response = await wallet.connect();
+
+      expect(response.status).toBe(UserResponseStatus.APPROVED);
+      if (response.status === UserResponseStatus.APPROVED) {
+        expect(response.args).toBeDefined();
+        expect(response.args.address).toBeDefined();
+      }
+    });
+
+    it("should return account with derived public key", async () => {
+      const response = await wallet.connect();
+
+      expect(response.status).toBe(UserResponseStatus.APPROVED);
+      if (response.status === UserResponseStatus.APPROVED) {
+        expect(response.args.publicKey).toBeInstanceOf(SolanaDerivedPublicKey);
+      }
+    });
+
+    it("should derive Aptos address from Solana public key", async () => {
+      const response = await wallet.connect();
+
+      expect(response.status).toBe(UserResponseStatus.APPROVED);
+      if (response.status === UserResponseStatus.APPROVED) {
+        // Address should be a valid 32-byte Aptos address
+        expect(response.args.address.toString()).toMatch(/^0x[a-f0-9]{64}$/i);
+      }
+    });
+  });
+
+  describe("getActiveAccount", () => {
+    it("should return active account info", async () => {
+      const accountInfo = await wallet.getActiveAccount();
+
+      expect(accountInfo).toBeDefined();
+      expect(accountInfo.publicKey).toBeInstanceOf(SolanaDerivedPublicKey);
+    });
+
+    it("should return consistent address for same solana account", async () => {
+      const account1 = await wallet.getActiveAccount();
+      const account2 = await wallet.getActiveAccount();
+
+      expect(account1.address.toString()).toBe(account2.address.toString());
+    });
+  });
+
+  describe("getActiveNetwork", () => {
+    it("should return current network info", async () => {
+      const networkInfo = await wallet.getActiveNetwork();
+
+      expect(networkInfo.name).toBe(Network.MAINNET);
+      expect(networkInfo.chainId).toBe(NetworkToChainId[Network.MAINNET]);
+      expect(networkInfo.url).toBe(NetworkToNodeAPI[Network.MAINNET]);
+    });
+
+    it("should reflect default network setting", async () => {
+      const testnetWallet = new SolanaDerivedWallet(mockSolanaWallet, {
+        defaultNetwork: Network.TESTNET,
+      });
+
+      const networkInfo = await testnetWallet.getActiveNetwork();
+
+      expect(networkInfo.name).toBe(Network.TESTNET);
+      expect(networkInfo.chainId).toBe(NetworkToChainId[Network.TESTNET]);
+    });
+  });
+
+  describe("changeNetwork", () => {
+    it("should change network successfully", async () => {
+      const response = await wallet.changeNetwork({
+        name: Network.TESTNET,
+        chainId: NetworkToChainId[Network.TESTNET],
+        url: NetworkToNodeAPI[Network.TESTNET],
+      });
+
+      expect(response.status).toBe(UserResponseStatus.APPROVED);
+      if (response.status === UserResponseStatus.APPROVED) {
+        expect(response.args.success).toBe(true);
+      }
+
+      const newNetwork = await wallet.getActiveNetwork();
+      expect(newNetwork.name).toBe(Network.TESTNET);
+    });
+
+    it("should throw for custom network", async () => {
+      await expect(
+        wallet.changeNetwork({
+          name: Network.CUSTOM,
+          url: "https://custom.node.com",
+        })
+      ).rejects.toThrow("Custom network not currently supported");
+    });
+
+    it("should notify listeners on network change", async () => {
+      let notifiedNetwork: { name: Network } | null = null;
+
+      wallet.onActiveNetworkChange((network) => {
+        notifiedNetwork = network;
+      });
+
+      await wallet.changeNetwork({
+        name: Network.TESTNET,
+        chainId: NetworkToChainId[Network.TESTNET],
+        url: NetworkToNodeAPI[Network.TESTNET],
+      });
+
+      expect(notifiedNetwork).not.toBeNull();
+      expect(notifiedNetwork!.name).toBe(Network.TESTNET);
+    });
+  });
+
+  describe("onActiveAccountChange", () => {
+    it("should register account change listener", async () => {
+      let callbackCalled = false;
+
+      wallet.onActiveAccountChange(() => {
+        callbackCalled = true;
+      });
+
+      // Emit connect event from the mock wallet
+      (mockSolanaWallet as any).emit("connect", TEST_SOLANA_KEYPAIR.publicKey);
+
+      expect(callbackCalled).toBe(true);
+    });
+
+    it("should unregister listeners when passed null callback marker", () => {
+      const callback = () => {};
+      wallet.onActiveAccountChange(callback);
+      // Create a null callback marker (function with _isNull property)
+      const nullCallback = Object.assign(() => {}, { _isNull: true });
+      // Should not throw
+      wallet.onActiveAccountChange(nullCallback as any);
+    });
+  });
+
+  describe("onActiveNetworkChange", () => {
+    it("should register network change listener", async () => {
+      let receivedNetwork: any = null;
+
+      wallet.onActiveNetworkChange((network) => {
+        receivedNetwork = network;
+      });
+
+      await wallet.changeNetwork({
+        name: Network.TESTNET,
+        chainId: NetworkToChainId[Network.TESTNET],
+        url: NetworkToNodeAPI[Network.TESTNET],
+      });
+
+      expect(receivedNetwork).not.toBeNull();
+      expect(receivedNetwork.name).toBe(Network.TESTNET);
+    });
+
+    it("should unregister listeners when passed null callback marker", () => {
+      const callback = () => {};
+      wallet.onActiveNetworkChange(callback);
+      // Create a null callback marker (function with _isNull property)
+      const nullCallback = Object.assign(() => {}, { _isNull: true });
+      // Should not throw
+      wallet.onActiveNetworkChange(nullCallback as any);
+    });
+  });
+
+  describe("signMessage", () => {
+    it("should sign a message", async () => {
+      const response = await wallet.signMessage({
+        message: "Hello, Aptos!",
+        nonce: "12345678",
+      });
+
+      expect(response.status).toBe(UserResponseStatus.APPROVED);
+      if (response.status === UserResponseStatus.APPROVED) {
+        expect(response.args.message).toBe("Hello, Aptos!");
+        expect(response.args.nonce).toBe("12345678");
+        expect(response.args.prefix).toBe("APTOS");
+      }
+    });
+
+    it("should include signature in response", async () => {
+      const response = await wallet.signMessage({
+        message: "Test",
+        nonce: "nonce",
+      });
+
+      expect(response.status).toBe(UserResponseStatus.APPROVED);
+      if (response.status === UserResponseStatus.APPROVED) {
+        expect(response.args.signature).toBeDefined();
+      }
+    });
+  });
+
+  // Note: signTransaction tests require network access to build transactions.
+  // These are tested via integration tests.
+});
+

--- a/packages/derived-wallet-solana/tests/createSiwsEnvelope.test.ts
+++ b/packages/derived-wallet-solana/tests/createSiwsEnvelope.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from "vitest";
+import { Hex } from "@aptos-labs/ts-sdk";
+import { StructuredMessage } from "@aptos-labs/derived-wallet-base";
+import {
+  createSiwsEnvelope,
+  createSiwsEnvelopeForAptosStructuredMessage,
+} from "../src/createSiwsEnvelope";
+import { TEST_SOLANA_PUBLIC_KEY } from "./mocks/solanaWallet";
+
+describe("createSiwsEnvelope", () => {
+  const testDomain = "test.example.com";
+
+  // Create a test signing message digest (32 bytes)
+  const testDigest = new Uint8Array(32).fill(0xab);
+
+  describe("createSiwsEnvelope", () => {
+    it("should create SIWS envelope with required fields", () => {
+      const envelope = createSiwsEnvelope({
+        solanaPublicKey: TEST_SOLANA_PUBLIC_KEY,
+        signingMessageDigest: testDigest,
+        domain: testDomain,
+        statement: "Sign this message",
+      });
+
+      expect(envelope).toHaveProperty("address");
+      expect(envelope).toHaveProperty("domain");
+      expect(envelope).toHaveProperty("nonce");
+      expect(envelope).toHaveProperty("statement");
+    });
+
+    it("should include solana address in envelope", () => {
+      const envelope = createSiwsEnvelope({
+        solanaPublicKey: TEST_SOLANA_PUBLIC_KEY,
+        signingMessageDigest: testDigest,
+        domain: testDomain,
+        statement: "Test statement",
+      });
+
+      // Address should be the base58 representation of the solana public key
+      expect(envelope.address).toBe(TEST_SOLANA_PUBLIC_KEY.toString());
+    });
+
+    it("should include domain in envelope", () => {
+      const envelope = createSiwsEnvelope({
+        solanaPublicKey: TEST_SOLANA_PUBLIC_KEY,
+        signingMessageDigest: testDigest,
+        domain: testDomain,
+        statement: "Test statement",
+      });
+
+      expect(envelope.domain).toBe(testDomain);
+    });
+
+    it("should include digest as hex nonce", () => {
+      const envelope = createSiwsEnvelope({
+        solanaPublicKey: TEST_SOLANA_PUBLIC_KEY,
+        signingMessageDigest: testDigest,
+        domain: testDomain,
+        statement: "Test statement",
+      });
+
+      const expectedHex = Hex.fromHexInput(testDigest).toString();
+      expect(envelope.nonce).toBe(expectedHex);
+    });
+
+    it("should include statement in envelope", () => {
+      const testStatement = "Please sign this transaction";
+      const envelope = createSiwsEnvelope({
+        solanaPublicKey: TEST_SOLANA_PUBLIC_KEY,
+        signingMessageDigest: testDigest,
+        domain: testDomain,
+        statement: testStatement,
+      });
+
+      expect(envelope.statement).toBe(testStatement);
+    });
+  });
+
+  describe("createSiwsEnvelopeForAptosStructuredMessage", () => {
+    it("should create SIWS envelope for structured message", () => {
+      const structuredMessage: StructuredMessage = {
+        message: "Hello, Aptos!",
+        nonce: "12345678",
+      };
+
+      const envelope = createSiwsEnvelopeForAptosStructuredMessage({
+        solanaPublicKey: TEST_SOLANA_PUBLIC_KEY,
+        signingMessageDigest: testDigest,
+        domain: testDomain,
+        structuredMessage,
+      });
+
+      expect(envelope).toHaveProperty("address");
+      expect(envelope).toHaveProperty("domain");
+      expect(envelope).toHaveProperty("nonce");
+      expect(envelope).toHaveProperty("statement");
+    });
+
+    it("should include solana address", () => {
+      const structuredMessage: StructuredMessage = {
+        message: "Test message",
+        nonce: "nonce123",
+      };
+
+      const envelope = createSiwsEnvelopeForAptosStructuredMessage({
+        solanaPublicKey: TEST_SOLANA_PUBLIC_KEY,
+        signingMessageDigest: testDigest,
+        domain: testDomain,
+        structuredMessage,
+      });
+
+      expect(envelope.address).toBe(TEST_SOLANA_PUBLIC_KEY.toString());
+    });
+
+    it("should include domain", () => {
+      const structuredMessage: StructuredMessage = {
+        message: "Test message",
+        nonce: "nonce123",
+      };
+
+      const envelope = createSiwsEnvelopeForAptosStructuredMessage({
+        solanaPublicKey: TEST_SOLANA_PUBLIC_KEY,
+        signingMessageDigest: testDigest,
+        domain: testDomain,
+        structuredMessage,
+      });
+
+      expect(envelope.domain).toBe(testDomain);
+    });
+
+    it("should include message content in statement", () => {
+      const structuredMessage: StructuredMessage = {
+        message: "Sign this specific message",
+        nonce: "unique-nonce",
+      };
+
+      const envelope = createSiwsEnvelopeForAptosStructuredMessage({
+        solanaPublicKey: TEST_SOLANA_PUBLIC_KEY,
+        signingMessageDigest: testDigest,
+        domain: testDomain,
+        structuredMessage,
+      });
+
+      // The statement should contain the message
+      expect(envelope.statement).toContain("Sign this specific message");
+    });
+
+    it("should handle structured message with all optional fields", () => {
+      const structuredMessage: StructuredMessage = {
+        message: "Full message",
+        nonce: "full-nonce",
+        address: "0x1234567890abcdef1234567890abcdef12345678",
+        application: "https://myapp.com",
+        chainId: 2,
+      };
+
+      const envelope = createSiwsEnvelopeForAptosStructuredMessage({
+        solanaPublicKey: TEST_SOLANA_PUBLIC_KEY,
+        signingMessageDigest: testDigest,
+        domain: testDomain,
+        structuredMessage,
+      });
+
+      expect(envelope).toHaveProperty("address");
+      expect(envelope).toHaveProperty("statement");
+    });
+  });
+
+  // Note: createSiwsEnvelopeForAptosTransaction tests require network access
+  // to build transactions. These are tested via integration tests.
+});
+

--- a/packages/derived-wallet-solana/tests/mocks/solanaWallet.ts
+++ b/packages/derived-wallet-solana/tests/mocks/solanaWallet.ts
@@ -1,0 +1,144 @@
+/**
+ * Mock Solana Wallet Adapter for testing
+ */
+import { Keypair, PublicKey } from "@solana/web3.js";
+import { createSignInMessage } from "@solana/wallet-standard-util";
+import type { SolanaSignInInputWithRequiredFields } from "@solana/wallet-standard-util";
+import type { StandardWalletAdapter } from "@solana/wallet-standard-wallet-adapter-base";
+import type { WalletIcon } from "@aptos-labs/wallet-standard";
+import nacl from "tweetnacl";
+
+type EventCallback = (...args: unknown[]) => void;
+
+export interface MockSolanaWalletOptions {
+  keypair: Keypair;
+  name?: string;
+  supportSignIn?: boolean;
+  initiallyConnected?: boolean;
+}
+
+/**
+ * Creates a mock Solana wallet adapter that simulates wallet behavior
+ */
+export function createMockSolanaWallet(
+  options: MockSolanaWalletOptions
+): StandardWalletAdapter & { emit: (event: string, ...args: unknown[]) => void } {
+  const {
+    keypair,
+    name = "Mock Solana Wallet",
+    supportSignIn = true,
+    initiallyConnected = false,
+  } = options;
+
+  const eventListeners: Map<string, Set<EventCallback>> = new Map();
+  let isConnected = initiallyConnected;
+  let currentPublicKey: PublicKey | null = initiallyConnected
+    ? keypair.publicKey
+    : null;
+
+  const wallet = {
+    name,
+    icon: "data:image/svg+xml,<svg></svg>" as WalletIcon,
+    url: "https://mock.solana.wallet",
+    get publicKey() {
+      return currentPublicKey;
+    },
+    get connected() {
+      return isConnected;
+    },
+    connecting: false,
+    readyState: "Installed" as const,
+
+    connect: async () => {
+      if (isConnected) {
+        // Already connected, no-op
+        return;
+      }
+      isConnected = true;
+      currentPublicKey = keypair.publicKey;
+      // Emit connect event
+      eventListeners.get("connect")?.forEach((cb) => cb(currentPublicKey));
+    },
+
+    disconnect: async () => {
+      isConnected = false;
+      currentPublicKey = null;
+      // Emit disconnect event
+      eventListeners.get("disconnect")?.forEach((cb) => cb());
+    },
+
+    signMessage: async (message: Uint8Array): Promise<Uint8Array> => {
+      if (!isConnected) {
+        throw new Error("Wallet not connected");
+      }
+      return nacl.sign.detached(message, keypair.secretKey);
+    },
+
+    signIn: supportSignIn
+      ? async (input: SolanaSignInInputWithRequiredFields) => {
+          if (!isConnected) {
+            throw new Error("Wallet not connected");
+          }
+          const message = createSignInMessage(input);
+          const signature = nacl.sign.detached(message, keypair.secretKey);
+          return {
+            account: {
+              address: keypair.publicKey.toBase58(),
+              publicKey: keypair.publicKey.toBytes(),
+              chains: ["solana:mainnet"],
+              features: [],
+            },
+            signature,
+            signatureType: "ed25519" as const,
+            signedMessage: message,
+          };
+        }
+      : undefined,
+
+    on: (event: string, callback: EventCallback) => {
+      if (!eventListeners.has(event)) {
+        eventListeners.set(event, new Set());
+      }
+      eventListeners.get(event)!.add(callback);
+    },
+
+    off: (event: string, callback?: EventCallback) => {
+      if (callback) {
+        eventListeners.get(event)?.delete(callback);
+      } else {
+        eventListeners.delete(event);
+      }
+    },
+
+    // Helper to emit events (for testing)
+    emit: (event: string, ...args: unknown[]) => {
+      eventListeners.get(event)?.forEach((cb) => cb(...args));
+    },
+  } as StandardWalletAdapter & {
+    emit: (event: string, ...args: unknown[]) => void;
+  };
+
+  return wallet;
+}
+
+/**
+ * Creates a pre-connected mock Solana wallet
+ */
+export function createConnectedMockSolanaWallet(
+  options: MockSolanaWalletOptions
+): StandardWalletAdapter {
+  return createMockSolanaWallet({ ...options, initiallyConnected: true });
+}
+
+/**
+ * Test keypair - DO NOT USE IN PRODUCTION
+ * Generated deterministically for testing purposes only
+ */
+export const TEST_SOLANA_KEYPAIR = Keypair.fromSeed(
+  new Uint8Array(32).fill(1) // Deterministic seed for reproducible tests
+);
+
+/**
+ * Derived from TEST_SOLANA_KEYPAIR
+ */
+export const TEST_SOLANA_PUBLIC_KEY = TEST_SOLANA_KEYPAIR.publicKey;

--- a/packages/derived-wallet-solana/tests/setup.ts
+++ b/packages/derived-wallet-solana/tests/setup.ts
@@ -1,0 +1,25 @@
+/**
+ * Vitest setup file for derived-wallet-solana tests
+ * Configures happy-dom environment and global mocks
+ */
+
+// Configure window.location for tests that need it
+// happy-dom provides this, but we can override specific values if needed
+if (typeof window !== "undefined") {
+  Object.defineProperty(window, "location", {
+    value: {
+      host: "test.example.com",
+      origin: "https://test.example.com",
+      protocol: "https:",
+      href: "https://test.example.com",
+      hostname: "test.example.com",
+      port: "",
+      pathname: "/",
+      search: "",
+      hash: "",
+    },
+    writable: true,
+    configurable: true,
+  });
+}
+

--- a/packages/derived-wallet-solana/tests/shared.test.ts
+++ b/packages/derived-wallet-solana/tests/shared.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from "vitest";
+import { UserResponseStatus } from "@aptos-labs/wallet-standard";
+import { WalletError } from "@solana/wallet-adapter-base";
+import {
+  defaultSolanaAuthenticationFunction,
+  wrapSolanaUserResponse,
+} from "../src/shared";
+
+describe("shared", () => {
+  describe("defaultSolanaAuthenticationFunction", () => {
+    it("should be the correct authentication function", () => {
+      expect(defaultSolanaAuthenticationFunction).toBe(
+        "0x1::solana_derivable_account::authenticate"
+      );
+    });
+
+    it("should be a valid Move function identifier format", () => {
+      expect(defaultSolanaAuthenticationFunction).toMatch(
+        /^0x[a-f0-9]+::\w+::\w+$/i
+      );
+    });
+  });
+
+  describe("wrapSolanaUserResponse", () => {
+    it("should wrap successful promise as approved user response", async () => {
+      const testValue = { data: "test" };
+      const promise = Promise.resolve(testValue);
+
+      const response = await wrapSolanaUserResponse(promise);
+
+      expect(response.status).toBe(UserResponseStatus.APPROVED);
+      if (response.status === UserResponseStatus.APPROVED) {
+        expect(response.args).toEqual(testValue);
+      }
+    });
+
+    it("should wrap Uint8Array result as approved", async () => {
+      const signature = new Uint8Array([1, 2, 3, 4]);
+      const promise = Promise.resolve(signature);
+
+      const response = await wrapSolanaUserResponse(promise);
+
+      expect(response.status).toBe(UserResponseStatus.APPROVED);
+      if (response.status === UserResponseStatus.APPROVED) {
+        expect(response.args).toEqual(signature);
+      }
+    });
+
+    it("should convert WalletError with rejection message to rejection", async () => {
+      const error = new WalletError("User rejected the request.");
+      const promise = Promise.reject(error);
+
+      const response = await wrapSolanaUserResponse(promise);
+
+      expect(response.status).toBe(UserResponseStatus.REJECTED);
+    });
+
+    it("should re-throw WalletError with different message", async () => {
+      const error = new WalletError("Connection failed");
+      const promise = Promise.reject(error);
+
+      await expect(wrapSolanaUserResponse(promise)).rejects.toThrow(
+        "Connection failed"
+      );
+    });
+
+    it("should re-throw non-WalletError errors", async () => {
+      const error = new Error("Network error");
+      const promise = Promise.reject(error);
+
+      await expect(wrapSolanaUserResponse(promise)).rejects.toThrow(
+        "Network error"
+      );
+    });
+
+    it("should handle null/undefined results", async () => {
+      const nullPromise = Promise.resolve(null);
+      const undefinedPromise = Promise.resolve(undefined);
+
+      const nullResponse = await wrapSolanaUserResponse(nullPromise);
+      const undefinedResponse = await wrapSolanaUserResponse(undefinedPromise);
+
+      expect(nullResponse.status).toBe(UserResponseStatus.APPROVED);
+      expect(undefinedResponse.status).toBe(UserResponseStatus.APPROVED);
+    });
+
+    it("should handle object results", async () => {
+      const signInResult = {
+        signature: new Uint8Array([1, 2, 3]),
+        signatureType: "ed25519",
+      };
+      const promise = Promise.resolve(signInResult);
+
+      const response = await wrapSolanaUserResponse(promise);
+
+      expect(response.status).toBe(UserResponseStatus.APPROVED);
+      if (response.status === UserResponseStatus.APPROVED) {
+        expect(response.args).toEqual(signInResult);
+      }
+    });
+  });
+});
+

--- a/packages/derived-wallet-solana/tests/signAptosMessage.test.ts
+++ b/packages/derived-wallet-solana/tests/signAptosMessage.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { UserResponseStatus } from "@aptos-labs/wallet-standard";
+import { Ed25519Signature } from "@aptos-labs/ts-sdk";
+import { signAptosMessageWithSolana } from "../src/signAptosMessage";
+import { defaultSolanaAuthenticationFunction } from "../src/shared";
+import {
+  createConnectedMockSolanaWallet,
+  createMockSolanaWallet,
+  TEST_SOLANA_KEYPAIR,
+} from "./mocks/solanaWallet";
+import type { StandardWalletAdapter } from "@solana/wallet-standard-wallet-adapter-base";
+
+describe("signAptosMessage", () => {
+  let mockWallet: StandardWalletAdapter;
+  const testDomain = "test.example.com";
+
+  beforeEach(() => {
+    mockWallet = createConnectedMockSolanaWallet({
+      keypair: TEST_SOLANA_KEYPAIR,
+    });
+  });
+
+  describe("signAptosMessageWithSolana", () => {
+    it("should sign a simple message", async () => {
+      const response = await signAptosMessageWithSolana({
+        solanaWallet: mockWallet,
+        authenticationFunction: defaultSolanaAuthenticationFunction,
+        messageInput: {
+          message: "Hello, Aptos!",
+          nonce: "12345678",
+        },
+        domain: testDomain,
+      });
+
+      expect(response.status).toBe(UserResponseStatus.APPROVED);
+      if (response.status === UserResponseStatus.APPROVED) {
+        expect(response.args.message).toBe("Hello, Aptos!");
+        expect(response.args.nonce).toBe("12345678");
+        expect(response.args.prefix).toBe("APTOS");
+      }
+    });
+
+    it("should return Ed25519Signature", async () => {
+      const response = await signAptosMessageWithSolana({
+        solanaWallet: mockWallet,
+        authenticationFunction: defaultSolanaAuthenticationFunction,
+        messageInput: {
+          message: "Test message",
+          nonce: "nonce123",
+        },
+        domain: testDomain,
+      });
+
+      expect(response.status).toBe(UserResponseStatus.APPROVED);
+      if (response.status === UserResponseStatus.APPROVED) {
+        expect(response.args.signature).toBeInstanceOf(Ed25519Signature);
+      }
+    });
+
+    it("should include full message in response", async () => {
+      const response = await signAptosMessageWithSolana({
+        solanaWallet: mockWallet,
+        authenticationFunction: defaultSolanaAuthenticationFunction,
+        messageInput: {
+          message: "My test message",
+          nonce: "abc123",
+        },
+        domain: testDomain,
+      });
+
+      expect(response.status).toBe(UserResponseStatus.APPROVED);
+      if (response.status === UserResponseStatus.APPROVED) {
+        expect(response.args.fullMessage).toBeDefined();
+        expect(typeof response.args.fullMessage).toBe("string");
+        // Full message should contain the original message
+        expect(response.args.fullMessage).toContain("My test message");
+      }
+    });
+
+    it("should handle message with address flag", async () => {
+      const response = await signAptosMessageWithSolana({
+        solanaWallet: mockWallet,
+        authenticationFunction: defaultSolanaAuthenticationFunction,
+        messageInput: {
+          message: "Message with address",
+          nonce: "addr-nonce",
+          address: true,
+        },
+        domain: testDomain,
+      });
+
+      expect(response.status).toBe(UserResponseStatus.APPROVED);
+      if (response.status === UserResponseStatus.APPROVED) {
+        // When address flag is true, fullMessage should contain an Aptos address
+        expect(response.args.fullMessage).toContain("0x");
+      }
+    });
+
+    it("should handle message with application flag", async () => {
+      const response = await signAptosMessageWithSolana({
+        solanaWallet: mockWallet,
+        authenticationFunction: defaultSolanaAuthenticationFunction,
+        messageInput: {
+          message: "Message with application",
+          nonce: "app-nonce",
+          application: true,
+        },
+        domain: testDomain,
+      });
+
+      expect(response.status).toBe(UserResponseStatus.APPROVED);
+      if (response.status === UserResponseStatus.APPROVED) {
+        // When application flag is true, fullMessage should contain the origin
+        expect(response.args.fullMessage).toContain("test.example.com");
+      }
+    });
+
+    it("should handle message with chainId", async () => {
+      const response = await signAptosMessageWithSolana({
+        solanaWallet: mockWallet,
+        authenticationFunction: defaultSolanaAuthenticationFunction,
+        messageInput: {
+          message: "Message with chain ID",
+          nonce: "chain-nonce",
+          chainId: 2, // Testnet
+        },
+        domain: testDomain,
+      });
+
+      expect(response.status).toBe(UserResponseStatus.APPROVED);
+      if (response.status === UserResponseStatus.APPROVED) {
+        // Chain ID should be included in full message
+        expect(response.args.fullMessage).toContain("2");
+      }
+    });
+
+    it("should throw if wallet does not support signMessage", async () => {
+      const walletWithoutSignMessage = {
+        ...mockWallet,
+        signMessage: undefined,
+      } as unknown as StandardWalletAdapter;
+
+      await expect(
+        signAptosMessageWithSolana({
+          solanaWallet: walletWithoutSignMessage,
+          authenticationFunction: defaultSolanaAuthenticationFunction,
+          messageInput: {
+            message: "Test",
+            nonce: "test",
+          },
+          domain: testDomain,
+        })
+      ).rejects.toThrow("solana:signMessage not available");
+    });
+
+    it("should throw if account not connected", async () => {
+      const disconnectedWallet = createMockSolanaWallet({
+        keypair: TEST_SOLANA_KEYPAIR,
+      });
+      // Wallet is not connected by default
+
+      await expect(
+        signAptosMessageWithSolana({
+          solanaWallet: disconnectedWallet,
+          authenticationFunction: defaultSolanaAuthenticationFunction,
+          messageInput: {
+            message: "Test",
+            nonce: "test",
+          },
+          domain: testDomain,
+        })
+      ).rejects.toThrow("Account not connected");
+    });
+  });
+});
+

--- a/packages/derived-wallet-solana/tests/signAptosTransaction.test.ts
+++ b/packages/derived-wallet-solana/tests/signAptosTransaction.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+import { AccountAuthenticatorAbstraction } from "@aptos-labs/ts-sdk";
+import {
+  SIGNATURE_TYPE,
+  createAccountAuthenticatorForSolanaTransaction,
+} from "../src/signAptosTransaction";
+import { defaultSolanaAuthenticationFunction } from "../src/shared";
+import { TEST_SOLANA_PUBLIC_KEY } from "./mocks/solanaWallet";
+
+describe("signAptosTransaction", () => {
+  const testDomain = "test.example.com";
+
+  // Test Ed25519 signature (64 bytes)
+  const testSignature = new Uint8Array(64).fill(0xab);
+
+  // Test signing message digest (32 bytes)
+  const testSigningMessageDigest = new Uint8Array(32).fill(0xcd);
+
+  describe("SIGNATURE_TYPE", () => {
+    it("should be 0", () => {
+      expect(SIGNATURE_TYPE).toBe(0);
+    });
+  });
+
+  describe("createAccountAuthenticatorForSolanaTransaction", () => {
+    it("should create AccountAuthenticatorAbstraction", () => {
+      const authenticator = createAccountAuthenticatorForSolanaTransaction(
+        testSignature,
+        TEST_SOLANA_PUBLIC_KEY,
+        testDomain,
+        defaultSolanaAuthenticationFunction,
+        testSigningMessageDigest
+      );
+
+      expect(authenticator).toBeInstanceOf(AccountAuthenticatorAbstraction);
+    });
+
+    it("should produce serializable authenticator", () => {
+      const authenticator = createAccountAuthenticatorForSolanaTransaction(
+        testSignature,
+        TEST_SOLANA_PUBLIC_KEY,
+        testDomain,
+        defaultSolanaAuthenticationFunction,
+        testSigningMessageDigest
+      );
+
+      // Should be serializable to bytes
+      const bytes = authenticator.bcsToBytes();
+      expect(bytes).toBeInstanceOf(Uint8Array);
+      expect(bytes.length).toBeGreaterThan(0);
+    });
+
+    it("should work with different domains", () => {
+      const auth1 = createAccountAuthenticatorForSolanaTransaction(
+        testSignature,
+        TEST_SOLANA_PUBLIC_KEY,
+        "domain1.com",
+        defaultSolanaAuthenticationFunction,
+        testSigningMessageDigest
+      );
+
+      const auth2 = createAccountAuthenticatorForSolanaTransaction(
+        testSignature,
+        TEST_SOLANA_PUBLIC_KEY,
+        "domain2.com",
+        defaultSolanaAuthenticationFunction,
+        testSigningMessageDigest
+      );
+
+      // Both should be valid authenticators
+      expect(auth1).toBeInstanceOf(AccountAuthenticatorAbstraction);
+      expect(auth2).toBeInstanceOf(AccountAuthenticatorAbstraction);
+
+      // Different domains should produce different bytes
+      expect(auth1.bcsToBytes()).not.toEqual(auth2.bcsToBytes());
+    });
+
+    it("should work with different signatures", () => {
+      const sig1 = new Uint8Array(64).fill(0x11);
+      const sig2 = new Uint8Array(64).fill(0x22);
+
+      const auth1 = createAccountAuthenticatorForSolanaTransaction(
+        sig1,
+        TEST_SOLANA_PUBLIC_KEY,
+        testDomain,
+        defaultSolanaAuthenticationFunction,
+        testSigningMessageDigest
+      );
+
+      const auth2 = createAccountAuthenticatorForSolanaTransaction(
+        sig2,
+        TEST_SOLANA_PUBLIC_KEY,
+        testDomain,
+        defaultSolanaAuthenticationFunction,
+        testSigningMessageDigest
+      );
+
+      // Different signatures should produce different bytes
+      expect(auth1.bcsToBytes()).not.toEqual(auth2.bcsToBytes());
+    });
+
+    it("should work with custom authentication function", () => {
+      const customAuthFunction = "0x1::custom::authenticate";
+
+      const authenticator = createAccountAuthenticatorForSolanaTransaction(
+        testSignature,
+        TEST_SOLANA_PUBLIC_KEY,
+        testDomain,
+        customAuthFunction,
+        testSigningMessageDigest
+      );
+
+      expect(authenticator).toBeInstanceOf(AccountAuthenticatorAbstraction);
+    });
+  });
+
+  // Note: createMessageForSolanaTransaction and signAptosTransactionWithSolana
+  // tests require network access to build transactions.
+  // These are tested via integration tests.
+});
+

--- a/packages/derived-wallet-solana/tsconfig.json
+++ b/packages/derived-wallet-solana/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "@aptos-labs/wallet-adapter-tsconfig/base.json",
-  "include": ["."],
-  "exclude": ["dist", "build", "node_modules"],
+  "include": ["src"],
+  "exclude": ["dist", "build", "node_modules", "tests"],
   "compilerOptions": {
     "target": "es2020",
     "lib": ["es2021", "dom"],

--- a/packages/derived-wallet-solana/vitest.config.ts
+++ b/packages/derived-wallet-solana/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "happy-dom",
+    include: ["tests/**/*.test.ts"],
+    setupFiles: ["./tests/setup.ts"],
+  },
+});
+

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -576,27 +576,24 @@ importers:
       '@aptos-labs/wallet-adapter-tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
-      '@types/jest':
-        specifier: ^29.2.4
-        version: 29.5.14
       '@types/node':
         specifier: ^20.10.4
         version: 20.17.27
       eslint:
         specifier: ^8.57.1
         version: 8.57.1
-      jest:
-        specifier: ^29.3.1
-        version: 29.7.0(@types/node@20.17.27)(babel-plugin-macros@3.1.0)
-      ts-jest:
-        specifier: ^29.0.3
-        version: 29.3.0(@babel/core@7.28.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.4))(jest@29.7.0(@types/node@20.17.27)(babel-plugin-macros@3.1.0))(typescript@5.8.3)
+      happy-dom:
+        specifier: ^15.11.7
+        version: 15.11.7
       tsup:
         specifier: ^8.4.0
         version: 8.4.0(@microsoft/api-extractor@7.43.0(@types/node@20.17.27))(@swc/core@1.11.16(@swc/helpers@0.5.15))(jiti@2.5.1)(postcss@8.5.6)(typescript@5.8.3)(yaml@2.8.1)
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@20.17.27)(happy-dom@15.11.7)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1)
 
   packages/derived-wallet-sui:
     dependencies:


### PR DESCRIPTION
## Summary
Add comprehensive unit tests for the derived-wallet-solana package using Vitest and happy-dom for browser environment simulation.

## Changes
- Replace Jest with Vitest
- Add happy-dom for browser environment testing
- Add mock Solana wallet adapter for wallet simulation
- Add 87 tests covering:
  - SolanaDerivedPublicKey (constructor, authKey, serialization, isInstance)
  - SolanaDerivedAccount (constructor, derived address, properties)
  - SolanaDerivedWallet (connect, account, network, signMessage)
  - shared utilities (defaultSolanaAuthenticationFunction, wrapSolanaUserResponse)
  - createSiwsEnvelope (SIWS envelope creation)
  - signAptosTransaction (SIGNATURE_TYPE, createAccountAuthenticator)
  - signAptosMessage (message signing with mock wallet)

## Test Results
All 87 tests passing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Vitest-based test suite and browser-like environment for `@aptos-labs/derived-wallet-solana`.
> 
> - Replace Jest with Vitest: update `package.json` scripts/devDeps, add `vitest` and `happy-dom`, and configure via `vitest.config.ts`
> - Add unit tests for key modules: `SolanaDerivedPublicKey`, `SolanaDerivedAccount`, `SolanaDerivedWallet`, `createSiwsEnvelope`, `signAptosMessage`, `signAptosTransaction`, and shared utilities
> - Introduce test helpers: mock Solana wallet adapter (`tests/mocks/solanaWallet.ts`) and test setup (`tests/setup.ts`)
> - Adjust TS config to exclude tests from type output (`tsconfig.json`); update lockfile accordingly
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 846b2f2085e373f9139dcc888d9c224aff8503fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->