### PR TITLE
feat(derived-wallet-sui): add Vitest test suite

### DIFF
--- a/packages/derived-wallet-sui/package.json
+++ b/packages/derived-wallet-sui/package.json
@@ -20,7 +20,7 @@
     "build:bundle": "tsup --sourcemap",
     "build:declarations": "tsc --emitDeclarationOnly --declaration --declarationMap",
     "dev": "tsup src/index.ts --format esm,cjs --watch --dts",
-    "test": "jest",
+    "test": "vitest run",
     "lint": "TIMING=1 eslint \"src/**/*.ts*\""
   },
   "tsup": {
@@ -46,18 +46,16 @@
   "devDependencies": {
     "@aptos-labs/eslint-config-adapter": "workspace:*",
     "@aptos-labs/wallet-adapter-tsconfig": "workspace:*",
-    "@types/jest": "^29.2.4",
     "@types/node": "^20.10.4",
     "eslint": "^8.15.0",
-    "jest": "^29.3.1",
-    "ts-jest": "^29.0.3",
+    "happy-dom": "^15.11.7",
     "tsup": "^8.4.0",
-    "typescript": "^5.4.5"
+    "tweetnacl": "^1.0.3",
+    "typescript": "^5.4.5",
+    "vitest": "^2.1.8"
   },
   "files": [
     "dist",
-    "src",
-    "!src/**.test.ts",
-    "!src/**/__tests__"
+    "src"
   ]
 }

--- a/packages/derived-wallet-sui/tests/SuiDerivedPublicKey.test.ts
+++ b/packages/derived-wallet-sui/tests/SuiDerivedPublicKey.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect } from "vitest";
+import { Deserializer, Serializer } from "@aptos-labs/ts-sdk";
+import { SuiDerivedPublicKey } from "../src/SuiDerivedPublicKey";
+import { defaultAuthenticationFunction } from "../src/shared";
+import { TEST_SUI_ADDRESS } from "./mocks/suiWallet";
+
+describe("SuiDerivedPublicKey", () => {
+  const testDomain = "test.example.com";
+  const testAuthFunction = defaultAuthenticationFunction;
+
+  describe("constructor", () => {
+    it("should store domain, suiAccountAddress, and authenticationFunction", () => {
+      const pubKey = new SuiDerivedPublicKey({
+        domain: testDomain,
+        suiAccountAddress: TEST_SUI_ADDRESS,
+        authenticationFunction: testAuthFunction,
+      });
+
+      expect(pubKey.domain).toBe(testDomain);
+      expect(pubKey.suiAccountAddress).toBe(TEST_SUI_ADDRESS);
+      expect(pubKey.authenticationFunction).toBe(testAuthFunction);
+    });
+
+    it("should work with different domains", () => {
+      const pubKey1 = new SuiDerivedPublicKey({
+        domain: "app1.com",
+        suiAccountAddress: TEST_SUI_ADDRESS,
+        authenticationFunction: testAuthFunction,
+      });
+
+      const pubKey2 = new SuiDerivedPublicKey({
+        domain: "app2.com",
+        suiAccountAddress: TEST_SUI_ADDRESS,
+        authenticationFunction: testAuthFunction,
+      });
+
+      expect(pubKey1.domain).toBe("app1.com");
+      expect(pubKey2.domain).toBe("app2.com");
+    });
+  });
+
+  describe("authKey", () => {
+    it("should return an AuthenticationKey", () => {
+      const pubKey = new SuiDerivedPublicKey({
+        domain: testDomain,
+        suiAccountAddress: TEST_SUI_ADDRESS,
+        authenticationFunction: testAuthFunction,
+      });
+
+      const authKey = pubKey.authKey();
+
+      expect(authKey).toBeDefined();
+      // AuthenticationKey can derive an address
+      const address = authKey.derivedAddress();
+      expect(address.toString()).toMatch(/^0x[a-f0-9]{64}$/i);
+    });
+
+    it("should produce consistent authentication key for same inputs", () => {
+      const pubKey1 = new SuiDerivedPublicKey({
+        domain: testDomain,
+        suiAccountAddress: TEST_SUI_ADDRESS,
+        authenticationFunction: testAuthFunction,
+      });
+
+      const pubKey2 = new SuiDerivedPublicKey({
+        domain: testDomain,
+        suiAccountAddress: TEST_SUI_ADDRESS,
+        authenticationFunction: testAuthFunction,
+      });
+
+      expect(pubKey1.authKey().derivedAddress().toString()).toBe(
+        pubKey2.authKey().derivedAddress().toString()
+      );
+    });
+
+    it("should produce different auth keys for different sui addresses", () => {
+      // Create a different address
+      const differentAddress =
+        "0x0202020202020202020202020202020202020202020202020202020202020202";
+
+      const pubKey1 = new SuiDerivedPublicKey({
+        domain: testDomain,
+        suiAccountAddress: TEST_SUI_ADDRESS,
+        authenticationFunction: testAuthFunction,
+      });
+
+      const pubKey2 = new SuiDerivedPublicKey({
+        domain: testDomain,
+        suiAccountAddress: differentAddress,
+        authenticationFunction: testAuthFunction,
+      });
+
+      expect(pubKey1.authKey().derivedAddress().toString()).not.toBe(
+        pubKey2.authKey().derivedAddress().toString()
+      );
+    });
+
+    it("should produce different auth keys for different domains", () => {
+      const pubKey1 = new SuiDerivedPublicKey({
+        domain: "domain1.com",
+        suiAccountAddress: TEST_SUI_ADDRESS,
+        authenticationFunction: testAuthFunction,
+      });
+
+      const pubKey2 = new SuiDerivedPublicKey({
+        domain: "domain2.com",
+        suiAccountAddress: TEST_SUI_ADDRESS,
+        authenticationFunction: testAuthFunction,
+      });
+
+      expect(pubKey1.authKey().derivedAddress().toString()).not.toBe(
+        pubKey2.authKey().derivedAddress().toString()
+      );
+    });
+
+    it("should derive a valid Aptos address", () => {
+      const pubKey = new SuiDerivedPublicKey({
+        domain: testDomain,
+        suiAccountAddress: TEST_SUI_ADDRESS,
+        authenticationFunction: testAuthFunction,
+      });
+
+      const address = pubKey.authKey().derivedAddress();
+
+      // Aptos addresses are 32 bytes (64 hex chars + 0x prefix)
+      expect(address.toString()).toMatch(/^0x[a-f0-9]{64}$/i);
+    });
+
+    it("should produce deterministic derived address", () => {
+      const pubKey = new SuiDerivedPublicKey({
+        domain: "test.example.com",
+        suiAccountAddress: TEST_SUI_ADDRESS,
+        authenticationFunction: defaultAuthenticationFunction,
+      });
+
+      const address = pubKey.authKey().derivedAddress();
+      // This is deterministic based on the inputs - record the actual value
+      expect(address.toString()).toMatch(/^0x[a-f0-9]{64}$/i);
+    });
+  });
+
+  describe("verifySignature", () => {
+    it("should throw when called synchronously", () => {
+      const pubKey = new SuiDerivedPublicKey({
+        domain: testDomain,
+        suiAccountAddress: TEST_SUI_ADDRESS,
+        authenticationFunction: testAuthFunction,
+      });
+
+      expect(() => {
+        pubKey.verifySignature({
+          message: new Uint8Array([1, 2, 3]),
+          signature: {} as any,
+        });
+      }).toThrow("Use verifySignatureAsync instead");
+    });
+  });
+
+  describe("serialization", () => {
+    it("should serialize correctly", () => {
+      const pubKey = new SuiDerivedPublicKey({
+        domain: testDomain,
+        suiAccountAddress: TEST_SUI_ADDRESS,
+        authenticationFunction: testAuthFunction,
+      });
+
+      const serializer = new Serializer();
+      pubKey.serialize(serializer);
+
+      const bytes = serializer.toUint8Array();
+      expect(bytes.length).toBeGreaterThan(0);
+    });
+
+    it("should serialize and deserialize roundtrip", () => {
+      const original = new SuiDerivedPublicKey({
+        domain: testDomain,
+        suiAccountAddress: TEST_SUI_ADDRESS,
+        authenticationFunction: testAuthFunction,
+      });
+
+      // Serialize
+      const serializer = new Serializer();
+      original.serialize(serializer);
+      const bytes = serializer.toUint8Array();
+
+      // Deserialize
+      const deserializer = new Deserializer(bytes);
+      const deserialized = SuiDerivedPublicKey.deserialize(deserializer);
+
+      expect(deserialized.domain).toBe(original.domain);
+      expect(deserialized.suiAccountAddress.toLowerCase()).toBe(
+        original.suiAccountAddress.toLowerCase()
+      );
+      expect(deserialized.authenticationFunction).toBe(
+        original.authenticationFunction
+      );
+    });
+
+    it("should preserve auth key through serialization", () => {
+      const original = new SuiDerivedPublicKey({
+        domain: testDomain,
+        suiAccountAddress: TEST_SUI_ADDRESS,
+        authenticationFunction: testAuthFunction,
+      });
+
+      const serializer = new Serializer();
+      original.serialize(serializer);
+      const bytes = serializer.toUint8Array();
+
+      const deserializer = new Deserializer(bytes);
+      const deserialized = SuiDerivedPublicKey.deserialize(deserializer);
+
+      // Compare derived addresses (which are deterministic)
+      expect(deserialized.authKey().derivedAddress().toString()).toBe(
+        original.authKey().derivedAddress().toString()
+      );
+    });
+  });
+});
+

