### PR TITLE
feat(cross-chain-core): add onTransactionSigned callback for per-transaction progress UI

### DIFF
--- a/.changeset/add-on-transaction-signed-callback.md
+++ b/.changeset/add-on-transaction-signed-callback.md
@@ -1,0 +1,6 @@
+---
+"@aptos-labs/cross-chain-core": minor
+---
+
+Added `onTransactionSigned` callback to all transfer and withdraw request types (`WormholeWithdrawRequest`, `WormholeTransferRequest`, `WormholeSubmitTransferRequest`, `WormholeClaimTransferRequest`, `WormholeInitiateWithdrawRequest`, `WormholeClaimWithdrawRequest`). The callback fires before and after each individual transaction is signed, enabling rich per-transaction progress UIs (e.g. "Approving USDC…", "Submitting bridge transaction…"). Also added to `Signer`, `AptosLocalSigner`, and `SolanaLocalSigner`.
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,8 @@ The Aptos Wallet Adapter is a comprehensive monorepo for building dapps on Aptos
 - **Derived Wallets**: Create Aptos wallets from external chain keys (Ethereum, Solana, Sui)
 - **UI Components**: Pre-built wallet selectors for Ant Design and Material-UI
 
+The Aptos Wallet Adapter monorepo lives in https://github.com/aptos-labs/aptos-wallet-adapter
+
 ## Repository Structure
 
 This is a **Turbo monorepo** with two main workspaces:

--- a/packages/cross-chain-core/src/providers/wormhole/signers/SolanaLocalSigner.ts
+++ b/packages/cross-chain-core/src/providers/wormhole/signers/SolanaLocalSigner.ts
@@ -16,6 +16,7 @@ import {
   PriorityFeeConfig,
   sendAndConfirmTransaction,
 } from "./solanaUtils";
+import { OnTransactionSigned } from "../types";
 
 export interface SolanaLocalSignerConfig {
   /** The Solana keypair to sign transactions with */
@@ -31,7 +32,7 @@ export interface SolanaLocalSignerConfig {
   /** Enable verbose logging (default: false) */
   verbose?: boolean;
   /** Optional callback fired before and after each individual transaction is signed. */
-  onTransactionSigned?: (description: string, txId: string | null) => void;
+  onTransactionSigned?: OnTransactionSigned;
 }
 
 /**
@@ -70,7 +71,7 @@ export class SolanaLocalSigner<N extends Network, C extends Chain>
   private retryIntervalMs: number;
   private priorityFeeConfig?: PriorityFeeConfig;
   private verbose: boolean;
-  private _onTransactionSigned?: (description: string, txId: string | null) => void;
+  private _onTransactionSigned?: OnTransactionSigned;
   private _claimedTransactionHashes: string[] = [];
 
   constructor(config: SolanaLocalSignerConfig) {

--- a/packages/cross-chain-core/src/providers/wormhole/types.ts
+++ b/packages/cross-chain-core/src/providers/wormhole/types.ts
@@ -35,12 +35,26 @@ export interface WormholeTransferRequest {
   mainSigner: Account;
   amount?: string;
   sponsorAccount?: Account;
+  /** Optional callback fired before and after each individual transaction is signed. */
+  onTransactionSigned?: OnTransactionSigned;
 }
 
 export type WithdrawPhase =
   | "initiating"  // User signing Aptos burn transaction
   | "tracking"    // Waiting for Wormhole attestation (~60s)
   | "claiming";   // Claiming on destination chain
