### PR TITLE
Add a warning of offchain signing issues with ledger on solana

### DIFF
--- a/packages/derived-wallet-solana/README.md
+++ b/packages/derived-wallet-solana/README.md
@@ -28,6 +28,8 @@ Currently, the wallets that have been tested and support cross-chain accounts ar
 
 ## Usage
 
+> **Note:** Ledger hardware wallets do not currently support off-chain message signing required for Solana-derived Aptos accounts. This is a known limitation of the Ledger Solana app. Users should use software wallets (Phantom, Solflare, etc.) without a hardware device connected.
+
 ### Option 1: Automatic Wallet Detection (Recommended for dApps)
 
 Use this approach when building a dApp where users connect their Solana wallets.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only change; no runtime behavior, APIs, or security-sensitive logic is modified.
> 
> **Overview**
> Adds a prominent note to `packages/derived-wallet-solana/README.md` warning that **Ledger Solana hardware wallets don’t support the off-chain message signing** required for Solana-derived Aptos accounts, and advises users to use a software wallet without a hardware device connected.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f7a850b2aa328478b0b2924adc85d5db5d943a1d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->