--- a/packages/derived-wallet-sui/tests/SuiDerivedSignature.test.ts
+++ b/packages/derived-wallet-sui/tests/SuiDerivedSignature.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from "vitest";
+import { Deserializer, Serializer } from "@aptos-labs/ts-sdk";
+import { toBase64, fromBase64 } from "@mysten/bcs";
+import { SuiDerivedEd25519Signature } from "../src/SuiDerivedSignature";
+
+describe("SuiDerivedEd25519Signature", () => {
+  // Create a test signature: 1 byte scheme flag + 64 bytes signature + 32 bytes public key
+  const createTestSignature = () => {
+    const signatureBytes = new Uint8Array(97);
+    signatureBytes[0] = 0x00; // Ed25519 scheme flag
+    // Fill signature portion (64 bytes)
+    for (let i = 1; i < 65; i++) {
+      signatureBytes[i] = i;
+    }
+    // Fill public key portion (32 bytes)
+    for (let i = 65; i < 97; i++) {
+      signatureBytes[i] = i - 64;
+    }
+    return toBase64(signatureBytes);
+  };
+
+  const testSignatureBase64 = createTestSignature();
+
+  describe("constructor", () => {
+    it("should store the base64 signature", () => {
+      const sig = new SuiDerivedEd25519Signature(testSignatureBase64);
+      expect(sig.signatureBase64).toBe(testSignatureBase64);
+    });
+  });
+
+  describe("SIGNATURE_LENGTH", () => {
+    it("should be 97 (1 + 64 + 32)", () => {
+      expect(SuiDerivedEd25519Signature.SIGNATURE_LENGTH).toBe(97);
+    });
+  });
+
+  describe("toUint8Array", () => {
+    it("should return the signature as Uint8Array", () => {
+      const sig = new SuiDerivedEd25519Signature(testSignatureBase64);
+      const bytes = sig.toUint8Array();
+
+      expect(bytes).toBeInstanceOf(Uint8Array);
+      expect(bytes.length).toBe(97);
+    });
+
+    it("should return bytes that match the original input", () => {
+      const sig = new SuiDerivedEd25519Signature(testSignatureBase64);
+      const bytes = sig.toUint8Array();
+
+      // Convert back to base64 and compare
+      expect(toBase64(bytes)).toBe(testSignatureBase64);
+    });
+  });
+
+  describe("signatureBase64", () => {
+    it("should return the original base64 signature", () => {
+      const sig = new SuiDerivedEd25519Signature(testSignatureBase64);
+      expect(sig.signatureBase64).toBe(testSignatureBase64);
+    });
+  });
+
+  describe("signatureHex", () => {
+    it("should return the signature as Hex", () => {
+      const sig = new SuiDerivedEd25519Signature(testSignatureBase64);
+      const hex = sig.signatureHex;
+
+      expect(hex).toBeDefined();
+      // Hex string should match the bytes
+      const hexString = hex.toString();
+      expect(hexString).toMatch(/^0x[a-f0-9]+$/i);
+    });
+
+    it("should produce consistent hex output", () => {
+      const sig = new SuiDerivedEd25519Signature(testSignatureBase64);
+
+      const hex1 = sig.signatureHex.toString();
+      const hex2 = sig.signatureHex.toString();
+
+      expect(hex1).toBe(hex2);
+    });
+  });
+
+  describe("serialization", () => {
+    it("should serialize correctly", () => {
+      const sig = new SuiDerivedEd25519Signature(testSignatureBase64);
+
+      const serializer = new Serializer();
+      sig.serialize(serializer);
+
+      const bytes = serializer.toUint8Array();
+      expect(bytes.length).toBeGreaterThan(0);
+    });
+
+    it("should serialize and deserialize roundtrip", () => {
+      const original = new SuiDerivedEd25519Signature(testSignatureBase64);
+
+      // Serialize
+      const serializer = new Serializer();
+      original.serialize(serializer);
+      const bytes = serializer.toUint8Array();
+
+      // Deserialize
+      const deserializer = new Deserializer(bytes);
+      const deserialized = SuiDerivedEd25519Signature.deserialize(deserializer);
+
+      expect(deserialized.signatureBase64).toBe(original.signatureBase64);
+    });
+
+    it("should preserve signature bytes through serialization", () => {
+      const original = new SuiDerivedEd25519Signature(testSignatureBase64);
+
+      const serializer = new Serializer();
+      original.serialize(serializer);
+      const bytes = serializer.toUint8Array();
+
+      const deserializer = new Deserializer(bytes);
+      const deserialized = SuiDerivedEd25519Signature.deserialize(deserializer);
+
+      // Compare the raw bytes
+      const originalBytes = original.toUint8Array();
+      const deserializedBytes = deserialized.toUint8Array();
+
+      expect(deserializedBytes.length).toBe(originalBytes.length);
+      for (let i = 0; i < originalBytes.length; i++) {
+        expect(deserializedBytes[i]).toBe(originalBytes[i]);
+      }
+    });
+  });
+
+  describe("different signature values", () => {
+    it("should handle different valid base64 signatures", () => {
+      // Create another valid signature
+      const otherSignatureBytes = new Uint8Array(97);
+      otherSignatureBytes[0] = 0x00;
+      for (let i = 1; i < 97; i++) {
+        otherSignatureBytes[i] = 255 - i;
+      }
+      const otherBase64 = toBase64(otherSignatureBytes);
+
+      const sig = new SuiDerivedEd25519Signature(otherBase64);
+      expect(sig.signatureBase64).toBe(otherBase64);
+      expect(sig.toUint8Array().length).toBe(97);
+    });
+  });
+});
+

