### PR TITLE
feat(cross-chain-core): allow configuring expireTimestamp for Aptos transactions

### DIFF
--- a/.changeset/add-expire-timestamp-config.md
+++ b/.changeset/add-expire-timestamp-config.md
@@ -1,0 +1,6 @@
+---
+"@aptos-labs/cross-chain-core": minor
+---
+
+Added `getExpireTimestamp` option to `CrossChainDappConfig` for configuring Aptos transaction expiration timestamps. The callback is invoked at transaction-build time so each transaction in a multi-step bridge flow gets a fresh expiration window. Threaded through both `AptosSigner` and `AptosLocalSigner`.
+

--- a/packages/cross-chain-core/src/CrossChainCore.ts
+++ b/packages/cross-chain-core/src/CrossChainCore.ts
@@ -29,6 +29,17 @@ import {
 export interface CrossChainDappConfig {
   aptosNetwork: Network;
   disableTelemetry?: boolean;
+  /**
+   * Returns an epoch-second timestamp used as `expireTimestamp` when building
+   * Aptos transactions. Called at transaction-build time so that each
+   * transaction in a multi-step bridge flow gets a fresh expiration window.
+   *
+   * @example
+   * ```ts
+   * getExpireTimestamp: () => Math.floor(Date.now() / 1000) + 120 // 2 minutes
+   * ```
+   */
+  getExpireTimestamp?: () => number;
   solanaConfig?: {
     rpc?: string;
     priorityFeeConfig?: {

--- a/packages/cross-chain-core/src/providers/wormhole/signers/AptosLocalSigner.ts
+++ b/packages/cross-chain-core/src/providers/wormhole/signers/AptosLocalSigner.ts
@@ -30,6 +30,7 @@ export class AptosLocalSigner<
   _wallet: Account;
   _sponsorAccount: Account | GasStationApiKey | undefined;
   _onTransactionSigned: OnTransactionSigned | undefined;
+  _getExpireTimestamp: (() => number) | undefined;
   _claimedTransactionHashes: string[] = [];
   _dappNetwork: AptosNetwork;
   constructor(
@@ -39,6 +40,7 @@ export class AptosLocalSigner<
     feePayerAccount: Account | GasStationApiKey | undefined,
     dappNetwork: AptosNetwork,
     onTransactionSigned?: OnTransactionSigned,
+    getExpireTimestamp?: () => number,
   ) {
     this._chain = chain;
     this._options = options;
@@ -46,6 +48,7 @@ export class AptosLocalSigner<
     this._sponsorAccount = feePayerAccount;
     this._dappNetwork = dappNetwork;
     this._onTransactionSigned = onTransactionSigned;
+    this._getExpireTimestamp = getExpireTimestamp;
   }
 
   chain(): C {
@@ -70,6 +73,7 @@ export class AptosLocalSigner<
         this._wallet,
         this._sponsorAccount,
         this._dappNetwork,
+        this._getExpireTimestamp,
       );
       this._onTransactionSigned?.(tx.description, txId);
       txHashes.push(txId);
@@ -84,6 +88,7 @@ export async function signAndSendTransaction(
   wallet: Account,
   sponsorAccount: Account | GasStationApiKey | undefined,
   dappNetwork: AptosNetwork,
+  getExpireTimestamp?: () => number,
 ) {
   if (!wallet) {
     throw new Error("Wallet is undefined");
@@ -106,10 +111,12 @@ export async function signAndSendTransaction(
   });
   const aptos = new Aptos(aptosConfig);
 
+  const expireTimestamp = getExpireTimestamp?.();
   const txnToSign = await aptos.transaction.build.simple({
     data: payload,
     sender: wallet.accountAddress.toString(),
     withFeePayer: sponsorAccount ? true : false,
+    ...(expireTimestamp ? { options: { expireTimestamp } } : {}),
   });
 
   const senderAuthenticator = await aptos.transaction.sign({
@@ -127,7 +134,7 @@ export async function signAndSendTransaction(
   };
 
   if (sponsorAccount) {
-    // Gas station is currently impossible to use, since the transactino we get from 
+    // Gas station is currently impossible to use, since the transactino we get from
     // Wormhole is a script transaction and gas station only supports entry function transactions
     const feePayerSignerAuthenticator = aptos.transaction.signAsFeePayer({
       signer: sponsorAccount as Account,

--- a/packages/cross-chain-core/src/providers/wormhole/signers/AptosLocalSigner.ts
+++ b/packages/cross-chain-core/src/providers/wormhole/signers/AptosLocalSigner.ts
@@ -18,7 +18,11 @@ import {
   AptosUnsignedTransaction,
   AptosChains,
 } from "@wormhole-foundation/sdk-aptos";
-import { GasStationApiKey, OnTransactionSigned } from "../types";
+import {
+  GasStationApiKey,
+  OnTransactionSigned,
+  validateExpireTimestamp,
+} from "../types";
 import { isAccount } from "./AptosSigner";
 
 export class AptosLocalSigner<
@@ -112,11 +116,16 @@ export async function signAndSendTransaction(
   const aptos = new Aptos(aptosConfig);
 
   const expireTimestamp = getExpireTimestamp?.();
+  if (typeof expireTimestamp !== "undefined") {
+    validateExpireTimestamp(expireTimestamp);
+  }
   const txnToSign = await aptos.transaction.build.simple({
     data: payload,
     sender: wallet.accountAddress.toString(),
     withFeePayer: sponsorAccount ? true : false,
-    ...(expireTimestamp ? { options: { expireTimestamp } } : {}),
+    ...(typeof expireTimestamp !== "undefined"
+      ? { options: { expireTimestamp } }
+      : {}),
   });
 
   const senderAuthenticator = await aptos.transaction.sign({
@@ -134,7 +143,7 @@ export async function signAndSendTransaction(
   };
 
   if (sponsorAccount) {
-    // Gas station is currently impossible to use, since the transactino we get from
+    // Gas station is currently impossible to use, since the transaction we get from
     // Wormhole is a script transaction and gas station only supports entry function transactions
     const feePayerSignerAuthenticator = aptos.transaction.signAsFeePayer({
       signer: sponsorAccount as Account,

--- a/packages/cross-chain-core/src/providers/wormhole/signers/AptosSigner.ts
+++ b/packages/cross-chain-core/src/providers/wormhole/signers/AptosSigner.ts
@@ -16,7 +16,7 @@ import {
   AptosChains,
   AptosUnsignedTransaction,
 } from "@wormhole-foundation/sdk-aptos";
-import { GasStationApiKey } from "..";
+import { GasStationApiKey, validateExpireTimestamp } from "..";
 import { UserResponseStatus } from "@aptos-labs/wallet-standard";
 import { GasStationClient, GasStationTransactionSubmitter } from "@aptos-labs/gas-station-client";
 import { CrossChainCore } from "../../../CrossChainCore";
@@ -93,13 +93,18 @@ export async function signAndSendTransaction(
   };
 
   const expireTimestamp = crossChainCore?._dappConfig?.getExpireTimestamp?.();
+  if (typeof expireTimestamp !== "undefined") {
+    validateExpireTimestamp(expireTimestamp);
+  }
   const txnToSign = await aptos.transaction.build.simple({
     data: transactionData,
     sender: (
       await wallet.features["aptos:account"]?.account()
     ).address.toString(),
     withFeePayer: sponsorAccount ? true : false,
-    ...(expireTimestamp ? { options: { expireTimestamp } } : {}),
+    ...(typeof expireTimestamp !== "undefined"
+      ? { options: { expireTimestamp } }
+      : {}),
   });
 
   const response =

--- a/packages/cross-chain-core/src/providers/wormhole/signers/Signer.ts
+++ b/packages/cross-chain-core/src/providers/wormhole/signers/Signer.ts
@@ -133,6 +133,7 @@ export const signAndSendTransaction = async (
       wallet,
       sponsorAccount,
       dappNetwork,
+      crossChainCore,
     );
     return tx;
   } else {

--- a/packages/cross-chain-core/src/providers/wormhole/types.ts
+++ b/packages/cross-chain-core/src/providers/wormhole/types.ts
@@ -166,6 +166,21 @@ export interface RetryWithdrawClaimResponse extends WormholeClaimWithdrawRespons
  * to recover the `originChainTxnId` and display an explorer link so the
  * user can verify their burn on-chain.
  */
+/**
+ * Validates that a value returned by `getExpireTimestamp` is a non-negative
+ * integer suitable for use as an epoch-second expiration timestamp.
+ * Throws immediately for NaN, Infinity, negative values, or floats so that
+ * misconfigured callbacks fail fast instead of producing silent misbehaviour.
+ */
+export function validateExpireTimestamp(value: number): void {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(
+      `getExpireTimestamp returned an invalid value (${value}). ` +
+        "Expected a non-negative integer (epoch seconds).",
+    );
+  }
+}
+
 export class WithdrawError extends Error {
   /** Aptos burn transaction hash — always available when this error is thrown. */
   readonly originChainTxnId: string;

--- a/packages/cross-chain-core/src/providers/wormhole/wormhole.ts
+++ b/packages/cross-chain-core/src/providers/wormhole/wormhole.ts
@@ -164,7 +164,8 @@ export class WormholeProvider implements CrossChainProvider<
   async submitCCTPTransfer(
     input: WormholeSubmitTransferRequest,
   ): Promise<WormholeStartTransferResponse> {
-    const { sourceChain, wallet, destinationAddress, onTransactionSigned } = input;
+    const { sourceChain, wallet, destinationAddress, onTransactionSigned } =
+      input;
 
     if (!this._wormholeContext) {
       await this.setWormholeContext(sourceChain);
@@ -254,6 +255,7 @@ export class WormholeProvider implements CrossChainProvider<
                 sponsorAccount, // the fee payer account
                 this.crossChainCore._dappConfig?.aptosNetwork,
                 onTransactionSigned,
+                this.crossChainCore._dappConfig?.getExpireTimestamp,
               );
 
               if (routes.isManual(this.wormholeRoute)) {
@@ -328,7 +330,8 @@ export class WormholeProvider implements CrossChainProvider<
   async initiateWithdraw(
     input: WormholeInitiateWithdrawRequest,
   ): Promise<WormholeInitiateWithdrawResponse> {
-    const { wallet, destinationAddress, sponsorAccount, onTransactionSigned } = input;
+    const { wallet, destinationAddress, sponsorAccount, onTransactionSigned } =
+      input;
 
     if (!this._wormholeContext) {
       throw new Error("Wormhole context not initialized");
@@ -339,9 +342,7 @@ export class WormholeProvider implements CrossChainProvider<
 
     const signer = new Signer(
       this.getChainConfig("Aptos"),
-      (
-        await wallet.features["aptos:account"].account()
-      ).address.toString(),
+      (await wallet.features["aptos:account"].account()).address.toString(),
       {},
       wallet,
       this.crossChainCore,
@@ -374,9 +375,7 @@ export class WormholeProvider implements CrossChainProvider<
    * Phase 2: Tracks a withdraw receipt until attestation is ready.
    * This polls Wormhole and returns once the receipt reaches the Attested state.
    */
-  async trackWithdraw(
-    receipt: routes.Receipt,
-  ): Promise<routes.Receipt> {
+  async trackWithdraw(receipt: routes.Receipt): Promise<routes.Receipt> {
     if (!this.wormholeRoute) {
       throw new Error("Wormhole route not initialized");
     }
@@ -498,7 +497,14 @@ export class WormholeProvider implements CrossChainProvider<
   async withdraw(
     input: WormholeWithdrawRequest,
   ): Promise<WormholeWithdrawResponse> {
-    const { sourceChain, wallet, destinationAddress, sponsorAccount, onPhaseChange, onTransactionSigned } = input;
+    const {
+      sourceChain,
+      wallet,
+      destinationAddress,
+      sponsorAccount,
+      onPhaseChange,
+      onTransactionSigned,
+    } = input;
 
     // Phase 1: Initiate — user signs Aptos burn
     onPhaseChange?.("initiating");

--- a/packages/cross-chain-core/tests/signers/AptosLocalSigner.test.ts
+++ b/packages/cross-chain-core/tests/signers/AptosLocalSigner.test.ts
@@ -1,11 +1,36 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   Account,
   Ed25519PrivateKey,
+  Network as AptosNetwork,
   PrivateKey,
   PrivateKeyVariants,
 } from "@aptos-labs/ts-sdk";
-import { AptosLocalSigner } from "../../src/providers/wormhole/signers/AptosLocalSigner";
+import {
+  AptosLocalSigner,
+  signAndSendTransaction,
+} from "../../src/providers/wormhole/signers/AptosLocalSigner";
+
+const mockBuildSimple = vi.fn();
+const mockSign = vi.fn();
+const mockSubmitSimple = vi.fn();
+const mockWaitForTransaction = vi.fn();
+
+vi.mock("@aptos-labs/ts-sdk", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@aptos-labs/ts-sdk")>();
+  return {
+    ...actual,
+    Aptos: vi.fn().mockImplementation(() => ({
+      transaction: {
+        build: { simple: mockBuildSimple },
+        sign: mockSign,
+        submit: { simple: mockSubmitSimple },
+        signAsFeePayer: vi.fn(),
+      },
+      waitForTransaction: mockWaitForTransaction,
+    })),
+  };
+});
 
 describe("AptosLocalSigner", () => {
   // Create a test account using a deterministic private key (AIP-80 compliant format)
@@ -183,6 +208,136 @@ describe("AptosLocalSigner", () => {
     });
   });
 
-  // Note: signAndSend tests require mocking Aptos SDK network calls
-  // These are covered in integration tests
+  describe("signAndSendTransaction – expireTimestamp forwarding", () => {
+    beforeEach(() => {
+      mockBuildSimple.mockReset().mockResolvedValue({ rawTransaction: "mock" });
+      mockSign
+        .mockReset()
+        .mockResolvedValue({ toUint8Array: () => new Uint8Array() });
+      mockSubmitSimple
+        .mockReset()
+        .mockResolvedValue({ hash: "0xmocktxhash" });
+      mockWaitForTransaction
+        .mockReset()
+        .mockResolvedValue({ hash: "0xmocktxhash" });
+    });
+
+    function makeRequest() {
+      return {
+        transaction: {
+          functionArguments: ["arg1", "arg2"],
+        },
+      } as any;
+    }
+
+    it("should pass expireTimestamp option when getExpireTimestamp returns a value", async () => {
+      const getExpireTimestamp = () => 1700000000;
+
+      await signAndSendTransaction(
+        makeRequest(),
+        testAccount,
+        undefined,
+        AptosNetwork.TESTNET,
+        getExpireTimestamp,
+      );
+
+      expect(mockBuildSimple).toHaveBeenCalledWith(
+        expect.objectContaining({
+          options: { expireTimestamp: 1700000000 },
+        }),
+      );
+    });
+
+    it("should pass expireTimestamp option when getExpireTimestamp returns 0", async () => {
+      const getExpireTimestamp = () => 0;
+
+      await signAndSendTransaction(
+        makeRequest(),
+        testAccount,
+        undefined,
+        AptosNetwork.TESTNET,
+        getExpireTimestamp,
+      );
+
+      expect(mockBuildSimple).toHaveBeenCalledWith(
+        expect.objectContaining({
+          options: { expireTimestamp: 0 },
+        }),
+      );
+    });
+
+    it("should omit options when getExpireTimestamp is not provided", async () => {
+      await signAndSendTransaction(
+        makeRequest(),
+        testAccount,
+        undefined,
+        AptosNetwork.TESTNET,
+      );
+
+      const callArg = mockBuildSimple.mock.calls[0][0];
+      expect(callArg).not.toHaveProperty("options");
+    });
+
+    it("should call getExpireTimestamp at build time", async () => {
+      const getExpireTimestamp = vi.fn().mockReturnValue(9999999999);
+
+      await signAndSendTransaction(
+        makeRequest(),
+        testAccount,
+        undefined,
+        AptosNetwork.TESTNET,
+        getExpireTimestamp,
+      );
+
+      expect(getExpireTimestamp).toHaveBeenCalledOnce();
+    });
+
+    it("should throw for NaN expireTimestamp", async () => {
+      await expect(
+        signAndSendTransaction(
+          makeRequest(),
+          testAccount,
+          undefined,
+          AptosNetwork.TESTNET,
+          () => NaN,
+        ),
+      ).rejects.toThrow("getExpireTimestamp returned an invalid value");
+    });
+
+    it("should throw for negative expireTimestamp", async () => {
+      await expect(
+        signAndSendTransaction(
+          makeRequest(),
+          testAccount,
+          undefined,
+          AptosNetwork.TESTNET,
+          () => -1,
+        ),
+      ).rejects.toThrow("getExpireTimestamp returned an invalid value");
+    });
+
+    it("should throw for non-integer expireTimestamp", async () => {
+      await expect(
+        signAndSendTransaction(
+          makeRequest(),
+          testAccount,
+          undefined,
+          AptosNetwork.TESTNET,
+          () => 1700000000.5,
+        ),
+      ).rejects.toThrow("getExpireTimestamp returned an invalid value");
+    });
+
+    it("should throw for Infinity expireTimestamp", async () => {
+      await expect(
+        signAndSendTransaction(
+          makeRequest(),
+          testAccount,
+          undefined,
+          AptosNetwork.TESTNET,
+          () => Infinity,
+        ),
+      ).rejects.toThrow("getExpireTimestamp returned an invalid value");
+    });
+  });
 });

--- a/packages/cross-chain-core/tests/signers/AptosSigner.test.ts
+++ b/packages/cross-chain-core/tests/signers/AptosSigner.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Network as AptosNetwork } from "@aptos-labs/ts-sdk";
+import { UserResponseStatus } from "@aptos-labs/wallet-standard";
+import { signAndSendTransaction } from "../../src/providers/wormhole/signers/AptosSigner";
+import { CrossChainCore } from "../../src/CrossChainCore";
+
+const mockBuildSimple = vi.fn();
+const mockSubmitSimple = vi.fn();
+const mockWaitForTransaction = vi.fn();
+
+vi.mock("@aptos-labs/ts-sdk", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@aptos-labs/ts-sdk")>();
+  return {
+    ...actual,
+    Aptos: vi.fn().mockImplementation(() => ({
+      transaction: {
+        build: { simple: mockBuildSimple },
+        sign: vi.fn(),
+        submit: { simple: mockSubmitSimple },
+        signAsFeePayer: vi.fn(),
+      },
+      waitForTransaction: mockWaitForTransaction,
+    })),
+  };
+});
+
+describe("AptosSigner – signAndSendTransaction", () => {
+  const mockSenderAuthenticator = { toUint8Array: () => new Uint8Array() };
+
+  function makeWallet() {
+    return {
+      features: {
+        "aptos:account": {
+          account: vi.fn().mockResolvedValue({
+            address: { toString: () => "0x1" },
+          }),
+        },
+        "aptos:signTransaction": {
+          signTransaction: vi.fn().mockResolvedValue({
+            status: UserResponseStatus.APPROVED,
+            args: mockSenderAuthenticator,
+          }),
+        },
+      },
+    } as any;
+  }
+
+  function makeRequest() {
+    return {
+      transaction: {
+        functionArguments: [
+          { bcsToBytes: () => new Uint8Array([100, 0, 0, 0, 0, 0, 0, 0]) },
+          { bcsToBytes: () => new Uint8Array([1, 0, 0, 0]) },
+          { bcsToBytes: () => new Uint8Array(32).fill(1) },
+          { bcsToBytes: () => new Uint8Array(32).fill(2) },
+        ],
+      },
+    } as any;
+  }
+
+  beforeEach(() => {
+    mockBuildSimple.mockReset().mockResolvedValue({ rawTransaction: "mock" });
+    mockSubmitSimple.mockReset().mockResolvedValue({ hash: "0xmocktxhash" });
+    mockWaitForTransaction
+      .mockReset()
+      .mockResolvedValue({ hash: "0xmocktxhash" });
+  });
+
+  it("should pass expireTimestamp option when getExpireTimestamp is configured", async () => {
+    const crossChainCore = new CrossChainCore({
+      dappConfig: {
+        aptosNetwork: AptosNetwork.TESTNET,
+        getExpireTimestamp: () => 1700000000,
+      },
+    });
+
+    await signAndSendTransaction(
+      makeRequest(),
+      makeWallet(),
+      undefined,
+      AptosNetwork.TESTNET,
+      crossChainCore,
+    );
+
+    expect(mockBuildSimple).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: { expireTimestamp: 1700000000 },
+      }),
+    );
+  });
+
+  it("should pass expireTimestamp option when getExpireTimestamp returns 0", async () => {
+    const crossChainCore = new CrossChainCore({
+      dappConfig: {
+        aptosNetwork: AptosNetwork.TESTNET,
+        getExpireTimestamp: () => 0,
+      },
+    });
+
+    await signAndSendTransaction(
+      makeRequest(),
+      makeWallet(),
+      undefined,
+      AptosNetwork.TESTNET,
+      crossChainCore,
+    );
+
+    expect(mockBuildSimple).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: { expireTimestamp: 0 },
+      }),
+    );
+  });
+
+  it("should omit options when getExpireTimestamp is not configured", async () => {
+    const crossChainCore = new CrossChainCore({
+      dappConfig: {
+        aptosNetwork: AptosNetwork.TESTNET,
+      },
+    });
+
+    await signAndSendTransaction(
+      makeRequest(),
+      makeWallet(),
+      undefined,
+      AptosNetwork.TESTNET,
+      crossChainCore,
+    );
+
+    const callArg = mockBuildSimple.mock.calls[0][0];
+    expect(callArg).not.toHaveProperty("options");
+  });
+
+  it("should omit options when crossChainCore is not provided", async () => {
+    await signAndSendTransaction(
+      makeRequest(),
+      makeWallet(),
+      undefined,
+      AptosNetwork.TESTNET,
+    );
+
+    const callArg = mockBuildSimple.mock.calls[0][0];
+    expect(callArg).not.toHaveProperty("options");
+  });
+
+  it("should throw for NaN expireTimestamp", async () => {
+    const crossChainCore = new CrossChainCore({
+      dappConfig: {
+        aptosNetwork: AptosNetwork.TESTNET,
+        getExpireTimestamp: () => NaN,
+      },
+    });
+
+    await expect(
+      signAndSendTransaction(
+        makeRequest(),
+        makeWallet(),
+        undefined,
+        AptosNetwork.TESTNET,
+        crossChainCore,
+      ),
+    ).rejects.toThrow("getExpireTimestamp returned an invalid value");
+  });
+
+  it("should throw for negative expireTimestamp", async () => {
+    const crossChainCore = new CrossChainCore({
+      dappConfig: {
+        aptosNetwork: AptosNetwork.TESTNET,
+        getExpireTimestamp: () => -1,
+      },
+    });
+
+    await expect(
+      signAndSendTransaction(
+        makeRequest(),
+        makeWallet(),
+        undefined,
+        AptosNetwork.TESTNET,
+        crossChainCore,
+      ),
+    ).rejects.toThrow("getExpireTimestamp returned an invalid value");
+  });
+
+  it("should throw for non-integer expireTimestamp", async () => {
+    const crossChainCore = new CrossChainCore({
+      dappConfig: {
+        aptosNetwork: AptosNetwork.TESTNET,
+        getExpireTimestamp: () => 1700000000.5,
+      },
+    });
+
+    await expect(
+      signAndSendTransaction(
+        makeRequest(),
+        makeWallet(),
+        undefined,
+        AptosNetwork.TESTNET,
+        crossChainCore,
+      ),
+    ).rejects.toThrow("getExpireTimestamp returned an invalid value");
+  });
+
+  it("should throw for Infinity expireTimestamp", async () => {
+    const crossChainCore = new CrossChainCore({
+      dappConfig: {
+        aptosNetwork: AptosNetwork.TESTNET,
+        getExpireTimestamp: () => Infinity,
+      },
+    });
+
+    await expect(
+      signAndSendTransaction(
+        makeRequest(),
+        makeWallet(),
+        undefined,
+        AptosNetwork.TESTNET,
+        crossChainCore,
+      ),
+    ).rejects.toThrow("getExpireTimestamp returned an invalid value");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #755

Aptos `transaction.build.simple()` supports an `options.expireTimestamp` parameter, but the cross-chain-core Aptos signers didn't expose it. For dapps with long-running bridge flows, the default transaction expiration may be too short, causing transactions to fail silently.

## Changes

### New `getExpireTimestamp` on `CrossChainDappConfig`

```ts
export interface CrossChainDappConfig {
  aptosNetwork: Network;
  // ...existing fields
  getExpireTimestamp?: () => number;  // Returns epoch seconds
}
```

This is a **function** (not a static number) because:
- Bridge flows span multiple transactions over minutes (burn → attestation → claim)
- Each transaction needs a fresh expiration window relative to the current time
- A static number frozen at config-creation time would go stale during long flows

### Where it's threaded

1. **`AptosSigner.signAndSendTransaction`** — now receives `crossChainCore` from the router `Signer`, reads `getExpireTimestamp` from the dapp config
2. **`AptosLocalSigner`** — accepts `getExpireTimestamp` as a constructor param, passed from `WormholeProvider.claimCCTPTransfer`
3. **Router `Signer.signAndSendTransaction`** — now passes `crossChainCore` to the Aptos signer path

### Usage

```ts
const crossChainCore = new CrossChainCore({
  dappConfig: {
    aptosNetwork: Network.MAINNET,
    getExpireTimestamp: () => Math.floor(Date.now() / 1000) + 120, // 2 min from now
  },
});
```

## Changeset

Minor — new optional config field, fully backward compatible.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Aptos transaction build/sign/submit paths; while the new behavior is optional and validated, misconfiguration could cause transaction failures or unexpected expirations.
> 
> **Overview**
> Adds optional `getExpireTimestamp` to `CrossChainDappConfig` to supply per-transaction Aptos `options.expireTimestamp` at build time (fresh window for multi-step flows).
> 
> Threads this callback through the Aptos signing stack (`Signer` → `AptosSigner`, and `WormholeProvider` → `AptosLocalSigner`) and introduces `validateExpireTimestamp` to fail fast on invalid values. Adds unit tests covering forwarding/omission and invalid timestamp handling for both signers, plus a changeset for a minor release.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7c38a4c787d4b92b67e6a4e9729a95f0ce51fa79. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->