### PR TITLE
[DNM] show ui on mainnet

### DIFF
--- a/apps/nextjs-x-chain/src/app/page.tsx
+++ b/apps/nextjs-x-chain/src/app/page.tsx
@@ -99,22 +99,7 @@ export default function Home() {
             originWalletDetails={originWalletDetails}
           />
 
-          {network?.name === Network.MAINNET && (
-            <>
-              <Alert variant="warning">
-                <AlertCircle className="h-4 w-4" />
-                <AlertTitle>Warning</AlertTitle>
-                <AlertDescription>
-                  The transactions flows below will not work on the Mainnet
-                  network.
-                </AlertDescription>
-              </Alert>
-              {/* Transaction actions are disabled on mainnet */}
-              <SingleSigner dappNetwork={Network.MAINNET} wallet={wallet} />
-            </>
-          )}
-
-          {network?.name === Network.TESTNET && (
+          {(network?.name === Network.TESTNET || network?.name === Network.MAINNET) && (
               <>
                 <>
                   <CCTPTransfer

--- a/apps/nextjs-x-chain/src/components/WalletProvider.tsx
+++ b/apps/nextjs-x-chain/src/components/WalletProvider.tsx
@@ -34,6 +34,7 @@ export const WalletProvider = ({ children }: PropsWithChildren) => {
         aptosApiKeys: {
           testnet: process.env.NEXT_PUBLIC_APTOS_API_KEY_TESNET,
           devnet: process.env.NEXT_PUBLIC_APTOS_API_KEY_DEVNET,
+          mainnet: process.env.NEXT_PUBLIC_APTOS_API_KEY_MAINNET,
         },
         aptosConnect: {
           claimSecretKey,

--- a/apps/nextjs-x-chain/src/config/index.ts
+++ b/apps/nextjs-x-chain/src/config/index.ts
@@ -21,6 +21,9 @@ export const DAPP_NETWORK: Network.MAINNET | Network.TESTNET =
 export const crossChainCore = new CrossChainCore({
   dappConfig: {
     aptosNetwork: DAPP_NETWORK,
+    solanaConfig: {
+      rpc: process.env.NEXT_PUBLIC_SOLANA_RPC_MAINNET || undefined,
+    },
   },
 });
 
@@ -49,4 +52,5 @@ export const claimSponsorAccount = Account.fromPrivateKey({
 
 export const sponsorAccount: GasStationApiKey = {
   [Network.TESTNET]: process.env.NEXT_PUBLIC_SWAP_CCTP_SPONSOR_ACCOUNT_GAS_STATION_API_KEY_TESTNET || "",
+  [Network.MAINNET]: process.env.NEXT_PUBLIC_SWAP_CCTP_SPONSOR_ACCOUNT_GAS_STATION_API_KEY_MAINNET || "",
 };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Enables transaction flows on mainnet and introduces new mainnet RPC/API-key configuration, which can cause real-funds transactions or environment misconfiguration if incorrect.
> 
> **Overview**
> The main page now renders the CCTP transfer/withdraw flows and `SingleSigner` for **mainnet as well as testnet**, removing the prior mainnet warning/disable behavior.
> 
> Configuration is extended to support mainnet operation by adding a `mainnet` Aptos API key, a mainnet Solana RPC override for `CrossChainCore`, and a mainnet Gas Station API key entry for the sponsor account.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 274314b66347d537efb82350a4a61406e4e8f83b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->