--- a/packages/derived-wallet-sui/tests/SuiDerivedWallet.test.ts
+++ b/packages/derived-wallet-sui/tests/SuiDerivedWallet.test.ts
@@ -1,0 +1,321 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  APTOS_CHAINS,
+  UserResponseStatus,
+} from "@aptos-labs/wallet-standard";
+import {
+  Network,
+  NetworkToChainId,
+  NetworkToNodeAPI,
+} from "@aptos-labs/ts-sdk";
+import type { Wallet } from "@mysten/wallet-standard";
+import { SuiDerivedWallet } from "../src/SuiDerivedWallet";
+import { SuiDerivedPublicKey } from "../src/SuiDerivedPublicKey";
+import { defaultAuthenticationFunction } from "../src/shared";
+import {
+  createConnectedMockSuiWallet,
+  TEST_SUI_KEYPAIR,
+} from "./mocks/suiWallet";
+
+describe("SuiDerivedWallet", () => {
+  let mockSuiWallet: Wallet;
+  let wallet: SuiDerivedWallet;
+
+  beforeEach(() => {
+    mockSuiWallet = createConnectedMockSuiWallet({
+      keypair: TEST_SUI_KEYPAIR,
+      name: "Test Sui Wallet",
+    });
+    wallet = new SuiDerivedWallet(mockSuiWallet);
+  });
+
+  describe("constructor", () => {
+    it("should create wallet from Sui wallet", () => {
+      expect(wallet).toBeDefined();
+      expect(wallet).toBeInstanceOf(SuiDerivedWallet);
+    });
+
+    it("should set wallet name with (Sui) suffix", () => {
+      expect(wallet.name).toBe("Test Sui Wallet (Sui)");
+    });
+
+    it("should set wallet icon from sui wallet", () => {
+      expect(wallet.icon).toBe(mockSuiWallet.icon);
+    });
+
+    it("should set wallet url to empty string", () => {
+      // Sui wallet standard does not have a URL
+      expect(wallet.url).toBe("");
+    });
+
+    it("should set version to 1.0.0", () => {
+      expect(wallet.version).toBe("1.0.0");
+    });
+
+    it("should set chains to APTOS_CHAINS", () => {
+      expect(wallet.chains).toBe(APTOS_CHAINS);
+    });
+
+    it("should default to MAINNET network", () => {
+      expect(wallet.defaultNetwork).toBe(Network.MAINNET);
+    });
+
+    it("should allow custom default network", () => {
+      const testnetWallet = new SuiDerivedWallet(mockSuiWallet, {
+        defaultNetwork: Network.TESTNET,
+      });
+      expect(testnetWallet.defaultNetwork).toBe(Network.TESTNET);
+    });
+
+    it("should use default authentication function", () => {
+      expect(wallet.authenticationFunction).toBe(defaultAuthenticationFunction);
+    });
+
+    it("should allow custom authentication function", () => {
+      const customAuthFunction = "0x1::custom::authenticate";
+      const customWallet = new SuiDerivedWallet(mockSuiWallet, {
+        authenticationFunction: customAuthFunction,
+      });
+      expect(customWallet.authenticationFunction).toBe(customAuthFunction);
+    });
+
+    it("should set domain from window.location.host", () => {
+      expect(wallet.domain).toBe("test.example.com");
+    });
+  });
+
+  describe("features", () => {
+    it("should have all required Aptos features", () => {
+      expect(wallet.features["aptos:connect"]).toBeDefined();
+      expect(wallet.features["aptos:disconnect"]).toBeDefined();
+      expect(wallet.features["aptos:account"]).toBeDefined();
+      expect(wallet.features["aptos:onAccountChange"]).toBeDefined();
+      expect(wallet.features["aptos:network"]).toBeDefined();
+      expect(wallet.features["aptos:changeNetwork"]).toBeDefined();
+      expect(wallet.features["aptos:onNetworkChange"]).toBeDefined();
+      expect(wallet.features["aptos:signMessage"]).toBeDefined();
+      expect(wallet.features["aptos:signTransaction"]).toBeDefined();
+    });
+
+    it("should have correct feature versions", () => {
+      expect(wallet.features["aptos:connect"].version).toBe("1.0.0");
+      expect(wallet.features["aptos:signMessage"].version).toBe("1.0.0");
+      expect(wallet.features["aptos:signTransaction"].version).toBe("1.0.0");
+    });
+  });
+
+  describe("connect", () => {
+    it("should return approved response with account info", async () => {
+      const response = await wallet.connect();
+
+      expect(response.status).toBe(UserResponseStatus.APPROVED);
+      if (response.status === UserResponseStatus.APPROVED) {
+        expect(response.args).toBeDefined();
+        expect(response.args.address).toBeDefined();
+      }
+    });
+
+    it("should return account with derived public key", async () => {
+      const response = await wallet.connect();
+
+      expect(response.status).toBe(UserResponseStatus.APPROVED);
+      if (response.status === UserResponseStatus.APPROVED) {
+        expect(response.args.publicKey).toBeInstanceOf(SuiDerivedPublicKey);
+      }
+    });
+
+    it("should derive Aptos address from Sui account", async () => {
+      const response = await wallet.connect();
+
+      expect(response.status).toBe(UserResponseStatus.APPROVED);
+      if (response.status === UserResponseStatus.APPROVED) {
+        // Address should be a valid 32-byte Aptos address
+        expect(response.args.address.toString()).toMatch(/^0x[a-f0-9]{64}$/i);
+      }
+    });
+  });
+
+  describe("disconnect", () => {
+    it("should disconnect from the underlying Sui wallet", async () => {
+      // Verify wallet is connected initially
+      expect(mockSuiWallet.accounts.length).toBe(1);
+
+      await wallet.disconnect();
+
+      // Verify disconnect was called on the underlying wallet
+      expect(mockSuiWallet.accounts.length).toBe(0);
+    });
+
+    it("should not throw when disconnecting", async () => {
+      await expect(wallet.disconnect()).resolves.not.toThrow();
+    });
+  });
+
+  describe("getActiveAccount", () => {
+    it("should return active account info", async () => {
+      const accountInfo = await wallet.getActiveAccount();
+
+      expect(accountInfo).toBeDefined();
+      expect(accountInfo.publicKey).toBeInstanceOf(SuiDerivedPublicKey);
+    });
+
+    it("should return consistent address for same sui account", async () => {
+      const account1 = await wallet.getActiveAccount();
+      const account2 = await wallet.getActiveAccount();
+
+      expect(account1.address.toString()).toBe(account2.address.toString());
+    });
+  });
+
+  describe("getActiveNetwork", () => {
+    it("should return current network info", async () => {
+      const networkInfo = await wallet.getActiveNetwork();
+
+      expect(networkInfo.name).toBe(Network.MAINNET);
+      expect(networkInfo.chainId).toBe(NetworkToChainId[Network.MAINNET]);
+      expect(networkInfo.url).toBe(NetworkToNodeAPI[Network.MAINNET]);
+    });
+
+    it("should reflect default network setting", async () => {
+      const testnetWallet = new SuiDerivedWallet(mockSuiWallet, {
+        defaultNetwork: Network.TESTNET,
+      });
+
+      const networkInfo = await testnetWallet.getActiveNetwork();
+
+      expect(networkInfo.name).toBe(Network.TESTNET);
+      expect(networkInfo.chainId).toBe(NetworkToChainId[Network.TESTNET]);
+    });
+  });
+
+  describe("changeNetwork", () => {
+    it("should change network successfully", async () => {
+      const response = await wallet.changeNetwork({
+        name: Network.TESTNET,
+        chainId: NetworkToChainId[Network.TESTNET],
+        url: NetworkToNodeAPI[Network.TESTNET],
+      });
+
+      expect(response.status).toBe(UserResponseStatus.APPROVED);
+      if (response.status === UserResponseStatus.APPROVED) {
+        expect(response.args.success).toBe(true);
+      }
+
+      const newNetwork = await wallet.getActiveNetwork();
+      expect(newNetwork.name).toBe(Network.TESTNET);
+    });
+
+    it("should throw for custom network", async () => {
+      await expect(
+        wallet.changeNetwork({
+          name: Network.CUSTOM,
+          url: "https://custom.node.com",
+        })
+      ).rejects.toThrow("Custom network not currently supported");
+    });
+
+    it("should notify listeners on network change", async () => {
+      let notifiedNetwork: { name: Network } | null = null;
+
+      wallet.onActiveNetworkChange((network) => {
+        notifiedNetwork = network;
+      });
+
+      await wallet.changeNetwork({
+        name: Network.TESTNET,
+        chainId: NetworkToChainId[Network.TESTNET],
+        url: NetworkToNodeAPI[Network.TESTNET],
+      });
+
+      expect(notifiedNetwork).not.toBeNull();
+      expect(notifiedNetwork!.name).toBe(Network.TESTNET);
+    });
+
+    it("should use default chainId if not provided", async () => {
+      let notifiedNetwork: { chainId?: number } | null = null;
+
+      wallet.onActiveNetworkChange((network) => {
+        notifiedNetwork = network;
+      });
+
+      await wallet.changeNetwork({
+        name: Network.TESTNET,
+      });
+
+      expect(notifiedNetwork).not.toBeNull();
+      expect(notifiedNetwork!.chainId).toBe(NetworkToChainId[Network.TESTNET]);
+    });
+  });
+
+  describe("onActiveAccountChange", () => {
+    it("should throw not implemented error", () => {
+      expect(() => {
+        wallet.onActiveAccountChange(() => {});
+      }).toThrow("Not implemented");
+    });
+  });
+
+  describe("onActiveNetworkChange", () => {
+    it("should register network change listener", async () => {
+      let receivedNetwork: any = null;
+
+      wallet.onActiveNetworkChange((network) => {
+        receivedNetwork = network;
+      });
+
+      await wallet.changeNetwork({
+        name: Network.TESTNET,
+        chainId: NetworkToChainId[Network.TESTNET],
+        url: NetworkToNodeAPI[Network.TESTNET],
+      });
+
+      expect(receivedNetwork).not.toBeNull();
+      expect(receivedNetwork.name).toBe(Network.TESTNET);
+    });
+
+    it("should clear listeners when passed null callback marker", () => {
+      const callback = () => {};
+      wallet.onActiveNetworkChange(callback);
+
+      // Create a null callback marker (function with _isNull property)
+      const nullCallback = Object.assign(() => {}, { _isNull: true });
+      // Should not throw
+      wallet.onActiveNetworkChange(nullCallback as any);
+
+      // Verify listeners were cleared
+      expect(wallet.onActiveNetworkChangeListeners.size).toBe(0);
+    });
+  });
+
+  describe("signMessage", () => {
+    it("should sign a message", async () => {
+      const response = await wallet.signMessage({
+        message: "Hello, Aptos!",
+        nonce: "12345678",
+      });
+
+      expect(response.status).toBe(UserResponseStatus.APPROVED);
+      if (response.status === UserResponseStatus.APPROVED) {
+        expect(response.args.message).toBe("Hello, Aptos!");
+        expect(response.args.nonce).toBe("12345678");
+        expect(response.args.prefix).toBe("APTOS");
+      }
+    });
+
+    it("should include signature in response", async () => {
+      const response = await wallet.signMessage({
+        message: "Test",
+        nonce: "nonce",
+      });
+
+      expect(response.status).toBe(UserResponseStatus.APPROVED);
+      if (response.status === UserResponseStatus.APPROVED) {
+        expect(response.args.signature).toBeDefined();
+      }
+    });
+  });
+
+  // Note: signTransaction tests require network access to build transactions.
+  // These are tested via integration tests.
+});
+

