### PR TITLE
Potential fix for code scanning alert no. 21: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,9 @@ name: Build
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/aptos-labs/aptos-wallet-adapter/security/code-scanning/21](https://github.com/aptos-labs/aptos-wallet-adapter/security/code-scanning/21)

In general, fix this kind of issue by adding an explicit `permissions` block either at the workflow root (applies to all jobs) or at the job level, granting only the minimal scopes required (often `contents: read` and optionally `packages: read`). This documents the intended permissions and prevents accidental escalation if repository defaults change.

For this specific workflow in `.github/workflows/build.yml`, the `build` job only checks out the code, sets up Node and pnpm, installs dependencies, and runs a build. None of these steps require write access to the repository or to pull requests. A safe, minimal configuration is to set `permissions: contents: read` at the workflow root, so it applies to all jobs (currently only `build`). To implement this, insert:

```yaml
permissions:
  contents: read
```

after the `on:` block (after line 5 in the provided snippet) and before the `concurrency:` block. No additional methods, imports, or other definitions are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
