### PR TITLE
Support gas station for cctp withdraw transactions

### DIFF
--- a/.changeset/cyan-onions-push.md
+++ b/.changeset/cyan-onions-push.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/cross-chain-core": minor
+---
+
+Support gas station for cctp withdraw transactions

--- a/apps/nextjs-x-chain/src/app/components/CCTPTransfer.tsx
+++ b/apps/nextjs-x-chain/src/app/components/CCTPTransfer.tsx
@@ -13,13 +13,11 @@ import {
   EthereumChainIdToTestnetChain,
   CrossChainCore,
   EthereumChainIdToMainnetChain,
+  GasStationApiKey,
 } from "@aptos-labs/cross-chain-core";
 import {
   Account,
-  Ed25519PrivateKey,
   Network,
-  PrivateKey,
-  PrivateKeyVariants,
 } from "@aptos-labs/ts-sdk";
 import {
   Chain,
@@ -51,7 +49,7 @@ export function CCTPTransfer({
   wallet: AdapterWallet | null;
   originWalletDetails: OriginWalletDetails | undefined;
   mainSigner: Account;
-  sponsorAccount: Account;
+  sponsorAccount: Account | GasStationApiKey;
   dappNetwork: Network.MAINNET | Network.TESTNET;
   crossChainCore: CrossChainCore;
   provider: any; // We'll type this properly later

--- a/apps/nextjs-x-chain/src/app/components/CCTPWithdraw.tsx
+++ b/apps/nextjs-x-chain/src/app/components/CCTPWithdraw.tsx
@@ -13,13 +13,11 @@ import {
   CrossChainCore,
   EthereumChainIdToMainnetChain,
   EthereumChainIdToTestnetChain,
+  GasStationApiKey,
 } from "@aptos-labs/cross-chain-core";
 import {
   Account,
-  Ed25519PrivateKey,
   Network,
-  PrivateKey,
-  PrivateKeyVariants,
 } from "@aptos-labs/ts-sdk";
 import {
   Chain,
@@ -49,7 +47,7 @@ export function CCTPWithdraw({
 }: {
   wallet: AdapterWallet | null;
   originWalletDetails: OriginWalletDetails | undefined;
-  sponsorAccount: Account;
+  sponsorAccount: Account | GasStationApiKey;
   dappNetwork: Network.MAINNET | Network.TESTNET;
   crossChainCore: CrossChainCore;
   provider: any; // We'll type this properly later

--- a/apps/nextjs-x-chain/src/app/page.tsx
+++ b/apps/nextjs-x-chain/src/app/page.tsx
@@ -23,6 +23,7 @@ import {
 import { CCTPWithdraw } from "./components/CCTPWithdraw";
 import {
   DAPP_NETWORK,
+  claimSponsorAccount,
   crossChainCore,
   crossChainProvider,
   mainSigner,
@@ -120,7 +121,7 @@ export default function Home() {
                     wallet={wallet}
                     originWalletDetails={originWalletDetails}
                     mainSigner={mainSigner}
-                    sponsorAccount={sponsorAccount}
+                    sponsorAccount={claimSponsorAccount}
                     dappNetwork={DAPP_NETWORK}
                     crossChainCore={crossChainCore}
                     provider={crossChainProvider}

--- a/apps/nextjs-x-chain/src/config/index.ts
+++ b/apps/nextjs-x-chain/src/config/index.ts
@@ -5,7 +5,7 @@ import {
   PrivateKey,
   PrivateKeyVariants,
 } from "@aptos-labs/ts-sdk";
-import { CrossChainCore } from "@aptos-labs/cross-chain-core";
+import { CrossChainCore, GasStationApiKey } from "@aptos-labs/cross-chain-core";
 
 /**
  * Shared configuration for the x-chain demo app.
@@ -42,6 +42,10 @@ const sponsorPrivateKey =
 const sponsorKey = new Ed25519PrivateKey(
   PrivateKey.formatPrivateKey(sponsorPrivateKey, PrivateKeyVariants.Ed25519),
 );
-export const sponsorAccount = Account.fromPrivateKey({
+export const claimSponsorAccount = Account.fromPrivateKey({
   privateKey: sponsorKey,
 });
+
+export const sponsorAccount: GasStationApiKey = {
+  [Network.TESTNET]: process.env.NEXT_PUBLIC_SWAP_CCTP_SPONSOR_ACCOUNT_GAS_STATION_API_KEY_TESTNET || "",
+};

--- a/packages/cross-chain-core/package.json
+++ b/packages/cross-chain-core/package.json
@@ -48,10 +48,11 @@
     "vitest": "^2.1.8"
   },
   "dependencies": {
-    "@aptos-labs/wallet-adapter-core": "workspace:*",
     "@aptos-labs/derived-wallet-ethereum": "workspace:*",
     "@aptos-labs/derived-wallet-solana": "workspace:*",
     "@aptos-labs/derived-wallet-sui": "workspace:*",
+    "@aptos-labs/gas-station-client": "^2.0.3",
+    "@aptos-labs/wallet-adapter-core": "workspace:*",
     "@aptos-labs/wallet-standard": "^0.5.2",
     "@mysten/sui": "1.24.0",
     "@mysten/wallet-standard": "^0.13.29",
@@ -65,8 +66,8 @@
     "@wormhole-foundation/sdk-evm": "4.7.1",
     "@wormhole-foundation/sdk-solana": "4.7.1",
     "@wormhole-foundation/sdk-sui": "4.7.1",
-    "buffer": "^6.0.3",
     "bs58": "^6.0.0",
+    "buffer": "^6.0.3",
     "ethers": "^6.13.5",
     "eventemitter3": "^4.0.7",
     "tweetnacl": "^1.0.3"

--- a/packages/cross-chain-core/src/providers/wormhole/signers/AptosLocalSigner.ts
+++ b/packages/cross-chain-core/src/providers/wormhole/signers/AptosLocalSigner.ts
@@ -19,6 +19,7 @@ import {
   AptosChains,
 } from "@wormhole-foundation/sdk-aptos";
 import { GasStationApiKey } from "../types";
+import { isAccount } from "./AptosSigner";
 
 export class AptosLocalSigner<
   N extends Network,
@@ -121,15 +122,13 @@ export async function signAndSendTransaction(
   };
 
   if (sponsorAccount) {
-    if (typeof sponsorAccount === "string") {
-      // TODO: handle gas station integration
-    } else {
-      const feePayerSignerAuthenticator = aptos.transaction.signAsFeePayer({
-        signer: sponsorAccount as Account,
-        transaction: txnToSign,
-      });
-      txnToSubmit.feePayerAuthenticator = feePayerSignerAuthenticator;
-    }
+    // Gas station is currently impossible to use, since the transactino we get from 
+    // Wormhole is a script transaction and gas station only supports entry function transactions
+    const feePayerSignerAuthenticator = aptos.transaction.signAsFeePayer({
+      signer: sponsorAccount as Account,
+      transaction: txnToSign,
+    });
+    txnToSubmit.feePayerAuthenticator = feePayerSignerAuthenticator;
   }
   const response = await aptos.transaction.submit.simple(txnToSubmit);
 

--- a/packages/cross-chain-core/src/providers/wormhole/types.ts
+++ b/packages/cross-chain-core/src/providers/wormhole/types.ts
@@ -1,4 +1,4 @@
-import { AccountAddressInput, Account } from "@aptos-labs/ts-sdk";
+import { AccountAddressInput, Account, Network } from "@aptos-labs/ts-sdk";
 import { AdapterWallet } from "@aptos-labs/wallet-adapter-core";
 import { routes, AttestationReceipt } from "@wormhole-foundation/sdk/dist/cjs";
 import { Chain, AptosAccount } from "../..";
@@ -26,7 +26,7 @@ export interface WormholeQuoteRequest {
   type: "transfer" | "withdraw";
 }
 
-export type GasStationApiKey = string;
+export type GasStationApiKey = Partial<Record<Network.TESTNET | Network.MAINNET, string>>;
 
 export interface WormholeTransferRequest {
   sourceChain: Chain;
@@ -34,7 +34,7 @@ export interface WormholeTransferRequest {
   destinationAddress: AccountAddressInput;
   mainSigner: Account;
   amount?: string;
-  sponsorAccount?: Account | GasStationApiKey;
+  sponsorAccount?: Account;
 }
 
 export interface WormholeWithdrawRequest {

--- a/packages/cross-chain-core/src/providers/wormhole/wormhole.ts
+++ b/packages/cross-chain-core/src/providers/wormhole/wormhole.ts
@@ -268,7 +268,7 @@ export class WormholeProvider implements CrossChainProvider<
                 "Aptos",
                 {},
                 mainSigner, // the account that signs the "claim" transaction
-                sponsorAccount ? sponsorAccount : undefined, // the fee payer account
+                sponsorAccount, // the fee payer account
                 this.crossChainCore._dappConfig?.aptosNetwork,
               );
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,10 +31,10 @@ importers:
         version: 2.29.7(@types/node@24.5.2)
       prettier:
         specifier: latest
-        version: 3.7.4
+        version: 3.8.1
       turbo:
         specifier: latest
-        version: 2.7.2
+        version: 2.8.3
 
   apps/nextjs-example:
     dependencies:
@@ -292,6 +292,9 @@ importers:
       '@aptos-labs/derived-wallet-sui':
         specifier: workspace:*
         version: link:../derived-wallet-sui
+      '@aptos-labs/gas-station-client':
+        specifier: ^2.0.3
+        version: 2.0.3(got@11.8.6)
       '@aptos-labs/ts-sdk':
         specifier: ^5.1.1
         version: 5.1.1(got@11.8.6)
@@ -575,7 +578,7 @@ importers:
         version: 8.10.0(eslint@8.57.1)
       eslint-config-turbo:
         specifier: latest
-        version: 2.7.2(eslint@8.57.1)(turbo@2.7.2)
+        version: 2.8.3(eslint@8.57.1)(turbo@2.8.3)
       eslint-plugin-react:
         specifier: 7.31.8
         version: 7.31.8(eslint@8.57.1)
@@ -4014,8 +4017,8 @@ packages:
     peerDependencies:
       eslint: '>=7.0.0'
 
-  eslint-config-turbo@2.7.2:
-    resolution: {integrity: sha512-Tj8P1kJFVNFZxH+BaQO9sowg11N5PkpD34aWZ87PImqkWo7Qk8yRGRpshCeqGwdO5YKX631ZyTQfcDvs4bqBMQ==}
+  eslint-config-turbo@2.8.3:
+    resolution: {integrity: sha512-cx9nT7IbP+insVejZPL4n55pkjPTlkWdjh3p/ZZL3W8BLt+2O1bWFJnT3lVyIGcC8v/4s6nZZPL+/id37zDdVA==}
     peerDependencies:
       eslint: '>6.6.0'
       turbo: '>2.0.0'
@@ -4104,8 +4107,8 @@ packages:
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
 
-  eslint-plugin-turbo@2.7.2:
-    resolution: {integrity: sha512-rZs+l0vQcFo/37OiCWDcTIcksrVfvSBwS6/CI41wc3hA/hWxGOAbT1Diy9/+PBrh2VJts0SzBXb80SqGgVFFPQ==}
+  eslint-plugin-turbo@2.8.3:
+    resolution: {integrity: sha512-9ACQrrjzOfrbBGG1CqzyC67NtOSRcA+vyc9cjbyLyIoVtcK27czO7/WM+R5K3Opz0fb4Uezo6X+csMfL//RfJQ==}
     peerDependencies:
       eslint: '>6.6.0'
       turbo: '>2.0.0'
@@ -5009,6 +5012,7 @@ packages:
   next@14.2.32:
     resolution: {integrity: sha512-fg5g0GZ7/nFc09X8wLe6pNSU8cLWbLRG3TZzPJ1BJvi2s9m7eF991se67wliM9kR5yLHRkyGKU49MMx58s3LJg==}
     engines: {node: '>=18.17.0'}
+    deprecated: This version has a security vulnerability. Please upgrade to a patched version. See https://nextjs.org/blog/security-update-2025-12-11 for more details.
     hasBin: true
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
@@ -5328,8 +5332,8 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
-  prettier@3.7.4:
-    resolution: {integrity: sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==}
+  prettier@3.8.1:
+    resolution: {integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -6236,41 +6240,41 @@ packages:
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
 
-  turbo-darwin-64@2.7.2:
-    resolution: {integrity: sha512-dxY3X6ezcT5vm3coK6VGixbrhplbQMwgNsCsvZamS/+/6JiebqW9DKt4NwpgYXhDY2HdH00I7FWs3wkVuan4rA==}
+  turbo-darwin-64@2.8.3:
+    resolution: {integrity: sha512-4kXRLfcygLOeNcP6JquqRLmGB/ATjjfehiojL2dJkL7GFm3SPSXbq7oNj8UbD8XriYQ5hPaSuz59iF1ijPHkTw==}
     cpu: [x64]
     os: [darwin]
 
-  turbo-darwin-arm64@2.7.2:
-    resolution: {integrity: sha512-1bXmuwPLqNFt3mzrtYcVx1sdJ8UYb124Bf48nIgcpMCGZy3kDhgxNv1503kmuK/37OGOZbsWSQFU4I08feIuSg==}
+  turbo-darwin-arm64@2.8.3:
+    resolution: {integrity: sha512-xF7uCeC0UY0Hrv/tqax0BMbFlVP1J/aRyeGQPZT4NjvIPj8gSPDgFhfkfz06DhUwDg5NgMo04uiSkAWE8WB/QQ==}
     cpu: [arm64]
     os: [darwin]
 
-  turbo-linux-64@2.7.2:
-    resolution: {integrity: sha512-kP+TiiMaiPugbRlv57VGLfcjFNsFbo8H64wMBCPV2270Or2TpDCBULMzZrvEsvWFjT3pBFvToYbdp8/Kw0jAQg==}
+  turbo-linux-64@2.8.3:
+    resolution: {integrity: sha512-vxMDXwaOjweW/4etY7BxrXCSkvtwh0PbwVafyfT1Ww659SedUxd5rM3V2ZCmbwG8NiCfY7d6VtxyHx3Wh1GoZA==}
     cpu: [x64]
     os: [linux]
 
-  turbo-linux-arm64@2.7.2:
-    resolution: {integrity: sha512-VDJwQ0+8zjAfbyY6boNaWfP6RIez4ypKHxwkuB6SrWbOSk+vxTyW5/hEjytTwK8w/TsbKVcMDyvpora8tEsRFw==}
+  turbo-linux-arm64@2.8.3:
+    resolution: {integrity: sha512-mQX7uYBZFkuPLLlKaNe9IjR1JIef4YvY8f21xFocvttXvdPebnq3PK1Zjzl9A1zun2BEuWNUwQIL8lgvN9Pm3Q==}
     cpu: [arm64]
     os: [linux]
 
   turbo-stream@2.4.0:
     resolution: {integrity: sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g==}
 
-  turbo-windows-64@2.7.2:
-    resolution: {integrity: sha512-rPjqQXVnI6A6oxgzNEE8DNb6Vdj2Wwyhfv3oDc+YM3U9P7CAcBIlKv/868mKl4vsBtz4ouWpTQNXG8vljgJO+w==}
+  turbo-windows-64@2.8.3:
+    resolution: {integrity: sha512-YLGEfppGxZj3VWcNOVa08h6ISsVKiG85aCAWosOKNUjb6yErWEuydv6/qImRJUI+tDLvDvW7BxopAkujRnWCrw==}
     cpu: [x64]
     os: [win32]
 
-  turbo-windows-arm64@2.7.2:
-    resolution: {integrity: sha512-tcnHvBhO515OheIFWdxA+qUvZzNqqcHbLVFc1+n+TJ1rrp8prYicQtbtmsiKgMvr/54jb9jOabU62URAobnB7g==}
+  turbo-windows-arm64@2.8.3:
+    resolution: {integrity: sha512-afTUGKBRmOJU1smQSBnFGcbq0iabAPwh1uXu2BVk7BREg30/1gMnJh9DFEQTah+UD3n3ru8V55J83RQNFfqoyw==}
     cpu: [arm64]
     os: [win32]
 
-  turbo@2.7.2:
-    resolution: {integrity: sha512-5JIA5aYBAJSAhrhbyag1ZuMSgUZnHtI+Sq3H8D3an4fL8PeF+L1yYvbEJg47akP1PFfATMf5ehkqFnxfkmuwZQ==}
+  turbo@2.8.3:
+    resolution: {integrity: sha512-8Osxz5Tu/Dw2kb31EAY+nhq/YZ3wzmQSmYa1nIArqxgCAldxv9TPlrAiaBUDVnKA4aiPn0OFBD1ACcpc5VFOAQ==}
     hasBin: true
 
   tweetnacl-util@0.15.1:
@@ -10845,7 +10849,7 @@ snapshots:
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.9.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.9.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.9.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.4(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.57.1)
@@ -10860,11 +10864,11 @@ snapshots:
     dependencies:
       eslint: 8.57.1
 
-  eslint-config-turbo@2.7.2(eslint@8.57.1)(turbo@2.7.2):
+  eslint-config-turbo@2.8.3(eslint@8.57.1)(turbo@2.8.3):
     dependencies:
       eslint: 8.57.1
-      eslint-plugin-turbo: 2.7.2(eslint@8.57.1)(turbo@2.7.2)
-      turbo: 2.7.2
+      eslint-plugin-turbo: 2.8.3(eslint@8.57.1)(turbo@2.8.3)
+      turbo: 2.8.3
 
   eslint-import-resolver-node@0.3.9:
     dependencies:
@@ -10897,7 +10901,7 @@ snapshots:
       stable-hash: 0.0.5
       tinyglobby: 0.2.12
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.9.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.9.1)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -10952,7 +10956,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.9.1(eslint-plugin-import@2.31.0(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.9.1)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -11048,11 +11052,11 @@ snapshots:
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
-  eslint-plugin-turbo@2.7.2(eslint@8.57.1)(turbo@2.7.2):
+  eslint-plugin-turbo@2.8.3(eslint@8.57.1)(turbo@2.8.3):
     dependencies:
       dotenv: 16.0.3
       eslint: 8.57.1
-      turbo: 2.7.2
+      turbo: 2.8.3
 
   eslint-scope@7.2.2:
     dependencies:
@@ -12336,7 +12340,7 @@ snapshots:
 
   prettier@3.6.2: {}
 
-  prettier@3.7.4: {}
+  prettier@3.8.1: {}
 
   pretty-format@27.5.1:
     dependencies:
@@ -13536,34 +13540,34 @@ snapshots:
       tslib: 1.14.1
       typescript: 5.8.3
 
-  turbo-darwin-64@2.7.2:
+  turbo-darwin-64@2.8.3:
     optional: true
 
-  turbo-darwin-arm64@2.7.2:
+  turbo-darwin-arm64@2.8.3:
     optional: true
 
-  turbo-linux-64@2.7.2:
+  turbo-linux-64@2.8.3:
     optional: true
 
-  turbo-linux-arm64@2.7.2:
+  turbo-linux-arm64@2.8.3:
     optional: true
 
   turbo-stream@2.4.0: {}
 
-  turbo-windows-64@2.7.2:
+  turbo-windows-64@2.8.3:
     optional: true
 
-  turbo-windows-arm64@2.7.2:
+  turbo-windows-arm64@2.8.3:
     optional: true
 
-  turbo@2.7.2:
+  turbo@2.8.3:
     optionalDependencies:
-      turbo-darwin-64: 2.7.2
-      turbo-darwin-arm64: 2.7.2
-      turbo-linux-64: 2.7.2
-      turbo-linux-arm64: 2.7.2
-      turbo-windows-64: 2.7.2
-      turbo-windows-arm64: 2.7.2
+      turbo-darwin-64: 2.8.3
+      turbo-darwin-arm64: 2.8.3
+      turbo-linux-64: 2.8.3
+      turbo-linux-arm64: 2.8.3
+      turbo-windows-64: 2.8.3
+      turbo-windows-arm64: 2.8.3
 
   tweetnacl-util@0.15.1: {}
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches transaction signing/submission paths for Wormhole CCTP withdraws and introduces a new submission mechanism (gas station client), which can affect transaction validity and fee payer behavior.
> 
> **Overview**
> Adds **Aptos Gas Station** support for CCTP *withdraw* transactions by allowing `sponsorAccount` to be either a local `Account` or a per-network `GasStationApiKey` map, and wiring that through the Next.js demo components/config.
> 
> In `cross-chain-core`, the Wormhole Aptos signer now configures the ts-sdk with a `GasStationTransactionSubmitter` when a gas-station key is provided, while only applying `signAsFeePayer` when the sponsor is an actual `Account`; the package also adds `@aptos-labs/gas-station-client` and includes a changeset bump.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6562c2c682c8416cc35b41202bdb45a74c4bd842. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->