--- a/packages/derived-wallet-sui/tests/createSuiEnvelope.test.ts
+++ b/packages/derived-wallet-sui/tests/createSuiEnvelope.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import { Hex } from "@aptos-labs/ts-sdk";
+import { createSuiEnvelopeForAptosTransaction } from "../src/createSuiEnvelope";
+import { TEST_SUI_ADDRESS } from "./mocks/suiWallet";
+
+describe("createSuiEnvelope", () => {
+  const testDomain = "test.example.com";
+
+  // Create a test signing message digest (32 bytes)
+  const testDigest = new Uint8Array(32).fill(0xab);
+
+  describe("createSuiEnvelopeForAptosTransaction", () => {
+    // Note: We can't fully test createSuiEnvelopeForAptosTransaction without
+    // a real AnyRawTransaction, which requires network access to build.
+    // These tests verify the envelope structure with a mock transaction.
+
+    // Shared mock transaction to avoid duplication
+    const mockRawTransaction = {
+      rawTransaction: {
+        sender: {
+          toString: () =>
+            "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+        },
+        sequence_number: BigInt(0),
+        payload: {
+          type: "entry_function_payload",
+          function: "0x1::coin::transfer",
+          type_arguments: [],
+          arguments: [],
+        },
+        max_gas_amount: BigInt(2000),
+        gas_unit_price: BigInt(1),
+        expiration_timestamp_secs: BigInt(Math.floor(Date.now() / 1000) + 600),
+        chain_id: { chainId: 1 },
+      },
+    };
+
+    const createEnvelope = () =>
+      createSuiEnvelopeForAptosTransaction({
+        suiAddress: TEST_SUI_ADDRESS,
+        signingMessageDigest: testDigest,
+        domain: testDomain,
+        rawTransaction: mockRawTransaction as any,
+      });
+
+    it("should create an envelope string", () => {
+      const envelope = createEnvelope();
+
+      expect(typeof envelope).toBe("string");
+      expect(envelope.length).toBeGreaterThan(0);
+    });
+
+    it("should include domain in envelope", () => {
+      const envelope = createEnvelope();
+
+      expect(envelope).toContain(testDomain);
+    });
+
+    it("should include sui address in envelope", () => {
+      const envelope = createEnvelope();
+
+      expect(envelope).toContain(TEST_SUI_ADDRESS);
+    });
+
+    it("should include nonce (digest as hex) in envelope", () => {
+      const envelope = createEnvelope();
+
+      const expectedHex = Hex.fromHexInput(testDigest).toString();
+      expect(envelope).toContain(expectedHex);
+    });
+
+    it("should include SIWS format text", () => {
+      const envelope = createEnvelope();
+
+      // Should include the SIWS format "wants you to sign in with your Sui account"
+      expect(envelope).toContain("wants you to sign in with your Sui account");
+    });
+
+    it("should include Nonce label", () => {
+      const envelope = createEnvelope();
+
+      expect(envelope).toContain("Nonce:");
+    });
+  });
+});

--- a/packages/derived-wallet-sui/tests/mocks/suiWallet.ts
+++ b/packages/derived-wallet-sui/tests/mocks/suiWallet.ts
@@ -1,0 +1,138 @@
+/**
+ * Mock Sui Wallet for testing
+ */
+import type { Wallet, WalletAccount } from "@mysten/wallet-standard";
+import type { WalletIcon } from "@aptos-labs/wallet-standard";
+import { toBase64 } from "@mysten/bcs";
+import nacl from "tweetnacl";
+
+export interface MockSuiWalletOptions {
+  keypair: nacl.SignKeyPair;
+  name?: string;
+  initiallyConnected?: boolean;
+}
+
+/**
+ * Test keypair - DO NOT USE IN PRODUCTION
+ * Generated deterministically for testing purposes only
+ */
+export const TEST_SUI_KEYPAIR = nacl.sign.keyPair.fromSeed(
+  new Uint8Array(32).fill(1) // Deterministic seed for reproducible tests
+);
+
+/**
+ * Derive Sui address from public key (simplified for testing)
+ * In reality, Sui addresses are derived differently, but for testing
+ * we just use a hex representation of the public key
+ */
+function deriveSuiAddress(publicKey: Uint8Array): string {
+  // Sui addresses are 32 bytes hex with 0x prefix
+  return (
+    "0x" +
+    Array.from(publicKey)
+      .map((b) => b.toString(16).padStart(2, "0"))
+      .join("")
+  );
+}
+
+/**
+ * Derived from TEST_SUI_KEYPAIR
+ */
+export const TEST_SUI_ADDRESS = deriveSuiAddress(TEST_SUI_KEYPAIR.publicKey);
+
+/**
+ * Creates a mock Sui wallet that simulates wallet behavior
+ */
+export function createMockSuiWallet(options: MockSuiWalletOptions): Wallet {
+  const { keypair, name = "Mock Sui Wallet", initiallyConnected = false } =
+    options;
+
+  const suiAddress = deriveSuiAddress(keypair.publicKey);
+
+  const mockAccount: WalletAccount = {
+    address: suiAddress,
+    publicKey: keypair.publicKey,
+    chains: ["sui:mainnet", "sui:testnet", "sui:devnet"],
+    features: ["sui:signPersonalMessage"],
+  };
+
+  let accounts: readonly WalletAccount[] = initiallyConnected
+    ? [mockAccount]
+    : [];
+
+  const wallet: Wallet = {
+    name,
+    icon: "data:image/svg+xml,<svg></svg>" as WalletIcon,
+    version: "1.0.0" as const,
+    chains: ["sui:mainnet", "sui:testnet", "sui:devnet"],
+    // Use getter so accounts reflects updates after connect/disconnect
+    get accounts() {
+      return accounts;
+    },
+
+    features: {
+      "standard:connect": {
+        version: "1.0.0" as const,
+        connect: async () => {
+          accounts = [mockAccount];
+          return { accounts };
+        },
+      },
+      "standard:disconnect": {
+        version: "1.0.0" as const,
+        disconnect: async () => {
+          accounts = [];
+        },
+      },
+      "standard:events": {
+        version: "1.0.0" as const,
+        on: () => () => {},
+      },
+      "sui:signPersonalMessage": {
+        version: "1.0.0" as const,
+        signPersonalMessage: async (input: {
+          message: Uint8Array;
+          account: WalletAccount;
+        }) => {
+          // Sign the message using Ed25519
+          const signature = nacl.sign.detached(input.message, keypair.secretKey);
+
+          // Sui signatures are: scheme flag (1 byte) + signature (64 bytes) + public key (32 bytes)
+          // For Ed25519, scheme flag is 0x00
+          const fullSignature = new Uint8Array(1 + 64 + 32);
+          fullSignature[0] = 0x00; // Ed25519 scheme flag
+          fullSignature.set(signature, 1);
+          fullSignature.set(keypair.publicKey, 65);
+
+          return {
+            signature: toBase64(fullSignature),
+            bytes: toBase64(input.message),
+          };
+        },
+      },
+    },
+  };
+
+  return wallet;
+}
+
+/**
+ * Creates a pre-connected mock Sui wallet
+ */
+export function createConnectedMockSuiWallet(
+  options: MockSuiWalletOptions
+): Wallet {
+  return createMockSuiWallet({ ...options, initiallyConnected: true });
+}
+
+/**
+ * Creates a mock wallet without signPersonalMessage feature
+ * Useful for testing missing feature handling
+ */
+export function createWalletWithoutSignFeature(
+  options: MockSuiWalletOptions
+): Wallet {
+  const wallet = createConnectedMockSuiWallet(options);
+  delete (wallet.features as any)["sui:signPersonalMessage"];
+  return wallet;
+}

--- a/packages/derived-wallet-sui/tests/setup.ts
+++ b/packages/derived-wallet-sui/tests/setup.ts
@@ -1,0 +1,25 @@
+/**
+ * Vitest setup file for derived-wallet-sui tests
+ * Configures happy-dom environment and global mocks
+ */
+
+// Configure window.location for tests that need it
+// happy-dom provides this, but we can override specific values if needed
+if (typeof window !== "undefined") {
+  Object.defineProperty(window, "location", {
+    value: {
+      host: "test.example.com",
+      origin: "https://test.example.com",
+      protocol: "https:",
+      href: "https://test.example.com",
+      hostname: "test.example.com",
+      port: "",
+      pathname: "/",
+      search: "",
+      hash: "",
+    },
+    writable: true,
+    configurable: true,
+  });
+}
+

--- a/packages/derived-wallet-sui/tests/shared.test.ts
+++ b/packages/derived-wallet-sui/tests/shared.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from "vitest";
+import { UserResponseStatus } from "@aptos-labs/wallet-standard";
+import {
+  defaultAuthenticationFunction,
+  wrapSuiUserResponse,
+} from "../src/shared";
+
+describe("shared", () => {
+  describe("defaultAuthenticationFunction", () => {
+    it("should be the correct authentication function", () => {
+      expect(defaultAuthenticationFunction).toBe(
+        "0x1::sui_derivable_account::authenticate"
+      );
+    });
+
+    it("should be a valid Move function identifier format", () => {
+      expect(defaultAuthenticationFunction).toMatch(
+        /^0x[a-f0-9]+::\w+::\w+$/i
+      );
+    });
+  });
+
+  describe("wrapSuiUserResponse", () => {
+    it("should wrap successful promise as approved user response", async () => {
+      const testValue = { data: "test" };
+      const promise = Promise.resolve(testValue);
+
+      const response = await wrapSuiUserResponse(promise);
+
+      expect(response.status).toBe(UserResponseStatus.APPROVED);
+      if (response.status === UserResponseStatus.APPROVED) {
+        expect(response.args).toEqual(testValue);
+      }
+    });
+
+    it("should wrap Uint8Array result as approved", async () => {
+      const signature = new Uint8Array([1, 2, 3, 4]);
+      const promise = Promise.resolve(signature);
+
+      const response = await wrapSuiUserResponse(promise);
+
+      expect(response.status).toBe(UserResponseStatus.APPROVED);
+      if (response.status === UserResponseStatus.APPROVED) {
+        expect(response.args).toEqual(signature);
+      }
+    });
+
+    it("should convert error with code 4001 to rejection (OKX wallet)", async () => {
+      const error = { code: 4001, message: "User rejected" };
+      const promise = Promise.reject(error);
+
+      const response = await wrapSuiUserResponse(promise);
+
+      expect(response.status).toBe(UserResponseStatus.REJECTED);
+    });
+
+    it("should convert error with rejected message to rejection", async () => {
+      const error = new Error("Transaction rejected by user");
+      const promise = Promise.reject(error);
+
+      const response = await wrapSuiUserResponse(promise);
+
+      expect(response.status).toBe(UserResponseStatus.REJECTED);
+    });
+
+    it("should convert error with denied message to rejection", async () => {
+      const error = new Error("Request denied");
+      const promise = Promise.reject(error);
+
+      const response = await wrapSuiUserResponse(promise);
+
+      expect(response.status).toBe(UserResponseStatus.REJECTED);
+    });
+
+    it("should re-throw errors with different messages", async () => {
+      const error = new Error("Connection failed");
+      const promise = Promise.reject(error);
+
+      await expect(wrapSuiUserResponse(promise)).rejects.toThrow(
+        "Connection failed"
+      );
+    });
+
+    it("should re-throw non-object errors", async () => {
+      const promise = Promise.reject("string error");
+
+      await expect(wrapSuiUserResponse(promise)).rejects.toBe("string error");
+    });
+
+    it("should handle null/undefined results", async () => {
+      const nullPromise = Promise.resolve(null);
+      const undefinedPromise = Promise.resolve(undefined);
+
+      const nullResponse = await wrapSuiUserResponse(nullPromise);
+      const undefinedResponse = await wrapSuiUserResponse(undefinedPromise);
+
+      expect(nullResponse.status).toBe(UserResponseStatus.APPROVED);
+      expect(undefinedResponse.status).toBe(UserResponseStatus.APPROVED);
+    });
+
+    it("should handle object results", async () => {
+      const signResult = {
+        signature: "base64signature",
+        bytes: "base64bytes",
+      };
+      const promise = Promise.resolve(signResult);
+
+      const response = await wrapSuiUserResponse(promise);
+
+      expect(response.status).toBe(UserResponseStatus.APPROVED);
+      if (response.status === UserResponseStatus.APPROVED) {
+        expect(response.args).toEqual(signResult);
+      }
+    });
+
+    it("should be case insensitive when checking rejection message", async () => {
+      const lowerCaseError = new Error("user rejected the request");
+      const upperCaseError = new Error("USER REJECTED THE REQUEST");
+      const mixedCaseError = new Error("User REJECTED The Request");
+
+      const response1 = await wrapSuiUserResponse(Promise.reject(lowerCaseError));
+      const response2 = await wrapSuiUserResponse(Promise.reject(upperCaseError));
+      const response3 = await wrapSuiUserResponse(Promise.reject(mixedCaseError));
+
+      expect(response1.status).toBe(UserResponseStatus.REJECTED);
+      expect(response2.status).toBe(UserResponseStatus.REJECTED);
+      expect(response3.status).toBe(UserResponseStatus.REJECTED);
+    });
+  });
+});
+

--- a/packages/derived-wallet-sui/tests/signAptosMessage.test.ts
+++ b/packages/derived-wallet-sui/tests/signAptosMessage.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { UserResponseStatus } from "@aptos-labs/wallet-standard";
+import type { Wallet } from "@mysten/wallet-standard";
+import { signAptosMessageWithSui } from "../src/signAptosMessage";
+import { defaultAuthenticationFunction } from "../src/shared";
+import { SuiDerivedEd25519Signature } from "../src/SuiDerivedSignature";
+import {
+  createConnectedMockSuiWallet,
+  createMockSuiWallet,
+  createWalletWithoutSignFeature,
+  TEST_SUI_KEYPAIR,
+} from "./mocks/suiWallet";
+
+describe("signAptosMessage", () => {
+  let mockWallet: Wallet;
+  const testDomain = "test.example.com";
+
+  beforeEach(() => {
+    mockWallet = createConnectedMockSuiWallet({
+      keypair: TEST_SUI_KEYPAIR,
+    });
+  });
+
+  describe("signAptosMessageWithSui", () => {
+    it("should sign a simple message", async () => {
+      const response = await signAptosMessageWithSui({
+        suiWallet: mockWallet,
+        suiAccount: mockWallet.accounts[0],
+        authenticationFunction: defaultAuthenticationFunction,
+        messageInput: {
+          message: "Hello, Aptos!",
+          nonce: "12345678",
+        },
+        domain: testDomain,
+      });
+
+      expect(response.status).toBe(UserResponseStatus.APPROVED);
+      if (response.status === UserResponseStatus.APPROVED) {
+        expect(response.args.message).toBe("Hello, Aptos!");
+        expect(response.args.nonce).toBe("12345678");
+        expect(response.args.prefix).toBe("APTOS");
+      }
+    });
+
+    it("should return SuiDerivedEd25519Signature", async () => {
+      const response = await signAptosMessageWithSui({
+        suiWallet: mockWallet,
+        suiAccount: mockWallet.accounts[0],
+        authenticationFunction: defaultAuthenticationFunction,
+        messageInput: {
+          message: "Test message",
+          nonce: "nonce123",
+        },
+        domain: testDomain,
+      });
+
+      expect(response.status).toBe(UserResponseStatus.APPROVED);
+      if (response.status === UserResponseStatus.APPROVED) {
+        expect(response.args.signature).toBeInstanceOf(
+          SuiDerivedEd25519Signature
+        );
+      }
+    });
+
+    it("should include full message in response", async () => {
+      const response = await signAptosMessageWithSui({
+        suiWallet: mockWallet,
+        suiAccount: mockWallet.accounts[0],
+        authenticationFunction: defaultAuthenticationFunction,
+        messageInput: {
+          message: "My test message",
+          nonce: "abc123",
+        },
+        domain: testDomain,
+      });
+
+      expect(response.status).toBe(UserResponseStatus.APPROVED);
+      if (response.status === UserResponseStatus.APPROVED) {
+        expect(response.args.fullMessage).toBeDefined();
+        expect(typeof response.args.fullMessage).toBe("string");
+        // Full message should contain the original message
+        expect(response.args.fullMessage).toContain("My test message");
+      }
+    });
+
+    it("should handle message with address flag", async () => {
+      const response = await signAptosMessageWithSui({
+        suiWallet: mockWallet,
+        suiAccount: mockWallet.accounts[0],
+        authenticationFunction: defaultAuthenticationFunction,
+        messageInput: {
+          message: "Message with address",
+          nonce: "addr-nonce",
+          address: true,
+        },
+        domain: testDomain,
+      });
+
+      expect(response.status).toBe(UserResponseStatus.APPROVED);
+      if (response.status === UserResponseStatus.APPROVED) {
+        // When address flag is true, fullMessage should contain an Aptos address
+        expect(response.args.fullMessage).toContain("0x");
+      }
+    });
+
+    it("should handle message with application flag", async () => {
+      const response = await signAptosMessageWithSui({
+        suiWallet: mockWallet,
+        suiAccount: mockWallet.accounts[0],
+        authenticationFunction: defaultAuthenticationFunction,
+        messageInput: {
+          message: "Message with application",
+          nonce: "app-nonce",
+          application: true,
+        },
+        domain: testDomain,
+      });
+
+      expect(response.status).toBe(UserResponseStatus.APPROVED);
+      if (response.status === UserResponseStatus.APPROVED) {
+        // When application flag is true, fullMessage should contain the origin
+        expect(response.args.fullMessage).toContain("test.example.com");
+      }
+    });
+
+    it("should handle message with chainId", async () => {
+      const response = await signAptosMessageWithSui({
+        suiWallet: mockWallet,
+        suiAccount: mockWallet.accounts[0],
+        authenticationFunction: defaultAuthenticationFunction,
+        messageInput: {
+          message: "Message with chain ID",
+          nonce: "chain-nonce",
+          chainId: 2, // Testnet
+        },
+        domain: testDomain,
+      });
+
+      expect(response.status).toBe(UserResponseStatus.APPROVED);
+      if (response.status === UserResponseStatus.APPROVED) {
+        // Chain ID should be included in full message
+        expect(response.args.fullMessage).toContain("2");
+      }
+    });
+
+    it("should throw if wallet does not support signPersonalMessage", async () => {
+      const walletWithoutSignFeature = createWalletWithoutSignFeature({
+        keypair: TEST_SUI_KEYPAIR,
+      });
+
+      await expect(
+        signAptosMessageWithSui({
+          suiWallet: walletWithoutSignFeature,
+          suiAccount: walletWithoutSignFeature.accounts[0],
+          authenticationFunction: defaultAuthenticationFunction,
+          messageInput: {
+            message: "Test",
+            nonce: "test",
+          },
+          domain: testDomain,
+        })
+      ).rejects.toThrow("sui:signPersonalMessage not available");
+    });
+
+    it("should throw if account not connected", async () => {
+      const disconnectedWallet = createMockSuiWallet({
+        keypair: TEST_SUI_KEYPAIR,
+      });
+      // Wallet is not connected by default - accounts array is empty
+
+      await expect(
+        signAptosMessageWithSui({
+          suiWallet: disconnectedWallet,
+          suiAccount: { address: "" } as any, // Empty address
+          authenticationFunction: defaultAuthenticationFunction,
+          messageInput: {
+            message: "Test",
+            nonce: "test",
+          },
+          domain: testDomain,
+        })
+      ).rejects.toThrow("Account not connected");
+    });
+
+    it("should handle different nonce values", async () => {
+      const response1 = await signAptosMessageWithSui({
+        suiWallet: mockWallet,
+        suiAccount: mockWallet.accounts[0],
+        authenticationFunction: defaultAuthenticationFunction,
+        messageInput: {
+          message: "Same message",
+          nonce: "nonce1",
+        },
+        domain: testDomain,
+      });
+
+      const response2 = await signAptosMessageWithSui({
+        suiWallet: mockWallet,
+        suiAccount: mockWallet.accounts[0],
+        authenticationFunction: defaultAuthenticationFunction,
+        messageInput: {
+          message: "Same message",
+          nonce: "nonce2",
+        },
+        domain: testDomain,
+      });
+
+      expect(response1.status).toBe(UserResponseStatus.APPROVED);
+      expect(response2.status).toBe(UserResponseStatus.APPROVED);
+
+      if (
+        response1.status === UserResponseStatus.APPROVED &&
+        response2.status === UserResponseStatus.APPROVED
+      ) {
+        expect(response1.args.nonce).toBe("nonce1");
+        expect(response2.args.nonce).toBe("nonce2");
+      }
+    });
+  });
+});
+

--- a/packages/derived-wallet-sui/tests/signAptosTransaction.test.ts
+++ b/packages/derived-wallet-sui/tests/signAptosTransaction.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import type { Wallet } from "@mysten/wallet-standard";
+import { signAptosTransactionWithSui, SIGNATURE_TYPE } from "../src/signAptosTransaction";
+import { defaultAuthenticationFunction } from "../src/shared";
+import {
+  createConnectedMockSuiWallet,
+  createMockSuiWallet,
+  createWalletWithoutSignFeature,
+  TEST_SUI_KEYPAIR,
+} from "./mocks/suiWallet";
+
+describe("signAptosTransaction", () => {
+  let mockWallet: Wallet;
+  const testDomain = "test.example.com";
+
+  beforeEach(() => {
+    mockWallet = createConnectedMockSuiWallet({
+      keypair: TEST_SUI_KEYPAIR,
+    });
+  });
+
+  describe("SIGNATURE_TYPE", () => {
+    it("should be 0", () => {
+      expect(SIGNATURE_TYPE).toBe(0);
+    });
+  });
+
+  describe("signAptosTransactionWithSui error handling", () => {
+    // Note: Full transaction signing tests require network access to build
+    // real AnyRawTransaction objects. These tests focus on error handling.
+
+    it("should throw if wallet does not support signPersonalMessage", async () => {
+      const walletWithoutSignFeature = createWalletWithoutSignFeature({
+        keypair: TEST_SUI_KEYPAIR,
+      });
+
+      // Create a minimal mock transaction that will trigger the feature check
+      const mockRawTransaction = {} as any;
+
+      await expect(
+        signAptosTransactionWithSui({
+          suiWallet: walletWithoutSignFeature,
+          suiAccount: walletWithoutSignFeature.accounts[0],
+          authenticationFunction: defaultAuthenticationFunction,
+          rawTransaction: mockRawTransaction,
+          domain: testDomain,
+        })
+      ).rejects.toThrow("sui:signPersonalMessage not available");
+    });
+
+    it("should throw if account not connected (empty address)", async () => {
+      const disconnectedWallet = createMockSuiWallet({
+        keypair: TEST_SUI_KEYPAIR,
+      });
+
+      // Create a minimal mock transaction
+      const mockRawTransaction = {} as any;
+
+      await expect(
+        signAptosTransactionWithSui({
+          suiWallet: disconnectedWallet,
+          suiAccount: { address: "" } as any, // Empty address
+          authenticationFunction: defaultAuthenticationFunction,
+          rawTransaction: mockRawTransaction,
+          domain: testDomain,
+        })
+      ).rejects.toThrow("Account not connected");
+    });
+
+    it("should use the provided authentication function", async () => {
+      // This test verifies that custom auth functions are passed through
+      const customAuthFunction = "0x1::custom::authenticate";
+      const walletWithoutSign = createWalletWithoutSignFeature({
+        keypair: TEST_SUI_KEYPAIR,
+      });
+
+      // We expect this to fail at the feature check, but we're verifying
+      // the input structure is correct
+      try {
+        await signAptosTransactionWithSui({
+          suiWallet: walletWithoutSign,
+          suiAccount: walletWithoutSign.accounts[0],
+          authenticationFunction: customAuthFunction,
+          rawTransaction: {} as any,
+          domain: testDomain,
+        });
+      } catch (e) {
+        // Expected to throw, we're just testing the input is accepted
+        expect((e as Error).message).toBe("sui:signPersonalMessage not available");
+      }
+    });
+
+    it("should use the provided domain", async () => {
+      const customDomain = "custom.domain.com";
+      const walletWithoutSign = createWalletWithoutSignFeature({
+        keypair: TEST_SUI_KEYPAIR,
+      });
+
+      // We expect this to fail at the feature check, but we're verifying
+      // the input structure is correct
+      try {
+        await signAptosTransactionWithSui({
+          suiWallet: walletWithoutSign,
+          suiAccount: walletWithoutSign.accounts[0],
+          authenticationFunction: defaultAuthenticationFunction,
+          rawTransaction: {} as any,
+          domain: customDomain,
+        });
+      } catch (e) {
+        // Expected to throw, we're just testing the input is accepted
+        expect((e as Error).message).toBe("sui:signPersonalMessage not available");
+      }
+    });
+  });
+});
+

--- a/packages/derived-wallet-sui/tsconfig.json
+++ b/packages/derived-wallet-sui/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "@aptos-labs/wallet-adapter-tsconfig/base.json",
-  "include": ["."],
-  "exclude": ["dist", "build", "node_modules"],
+  "include": ["src"],
+  "exclude": ["dist", "build", "node_modules", "tests"],
   "compilerOptions": {
     "target": "es2020",
     "lib": ["es2021", "dom"],

--- a/packages/derived-wallet-sui/vitest.config.ts
+++ b/packages/derived-wallet-sui/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "happy-dom",
+    include: ["tests/**/*.test.ts"],
+    setupFiles: ["./tests/setup.ts"],
+  },
+});
+

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -619,27 +619,27 @@ importers:
       '@aptos-labs/wallet-adapter-tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
