### PR TITLE
Remove import of an uninstalled dependency

### DIFF
--- a/apps/nextjs-x-chain/src/app/layout.tsx
+++ b/apps/nextjs-x-chain/src/app/layout.tsx
@@ -1,4 +1,3 @@
-import "@aptos-labs/wallet-adapter-ant-design/dist/index.css";
 import "./globals.css";
 
 import { ThemeProvider } from "@/components/ThemeProvider";


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Removes a single CSS import for an uninstalled dependency; very low risk aside from minor styling differences if the stylesheet was unintentionally relied upon.
> 
> **Overview**
> Removes the `@aptos-labs/wallet-adapter-ant-design/dist/index.css` import from `apps/nextjs-x-chain/src/app/layout.tsx` to avoid referencing an uninstalled dependency.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e65f4416af495f957a508ef77c92199fdfb8d732. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->