### PR TITLE
handle links and redirect to vercel

### DIFF
--- a/.github/workflows/gh-pages-redirect.yml
+++ b/.github/workflows/gh-pages-redirect.yml
@@ -1,0 +1,42 @@
+name: Deploy GitHub Pages Redirects
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/gh-pages-redirect.yml"
+      - "gh-pages-redirect/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: gh-pages-redirect
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+

--- a/apps/nextjs-example/README.md
+++ b/apps/nextjs-example/README.md
@@ -3,7 +3,7 @@
 This project is a demo of the Aptos Wallet Selector using [Next.js](https://nextjs.org/) and [shadcn/ui](https://ui.shadcn.com/).
 
 A live version is hosted at:
-https://aptos-labs.github.io/aptos-wallet-adapter
+https://aptos-wallet-adapter-example.vercel.app/
 
 ## Use shadcn/ui wallet selector for your own app
 

--- a/apps/nextjs-x-chain/README.md
+++ b/apps/nextjs-x-chain/README.md
@@ -3,7 +3,7 @@
 This project is a demo of the Aptos Cross-Chain Wallet Selector using [Next.js](https://nextjs.org/) and [shadcn/ui](https://ui.shadcn.com/).
 
 A live version is hosted at:
-https://aptos-labs.github.io/aptos-wallet-adapter/nextjs-cross-chain-example/
+https://x-chain-accounts.vercel.app/
 
 ## Use shadcn/ui wallet selector for your own app
 

--- a/gh-pages-redirect/index.html
+++ b/gh-pages-redirect/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Redirecting…</title>
+    <meta
+      http-equiv="refresh"
+      content="0; url=https://aptos-wallet-adapter-example.vercel.app/"
+    />
+    <link
+      rel="canonical"
+      href="https://aptos-wallet-adapter-example.vercel.app/"
+    />
+  </head>
+  <body>
+    <p>
+      This page has moved to
+      <a href="https://aptos-wallet-adapter-example.vercel.app/"
+        >https://aptos-wallet-adapter-example.vercel.app/</a
+      >.
+    </p>
+  </body>
+</html>
+

--- a/gh-pages-redirect/nextjs-cross-chain-example/index.html
+++ b/gh-pages-redirect/nextjs-cross-chain-example/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Redirecting…</title>
+    <meta
+      http-equiv="refresh"
+      content="0; url=https://x-chain-accounts.vercel.app/"
+    />
+    <link rel="canonical" href="https://x-chain-accounts.vercel.app/" />
+  </head>
+  <body>
+    <p>
+      This page has moved to
+      <a href="https://x-chain-accounts.vercel.app/"
+        >https://x-chain-accounts.vercel.app/</a
+      >.
+    </p>
+  </body>
+</html>
+

--- a/gh-pages-redirect/nextjs-example-testing/index.html
+++ b/gh-pages-redirect/nextjs-example-testing/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Redirecting…</title>
+    <meta
+      http-equiv="refresh"
+      content="0; url=https://aptos-wallet-adapter-example.vercel.app/"
+    />
+    <link
+      rel="canonical"
+      href="https://aptos-wallet-adapter-example.vercel.app/"
+    />
+  </head>
+  <body>
+    <p>
+      This page has moved to
+      <a href="https://aptos-wallet-adapter-example.vercel.app/"
+        >https://aptos-wallet-adapter-example.vercel.app/</a
+      >.
+    </p>
+  </body>
+</html>
+

--- a/packages/derived-wallet-ethereum/README.md
+++ b/packages/derived-wallet-ethereum/README.md
@@ -208,7 +208,7 @@ if (isEIP1193DerivedWallet(wallet)) {
 ## Resources
 
 - X-Chain Accounts Adapter Demo App
-  - [Live site](https://aptos-labs.github.io/aptos-wallet-adapter/nextjs-cross-chain-example/)
+  - [Live site](https://x-chain-accounts.vercel.app/)
   - [Source code](../../apps/nextjs-x-chain/)
 - [AIP-113 Derivable Account Abstraction](https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-113.md)
 - [AIP-122 x-chain DAA authentication using Sign-in-With-Ethereum](https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-122.md)

--- a/packages/derived-wallet-solana/README.md
+++ b/packages/derived-wallet-solana/README.md
@@ -208,7 +208,7 @@ if (isSolanaDerivedWallet(wallet)) {
 ## Resources
 
 - X-Chain Accounts Adapter Demo App
-  - [Live site](https://aptos-labs.github.io/aptos-wallet-adapter/nextjs-cross-chain-example/)
+  - [Live site](https://x-chain-accounts.vercel.app/)
   - [Source code](../../apps/nextjs-x-chain/)
 - [AIP-113 Derivable Account Abstraction](https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-113.md)
 - [AIP-121 x-chain DAA authentication using Sign-in-With-Solana](https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-121.md)

--- a/packages/derived-wallet-sui/README.md
+++ b/packages/derived-wallet-sui/README.md
@@ -161,7 +161,7 @@ if (isSuiDerivedWallet(wallet)) {
 ## Resources
 
 - X-Chain Accounts Adapter Demo App
-  - [Live site](https://aptos-labs.github.io/aptos-wallet-adapter/nextjs-cross-chain-example/)
+  - [Live site](https://x-chain-accounts.vercel.app/)
   - [Source code](../../apps/nextjs-x-chain/)
 - [AIP-113 Derivable Account Abstraction](https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-113.md)
 


### PR DESCRIPTION
We use Vercel to serve the demo dapps https://github.com/aptos-labs/aptos-wallet-adapter/pull/749
This PR updated the links, and adds a redirect from the previous GitHub Pages URLs to the new Vercel URLs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only documentation and GitHub Pages redirect/deployment changes; no runtime library or wallet logic is modified.
> 
> **Overview**
> Updates documentation links for the Next.js demo apps and derived-wallet packages to point to the new Vercel-hosted demos instead of the previous GitHub Pages URLs.
> 
> Adds a `gh-pages-redirect` static site plus a new `gh-pages-redirect.yml` GitHub Actions workflow to deploy it to GitHub Pages, providing immediate HTML meta-refresh redirects (including legacy subpaths like `nextjs-cross-chain-example/` and `nextjs-example-testing/`) to the Vercel URLs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf0f6b43b10141a88b83c059d6bbde49e8474110. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->