-      '@types/jest':
-        specifier: ^29.2.4
-        version: 29.5.14
       '@types/node':
         specifier: ^20.10.4
         version: 20.19.17
       eslint:
         specifier: ^8.15.0
         version: 8.57.1
-      jest:
-        specifier: ^29.3.1
-        version: 29.7.0(@types/node@20.19.17)(babel-plugin-macros@3.1.0)
-      ts-jest:
-        specifier: ^29.0.3
-        version: 29.3.0(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(jest@29.7.0(@types/node@20.19.17)(babel-plugin-macros@3.1.0))(typescript@5.8.3)
+      happy-dom:
+        specifier: ^15.11.7
+        version: 15.11.7
       tsup:
         specifier: ^8.4.0
         version: 8.4.0(@microsoft/api-extractor@7.43.0(@types/node@20.19.17))(@swc/core@1.11.16(@swc/helpers@0.5.15))(jiti@2.5.1)(postcss@8.5.6)(typescript@5.8.3)(yaml@2.8.1)
+      tweetnacl:
+        specifier: ^1.0.3
+        version: 1.0.3
       typescript:
         specifier: ^5.4.5
         version: 5.8.3
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@20.19.17)(happy-dom@15.11.7)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1)
 
   packages/eslint-config-adapter:
     dependencies:
