### PR TITLE
Remove vue/nuxt from changeset ignore

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,6 +7,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "privatePackages": false,
-  "ignore": ["@aptos-labs/wallet-adapter-vue", "nuxt-app"]
+  "privatePackages": false
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk config-only change that just re-enables changeset versioning for previously ignored packages.
> 
> **Overview**
> Removes the `ignore` list from `.changeset/config.json`, so changesets will now include the previously excluded `@aptos-labs/wallet-adapter-vue` and `nuxt-app` packages in versioning/release workflows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2812201e26bcb6ea75207330f3e91a1bcf3b9dc2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->