+
+/**
+ * Callback fired before and after each individual transaction is signed
+ * and submitted during a bridge flow.
+ *
+ * @param description - A human-readable description of the transaction
+ *   (e.g. "Approving USDC transfer"). Comes from the Wormhole SDK's
+ *   `UnsignedTransaction.description`.
+ * @param txId - `null` when called *before* signing; the on-chain
+ *   transaction hash when called *after* signing.
+ */
+export type OnTransactionSigned = (description: string, txId: string | null) => void;
 
 export interface WormholeWithdrawRequest {
   /**
@@ -57,18 +71,24 @@ export interface WormholeWithdrawRequest {
   sponsorAccount?: Account | GasStationApiKey;
   /** Optional callback fired when the withdraw progresses to a new phase. */
   onPhaseChange?: (phase: WithdrawPhase) => void;
+  /** Optional callback fired before and after each individual transaction is signed. */
+  onTransactionSigned?: OnTransactionSigned;
 }
 
 export interface WormholeSubmitTransferRequest {
   sourceChain: Chain;
   wallet: AdapterWallet;
   destinationAddress: AccountAddressInput;
+  /** Optional callback fired before and after each individual transaction is signed. */
+  onTransactionSigned?: OnTransactionSigned;
 }
 
 export interface WormholeClaimTransferRequest {
   receipt: routes.Receipt<AttestationReceipt>;
   mainSigner: AptosAccount;
   sponsorAccount?: AptosAccount | GasStationApiKey;
+  /** Optional callback fired before and after each individual transaction is signed. */
+  onTransactionSigned?: OnTransactionSigned;
 }
 
 export interface WormholeTransferResponse {
@@ -92,6 +112,8 @@ export interface WormholeInitiateWithdrawRequest {
   wallet: AdapterWallet;
   destinationAddress: AccountAddressInput;
   sponsorAccount?: Account | GasStationApiKey;
+  /** Optional callback fired before and after each individual transaction is signed. */
+  onTransactionSigned?: OnTransactionSigned;
 }
 
 export interface WormholeInitiateWithdrawResponse {
@@ -113,6 +135,8 @@ export interface WormholeClaimWithdrawRequest {
   // Required for wallet-based claim (non-Solana chains, or Solana without serverClaimUrl).
   // Not needed when the SDK uses the configured serverClaimUrl for Solana claims.
   wallet?: AdapterWallet;
+  /** Optional callback fired before and after each individual transaction is signed. */
+  onTransactionSigned?: OnTransactionSigned;
 }
 
 export interface WormholeClaimWithdrawResponse {


### PR DESCRIPTION
## Summary

Closes #753

Bridge flows involve multiple individual transactions (approve, transfer, claim), but the only progress callback available today is `onPhaseChange` which fires at the phase level. For progress UIs that show "Approving USDC…", "Submitting bridge transaction…", etc., consumers need a callback that fires before and after each individual transaction.

## Changes

### New `onTransactionSigned` callback

Added an `OnTransactionSigned` type and threaded it through all request types and signers:

**Request types updated:**
- `WormholeWithdrawRequest`
- `WormholeTransferRequest`
- `WormholeSubmitTransferRequest`
- `WormholeClaimTransferRequest`
- `WormholeInitiateWithdrawRequest`
- `WormholeClaimWithdrawRequest`

**Signers updated:**
- `Signer` — wallet-based signer for all chains
- `AptosLocalSigner` — programmatic Aptos signer for claims
- `SolanaLocalSigner` — server-side Solana signer (via config)

### How it works

The callback fires twice per transaction:
- **Before signing**: `onTransactionSigned(description, null)` — description comes from Wormhole SDK's `UnsignedTransaction.description`
- **After signing**: `onTransactionSigned(description, txId)` — txId is the on-chain transaction hash

### Usage example

```ts
await provider.withdraw({
  sourceChain: "Solana",
  wallet,
  destinationAddress,
  onPhaseChange: (phase) => setPhase(phase),
  onTransactionSigned: (desc, txId) => {
    if (!txId) {
      setStatus(`Signing: ${desc}...`);
    } else {
      setStatus(`Submitted: ${desc} (${txId})`);
    }
  },
});
```

## Changeset

Minor — new optional callback, fully backward compatible.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cross-chain transfer/withdraw signing paths and threads a new callback through multiple public request types and signers; low functional risk but mistakes could impact transaction submission UX/telemetry in critical flows.
> 
> **Overview**
> Adds a new `OnTransactionSigned` callback type and exposes `onTransactionSigned` as an optional field on Wormhole transfer/withdraw request types so clients can track progress *per individual transaction*.
> 
> Threads the callback through `WormholeProvider` into `Signer`, `AptosLocalSigner`, and `SolanaLocalSigner`, invoking it twice per transaction (`(description, null)` pre-sign and `(description, txId)` post-submit). Includes a changeset marking `@aptos-labs/cross-chain-core` as a minor bump.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e9705529ce3cbbfc7f83ec3c59ddcd069c54d94e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->