### PR TITLE
Fix Solana multi-signer transaction order for Phantom wallet

### DIFF
--- a/.changeset/calm-yaks-dream.md
+++ b/.changeset/calm-yaks-dream.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/cross-chain-core": patch
+---
+
+Fix Solana multi-signer transaction order


### PR DESCRIPTION
Phantom wallet's Lighthouse security system was blocking CCTP transfer transactions on mainnet, flagging them as potentially malicious. This occurred because multi-signer transactions weren't following the correct signing order.

## Changes

Solana CCTP transactions from the Wormhole SDK require multiple signers. In addition to the user's wallet, the SDK generates ephemeral keypairs for protocol-specific accounts like message nonce accounts and token authority accounts. These aren't other users - they're keypairs the SDK creates internally to satisfy Solana's account model requirements for the CCTP program.

The SDK passes these additional signers via `request.transaction.signers`, which our code then needs to apply with `partialSign()`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to Solana transaction signing order; main risk is unintended incompatibility with other wallets/transaction types if they expect the previous signer ordering.
> 
> **Overview**
> Fixes Solana multi-signer transaction signing order to satisfy Phantom Lighthouse security checks.
> 
> `signAndSendTransaction` now has the wallet sign the transaction first, then applies any extra Wormhole/CCTP `request.transaction.signers` via `partialSign()` afterward, and removes the earlier `partialSign()` done during priority-fee instruction setup. A changeset bumps `@aptos-labs/cross-chain-core` as a patch release.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e6817503da04bbddb57e41b4b4a1b46242fb5342. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->