@@ -746,7 +746,7 @@ importers:
         version: 29.7.0(@types/node@20.17.27)(babel-plugin-macros@3.1.0)
       ts-jest:
         specifier: ^29.0.3
-        version: 29.3.0(@babel/core@7.28.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.4))(jest@29.7.0(@types/node@20.17.27)(babel-plugin-macros@3.1.0))(typescript@5.8.3)
+        version: 29.3.0(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(jest@29.7.0(@types/node@20.17.27)(babel-plugin-macros@3.1.0))(typescript@5.8.3)
       tsup:
         specifier: ^8.4.0
         version: 8.4.0(@microsoft/api-extractor@7.43.0(@types/node@20.17.27))(@swc/core@1.11.16(@swc/helpers@0.5.15))(jiti@2.5.1)(postcss@8.5.6)(typescript@5.8.3)(yaml@2.8.1)
@@ -11264,77 +11264,35 @@ snapshots:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.28.4)':
-    dependencies:
-      '@babel/core': 7.28.4
-      '@babel/helper-plugin-utils': 7.27.1
-    optional: true
-
   '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.27.1
-
-  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.28.4)':
-    dependencies:
-      '@babel/core': 7.28.4
-      '@babel/helper-plugin-utils': 7.27.1
-    optional: true
 
   '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.28.4)':
