### PR TITLE
fix next config

### DIFF
--- a/apps/nextjs-x-chain/next.config.mjs
+++ b/apps/nextjs-x-chain/next.config.mjs
@@ -1,14 +1,17 @@
-const isProd = process.env.NODE_ENV === "production";
-
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  output: "export",
   reactStrictMode: true,
-  transpilePackages: ["wallet-adapter-react", "wallet-adapter-plugin"],
-  assetPrefix: isProd ? "/aptos-wallet-adapter/nextjs-cross-chain-example" : "",
-  basePath: isProd ? "/aptos-wallet-adapter/nextjs-cross-chain-example" : "",
-  webpack: (config) => {
-    config.resolve.fallback = { "@solana/web3.js": false };
+  transpilePackages: [
+    "@aptos-labs/wallet-adapter-react",
+    "@aptos-labs/wallet-adapter-core",
+    "@aptos-labs/wallet-adapter-mui-design",
+    "@aptos-labs/cross-chain-core",
+  ],
+  webpack: (config, { isServer }) => {
+    // Only apply fallback on client-side
+    if (!isServer) {
+      config.resolve.fallback = { "@solana/web3.js": false };
+    }
     return config;
   },
 };

--- a/package.json
+++ b/package.json
@@ -17,13 +17,10 @@
     "changeset": "changeset",
     "version-packages": "changeset version",
     "publish-packages": "changeset version && changeset publish",
-    "deploy:example": "(pnpm run deploy:adapter-example) && (pnpm run deploy:cross-chain-example)",
+    "deploy:example": "pnpm run deploy:adapter-example",
     "deploy:adapter-example": "pnpm run adapter-example:build && pnpm run adapter-example:export && touch ./apps/nextjs-example/out/.nojekyll && gh-pages --dist apps/nextjs-example/out --dotfiles",
     "adapter-example:export": "pnpm run --filter {apps/nextjs-example} export",
     "adapter-example:build": "pnpm run --filter {apps/nextjs-example} build",
-    "deploy:cross-chain-example": "pnpm run cross-chain-example:build && pnpm run cross-chain-example:export && touch ./apps/nextjs-x-chain/out/.nojekyll && gh-pages --dist apps/nextjs-x-chain/out --dest nextjs-cross-chain-example --dotfiles",
-    "cross-chain-example:export": "pnpm run --filter {apps/nextjs-x-chain} export",
-    "cross-chain-example:build": "pnpm run --filter {apps/nextjs-x-chain} build",
     "deploy:example-testing": "pnpm run example:build && pnpm run example:export && touch ./apps/nextjs-example/out/.nojekyll && gh-pages --dist apps/nextjs-example/out --dest nextjs-example-testing --dotfiles"
   },
   "devDependencies": {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Build/config and CI/deploy-script changes only; main risk is unintentionally changing packaging/deploy behavior for the removed cross-chain example workflow.
> 
> **Overview**
> Updates `apps/nextjs-x-chain/next.config.mjs` to transpile the scoped `@aptos-labs/*` packages and to apply the `@solana/web3.js` webpack fallback **only on the client** (avoiding server-side bundling issues).
> 
> Simplifies root `package.json` deployment by removing the cross-chain example deploy/build/export scripts and making `deploy:example` run only the adapter example deploy.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1f5794d9baf8d2514fe8bd88b52d109dad34e718. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->