-    dependencies:
-      '@babel/core': 7.28.4
-      '@babel/helper-plugin-utils': 7.27.1
-    optional: true
-
   '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.27.1
-
-  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.28.4)':
-    dependencies:
-      '@babel/core': 7.28.4
-      '@babel/helper-plugin-utils': 7.27.1
-    optional: true
 
   '@babel/plugin-syntax-import-attributes@7.26.0(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-import-attributes@7.26.0(@babel/core@7.28.4)':
-    dependencies:
-      '@babel/core': 7.28.4
-      '@babel/helper-plugin-utils': 7.27.1
-    optional: true
-
   '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.28.4)':
-    dependencies:
-      '@babel/core': 7.28.4
-      '@babel/helper-plugin-utils': 7.27.1
-    optional: true
-
   '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.27.1
-
-  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.28.4)':
-    dependencies:
-      '@babel/core': 7.28.4
-      '@babel/helper-plugin-utils': 7.27.1
-    optional: true
 
   '@babel/plugin-syntax-jsx@7.25.9(@babel/core@7.26.10)':
     dependencies:
@@ -11351,88 +11309,40 @@ snapshots:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.28.4)':
-    dependencies:
-      '@babel/core': 7.28.4
-      '@babel/helper-plugin-utils': 7.27.1
-    optional: true
-
   '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.27.1
-
-  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.28.4)':
-    dependencies:
-      '@babel/core': 7.28.4
-      '@babel/helper-plugin-utils': 7.27.1
-    optional: true
 
   '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.28.4)':
-    dependencies:
-      '@babel/core': 7.28.4
-      '@babel/helper-plugin-utils': 7.27.1
-    optional: true
-
   '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.27.1
-
-  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.28.4)':
-    dependencies:
-      '@babel/core': 7.28.4
-      '@babel/helper-plugin-utils': 7.27.1
-    optional: true
 
   '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.28.4)':
-    dependencies:
-      '@babel/core': 7.28.4
-      '@babel/helper-plugin-utils': 7.27.1
-    optional: true
-
   '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.27.1
-
-  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.28.4)':
-    dependencies:
-      '@babel/core': 7.28.4
-      '@babel/helper-plugin-utils': 7.27.1
-    optional: true
 
   '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.28.4)':
-    dependencies:
-      '@babel/core': 7.28.4
-      '@babel/helper-plugin-utils': 7.27.1
-    optional: true
-
   '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.27.1
-
-  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.28.4)':
-    dependencies:
-      '@babel/core': 7.28.4
-      '@babel/helper-plugin-utils': 7.27.1
-    optional: true
 
   '@babel/plugin-syntax-typescript@7.25.9(@babel/core@7.26.10)':
     dependencies:
@@ -15350,6 +15260,14 @@ snapshots:
     optionalDependencies:
       vite: 6.3.6(@types/node@20.17.27)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1)
 
+  '@vitest/mocker@2.1.9(vite@6.3.6(@types/node@20.19.17)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.19
+    optionalDependencies:
+      vite: 6.3.6(@types/node@20.19.17)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1)
+
   '@vitest/pretty-format@2.1.9':
     dependencies:
       tinyrainbow: 1.2.0
@@ -16477,20 +16395,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-jest@29.7.0(@babel/core@7.28.4):
-    dependencies:
-      '@babel/core': 7.28.4
-      '@jest/transform': 29.7.0
-      '@types/babel__core': 7.20.5
-      babel-plugin-istanbul: 6.1.1
-      babel-preset-jest: 29.6.3(@babel/core@7.28.4)
-      chalk: 4.1.2
-      graceful-fs: 4.2.11
-      slash: 3.0.0
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   babel-plugin-istanbul@6.1.1:
     dependencies:
       '@babel/helper-plugin-utils': 7.26.5
@@ -16533,38 +16437,11 @@ snapshots:
       '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.26.10)
       '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.26.10)
 
-  babel-preset-current-node-syntax@1.1.0(@babel/core@7.28.4):
-    dependencies:
-      '@babel/core': 7.28.4
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.28.4)
-      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.28.4)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.28.4)
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.28.4)
-      '@babel/plugin-syntax-import-attributes': 7.26.0(@babel/core@7.28.4)
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.28.4)
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.28.4)
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.28.4)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.28.4)
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.28.4)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.28.4)
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.28.4)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.28.4)
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.28.4)
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.28.4)
-    optional: true
-
   babel-preset-jest@29.6.3(@babel/core@7.26.10):
     dependencies:
       '@babel/core': 7.26.10
       babel-plugin-jest-hoist: 29.6.3
       babel-preset-current-node-syntax: 1.1.0(@babel/core@7.26.10)
-
-  babel-preset-jest@29.6.3(@babel/core@7.28.4):
-    dependencies:
-      '@babel/core': 7.28.4
-      babel-plugin-jest-hoist: 29.6.3
-      babel-preset-current-node-syntax: 1.1.0(@babel/core@7.28.4)
-    optional: true
 
   balanced-match@1.0.2: {}
 
@@ -17045,21 +16922,6 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-config: 29.7.0(@types/node@20.17.27)(babel-plugin-macros@3.1.0)
-      jest-util: 29.7.0
-      prompts: 2.4.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
-  create-jest@29.7.0(@types/node@20.19.17)(babel-plugin-macros@3.1.0):
-    dependencies:
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@20.19.17)(babel-plugin-macros@3.1.0)
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -19170,25 +19032,6 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@20.19.17)(babel-plugin-macros@3.1.0):
-    dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)
-      '@jest/test-result': 29.7.0
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.19.17)(babel-plugin-macros@3.1.0)
-      exit: 0.1.2
-      import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@20.19.17)(babel-plugin-macros@3.1.0)
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   jest-config@29.7.0(@types/node@20.17.27)(babel-plugin-macros@3.1.0):
     dependencies:
       '@babel/core': 7.26.10
@@ -19476,18 +19319,6 @@ snapshots:
       '@jest/types': 29.6.3
       import-local: 3.2.0
       jest-cli: 29.7.0(@types/node@20.17.27)(babel-plugin-macros@3.1.0)
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
-  jest@29.7.0(@types/node@20.19.17)(babel-plugin-macros@3.1.0):
-    dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)
-      '@jest/types': 29.6.3
-      import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@20.19.17)(babel-plugin-macros@3.1.0)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -22354,27 +22185,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  ts-jest@29.3.0(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(jest@29.7.0(@types/node@20.19.17)(babel-plugin-macros@3.1.0))(typescript@5.8.3):
-    dependencies:
-      bs-logger: 0.2.6
-      ejs: 3.1.10
-      fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@20.19.17)(babel-plugin-macros@3.1.0)
-      jest-util: 29.7.0
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.7.1
-      type-fest: 4.38.0
-      typescript: 5.8.3
-      yargs-parser: 21.1.1
-    optionalDependencies:
-      '@babel/core': 7.26.10
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.26.10)
-
-  ts-jest@29.3.0(@babel/core@7.28.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.4))(jest@29.7.0(@types/node@20.17.27)(babel-plugin-macros@3.1.0))(typescript@5.8.3):
+  ts-jest@29.3.0(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(jest@29.7.0(@types/node@20.17.27)(babel-plugin-macros@3.1.0))(typescript@5.8.3):
     dependencies:
       bs-logger: 0.2.6
       ejs: 3.1.10
@@ -22389,10 +22200,10 @@ snapshots:
       typescript: 5.8.3
       yargs-parser: 21.1.1
     optionalDependencies:
-      '@babel/core': 7.28.4
+      '@babel/core': 7.26.10
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.28.4)
+      babel-jest: 29.7.0(@babel/core@7.26.10)
 
   tsconfig-paths@3.15.0:
     dependencies:
@@ -22874,6 +22685,27 @@ snapshots:
       - tsx
       - yaml
 
+  vite-node@2.1.9(@types/node@20.19.17)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 6.3.6(@types/node@20.19.17)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vite-node@3.2.4(@types/node@24.5.2)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1):
     dependencies:
       cac: 6.7.14
@@ -22993,6 +22825,21 @@ snapshots:
       terser: 5.44.0
       yaml: 2.8.1
 
+  vite@6.3.6(@types/node@20.19.17)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1):
+    dependencies:
+      esbuild: 0.25.1
+      fdir: 6.4.4(picomatch@4.0.2)
+      picomatch: 4.0.2
+      postcss: 8.5.6
+      rollup: 4.50.2
+      tinyglobby: 0.2.13
+    optionalDependencies:
+      '@types/node': 20.19.17
+      fsevents: 2.3.3
+      jiti: 2.5.1
+      terser: 5.44.0
+      yaml: 2.8.1
+
   vite@6.3.6(@types/node@24.5.2)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1):
     dependencies:
       esbuild: 0.25.1
@@ -23032,6 +22879,45 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.17.27
+      happy-dom: 15.11.7
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vitest@2.1.9(@types/node@20.19.17)(happy-dom@15.11.7)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@6.3.6(@types/node@20.19.17)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.19
+      pathe: 1.1.2
+      std-env: 3.9.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 6.3.6(@types/node@20.19.17)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1)
+      vite-node: 2.1.9(@types/node@20.19.17)(jiti@2.5.1)(terser@5.44.0)(yaml@2.8.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.19.17
       happy-dom: 15.11.7
     transitivePeerDependencies:
       - jiti


### PR DESCRIPTION
## Summary

This PR adds a comprehensive test suite to the `derived-wallet-sui` package, migrating from Jest to Vitest.

## Changes

### Configuration
- Migrate from Jest to Vitest
- Add `happy-dom` environment for `window.location` access
- Add `tweetnacl` for mock wallet signing

### Test Coverage (86 tests across 7 files)

| File | Tests | Coverage |
|------|-------|----------|
| `SuiDerivedPublicKey.test.ts` | 12 | Constructor, authKey, verifySignature, serialization |
| `SuiDerivedSignature.test.ts` | 11 | Constructor, toUint8Array, getters, serialization |
| `SuiDerivedWallet.test.ts` | 31 | Constructor, features, connect/disconnect, networks, signing |
| `createSuiEnvelope.test.ts` | 6 | Envelope format, domain, address, nonce |
| `signAptosMessage.test.ts` | 9 | Message signing, flags, error cases |
| `signAptosTransaction.test.ts` | 5 | Error handling for missing features |
| `shared.test.ts` | 12 | Auth function constant, wrapSuiUserResponse |

### Test Infrastructure
- Mock Sui wallet implementation (`tests/mocks/suiWallet.ts`)
- Setup file for `happy-dom` environment (`tests/setup.ts`)

## Testing

```bash
cd packages/derived-wallet-sui && pnpm test
```

All 86 tests pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR primarily changes test infrastructure (Jest→Vitest) and adds new unit tests/mocks without altering runtime source behavior.
> 
> **Overview**
> Adds a Vitest-based test setup for `derived-wallet-sui`, replacing Jest (`package.json` script/deps) and introducing `vitest.config.ts` with a `happy-dom` environment plus a test `setup.ts` for `window.location`.
> 
> Introduces a new `tests/` suite covering derived public keys/signatures, wallet connect/network/message signing behaviors, SIWS envelope creation, and shared helpers, backed by a deterministic mock Sui wallet implementation using `tweetnacl`.
> 
> Tightens `tsconfig.json` to compile only `src` (excluding `tests`), and updates the lockfile for the new testing dependencies.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fcc8e7cff5a76e6930eedf4961da04f717c30c4c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->