### PR TITLE
fix(derived-wallet-solana): fallback when SIWS signIn is unimplemented

### DIFF
--- a/.changeset/fix-solana-signin-fallback.md
+++ b/.changeset/fix-solana-signin-fallback.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/derived-wallet-solana": patch
+---
+
+Improved Solana transaction signing fallback behavior by trying SIWS (`signIn`) first and automatically falling back to `signMessage` when wallets expose `signIn` but throw at runtime (for example, "not implemented"). This removes wallet-name specific handling and makes compatibility more robust across wallet implementations.

--- a/.changeset/fix-solana-signin-fallback.md
+++ b/.changeset/fix-solana-signin-fallback.md
@@ -2,4 +2,4 @@
 "@aptos-labs/derived-wallet-solana": patch
 ---
 
-Improved Solana transaction signing fallback behavior by trying SIWS (`signIn`) first and automatically falling back to `signMessage` when wallets expose `signIn` but throw at runtime (for example, "not implemented"). This removes wallet-name specific handling and makes compatibility more robust across wallet implementations.
+Improved Solana transaction signing fallback behavior by trying SIWS (`signIn`) first and automatically falling back to `signMessage` when wallets expose `signIn` but throw at runtime (for example, "not implemented"). The fallback only triggers for non-`WalletError` exceptions, so user rejections signaled via `WalletError` (even with non-standard messages) propagate correctly instead of silently double-prompting via `signMessage`.

--- a/packages/derived-wallet-solana/src/signAptosTransaction.ts
+++ b/packages/derived-wallet-solana/src/signAptosTransaction.ts
@@ -51,29 +51,37 @@ export async function signAptosTransactionWithSolana(
     },
   );
 
-  // Prioritize SIWS if available
+  // Try SIWS (signIn) first, fall back to signMessage if it throws.
+  // Some wallets (e.g. Trust) declare signIn but throw "not implemented".
+  // User rejections are already converted to UserResponse by wrapSolanaUserResponse
+  // and won't reach the catch block, so only broken implementations trigger fallback.
   if (solanaWallet.signIn) {
-    const response = await wrapSolanaUserResponse(
-      solanaWallet.signIn!(siwsInput),
-    );
-    return mapUserResponse(response, (output): AccountAuthenticator => {
-      if (output.signatureType && output.signatureType !== "ed25519") {
-        throw new Error("Unsupported signature type");
-      }
-
-      // The wallet might change some of the fields in the SIWS input, so we
-      // might need to include the finalized input in the signature.
-      // For now, we can assume the input is unchanged.
-      return createAccountAuthenticatorForSolanaTransaction(
-        output.signature,
-        solanaPublicKey,
-        domain,
-        authenticationFunction,
-        signingMessageDigest,
+    try {
+      const response = await wrapSolanaUserResponse(
+        solanaWallet.signIn!(siwsInput),
       );
-    });
-  } else if (solanaWallet.signMessage) {
-    // Fallback to signMessage if SIWS is not available
+      return mapUserResponse(response, (output): AccountAuthenticator => {
+        if (output.signatureType && output.signatureType !== "ed25519") {
+          throw new Error("Unsupported signature type");
+        }
+
+        // The wallet might change some of the fields in the SIWS input, so we
+        // might need to include the finalized input in the signature.
+        // For now, we can assume the input is unchanged.
+        return createAccountAuthenticatorForSolanaTransaction(
+          output.signature,
+          solanaPublicKey,
+          domain,
+          authenticationFunction,
+          signingMessageDigest,
+        );
+      });
+    } catch (error) {
+      if (!solanaWallet.signMessage) throw error;
+    }
+  }
+
+  if (solanaWallet.signMessage) {
     const response = await wrapSolanaUserResponse(
       solanaWallet.signMessage(createSignInMessage(siwsInput)),
     );
@@ -86,11 +94,11 @@ export async function signAptosTransactionWithSolana(
         signingMessageDigest,
       );
     });
-  } else {
-    throw new Error(
-      `${solanaWallet.name} does not support SIWS or signMessage`,
-    );
   }
+
+  throw new Error(
+    `${solanaWallet.name} does not support SIWS or signMessage`,
+  );
 }
 
 // A helper function to create an AccountAuthenticator from a Solana signature

--- a/packages/derived-wallet-solana/src/signAptosTransaction.ts
+++ b/packages/derived-wallet-solana/src/signAptosTransaction.ts
@@ -13,6 +13,7 @@ import {
   Serializer,
   AbstractedAccount,
 } from "@aptos-labs/ts-sdk";
+import { WalletError } from "@solana/wallet-adapter-base";
 import { PublicKey as SolanaPublicKey } from "@solana/web3.js";
 import { StandardWalletAdapter as SolanaWalletAdapter } from "@solana/wallet-standard-wallet-adapter-base";
 import { createSiwsEnvelopeForAptosTransaction } from "./createSiwsEnvelope";
@@ -53,13 +54,15 @@ export async function signAptosTransactionWithSolana(
 
   // Try SIWS (signIn) first, fall back to signMessage if it throws.
   // Some wallets (e.g. Trust) declare signIn but throw at runtime.
-  // User rejections are already converted to UserResponse by wrapSolanaUserResponse
-  // and won't reach the catch handler, so only broken implementations trigger fallback.
+  // Re-throw WalletError instances — they represent wallet-level issues
+  // (e.g. user rejections with non-standard messages) and must not silently
+  // fall back to signMessage, which would double-prompt the user.
   if (solanaWallet.signIn) {
     const signInResponse = await wrapSolanaUserResponse(
       solanaWallet.signIn!(siwsInput),
     ).catch((error) => {
-      if (!solanaWallet.signMessage) throw error;
+      if (error instanceof WalletError || !solanaWallet.signMessage)
+        throw error;
       return undefined;
     });
     if (signInResponse) {

--- a/packages/derived-wallet-solana/src/signAptosTransaction.ts
+++ b/packages/derived-wallet-solana/src/signAptosTransaction.ts
@@ -52,15 +52,18 @@ export async function signAptosTransactionWithSolana(
   );
 
   // Try SIWS (signIn) first, fall back to signMessage if it throws.
-  // Some wallets (e.g. Trust) declare signIn but throw "not implemented".
+  // Some wallets (e.g. Trust) declare signIn but throw at runtime.
   // User rejections are already converted to UserResponse by wrapSolanaUserResponse
-  // and won't reach the catch block, so only broken implementations trigger fallback.
+  // and won't reach the catch handler, so only broken implementations trigger fallback.
   if (solanaWallet.signIn) {
-    try {
-      const response = await wrapSolanaUserResponse(
-        solanaWallet.signIn!(siwsInput),
-      );
-      return mapUserResponse(response, (output): AccountAuthenticator => {
+    const signInResponse = await wrapSolanaUserResponse(
+      solanaWallet.signIn!(siwsInput),
+    ).catch((error) => {
+      if (!solanaWallet.signMessage) throw error;
+      return undefined;
+    });
+    if (signInResponse) {
+      return mapUserResponse(signInResponse, (output): AccountAuthenticator => {
         if (output.signatureType && output.signatureType !== "ed25519") {
           throw new Error("Unsupported signature type");
         }
@@ -76,8 +79,6 @@ export async function signAptosTransactionWithSolana(
           signingMessageDigest,
         );
       });
-    } catch (error) {
-      if (!solanaWallet.signMessage) throw error;
     }
   }
 
@@ -96,9 +97,7 @@ export async function signAptosTransactionWithSolana(
     });
   }
 
-  throw new Error(
-    `${solanaWallet.name} does not support SIWS or signMessage`,
-  );
+  throw new Error(`${solanaWallet.name} does not support SIWS or signMessage`);
 }
 
 // A helper function to create an AccountAuthenticator from a Solana signature

--- a/packages/derived-wallet-solana/src/signAptosTransaction.ts
+++ b/packages/derived-wallet-solana/src/signAptosTransaction.ts
@@ -58,8 +58,10 @@ export async function signAptosTransactionWithSolana(
   // (e.g. user rejections with non-standard messages) and must not silently
   // fall back to signMessage, which would double-prompt the user.
   if (solanaWallet.signIn) {
+    // Invoke signIn inside .then() so synchronous throws become rejections
+    // that .catch() can handle uniformly with async failures.
     const signInResponse = await wrapSolanaUserResponse(
-      solanaWallet.signIn!(siwsInput),
+      Promise.resolve().then(() => solanaWallet.signIn!(siwsInput)),
     ).catch((error) => {
       if (error instanceof WalletError || !solanaWallet.signMessage)
         throw error;

--- a/packages/derived-wallet-solana/tests/signAptosTransactionFallback.test.ts
+++ b/packages/derived-wallet-solana/tests/signAptosTransactionFallback.test.ts
@@ -4,6 +4,7 @@ import {
   AnyRawTransaction,
   AccountAuthenticatorAbstraction,
 } from "@aptos-labs/ts-sdk";
+import { WalletError } from "@solana/wallet-adapter-base";
 import type { StandardWalletAdapter } from "@solana/wallet-standard-wallet-adapter-base";
 import { signAptosTransactionWithSolana } from "../src/signAptosTransaction";
 import { defaultSolanaAuthenticationFunction } from "../src/shared";
@@ -92,7 +93,7 @@ describe("signAptosTransactionWithSolana fallback behavior", () => {
   });
 
   describe("when signIn throws at runtime", () => {
-    it("should fall back to signMessage", async () => {
+    it("should fall back to signMessage for non-WalletError", async () => {
       const wallet = createConnectedMockSolanaWallet({
         keypair: TEST_SOLANA_KEYPAIR,
         supportSignIn: true,
@@ -123,6 +124,38 @@ describe("signAptosTransactionWithSolana fallback behavior", () => {
       (wallet as any).signMessage = undefined;
 
       await expect(callSign(wallet)).rejects.toThrow("not implemented");
+    });
+
+    it("should NOT fall back when signIn throws a WalletError (non-standard rejection)", async () => {
+      const wallet = createConnectedMockSolanaWallet({
+        keypair: TEST_SOLANA_KEYPAIR,
+        supportSignIn: true,
+      });
+      const signMessageSpy = vi.fn(wallet.signMessage!);
+      (wallet as any).signIn = async () => {
+        throw new WalletError("Request denied by user");
+      };
+      (wallet as any).signMessage = signMessageSpy;
+
+      await expect(callSign(wallet)).rejects.toThrow("Request denied by user");
+      expect(signMessageSpy).not.toHaveBeenCalled();
+    });
+
+    it("should return rejection for WalletError with standard message", async () => {
+      const wallet = createConnectedMockSolanaWallet({
+        keypair: TEST_SOLANA_KEYPAIR,
+        supportSignIn: true,
+      });
+      const signMessageSpy = vi.fn(wallet.signMessage!);
+      (wallet as any).signIn = async () => {
+        throw new WalletError("User rejected the request.");
+      };
+      (wallet as any).signMessage = signMessageSpy;
+
+      const result = await callSign(wallet);
+
+      expect(result.status).toBe(UserResponseStatus.REJECTED);
+      expect(signMessageSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/derived-wallet-solana/tests/signAptosTransactionFallback.test.ts
+++ b/packages/derived-wallet-solana/tests/signAptosTransactionFallback.test.ts
@@ -93,13 +93,33 @@ describe("signAptosTransactionWithSolana fallback behavior", () => {
   });
 
   describe("when signIn throws at runtime", () => {
-    it("should fall back to signMessage for non-WalletError", async () => {
+    it("should fall back to signMessage for async non-WalletError", async () => {
       const wallet = createConnectedMockSolanaWallet({
         keypair: TEST_SOLANA_KEYPAIR,
         supportSignIn: true,
       });
       const signMessageSpy = vi.fn(wallet.signMessage!);
       (wallet as any).signIn = async () => {
+        throw new Error("not implemented");
+      };
+      (wallet as any).signMessage = signMessageSpy;
+
+      const result = await callSign(wallet);
+
+      expect(signMessageSpy).toHaveBeenCalled();
+      expect(result.status).toBe(UserResponseStatus.APPROVED);
+      if (result.status === UserResponseStatus.APPROVED) {
+        expect(result.args).toBeInstanceOf(AccountAuthenticatorAbstraction);
+      }
+    });
+
+    it("should fall back to signMessage for synchronous non-WalletError", async () => {
+      const wallet = createConnectedMockSolanaWallet({
+        keypair: TEST_SOLANA_KEYPAIR,
+        supportSignIn: true,
+      });
+      const signMessageSpy = vi.fn(wallet.signMessage!);
+      (wallet as any).signIn = () => {
         throw new Error("not implemented");
       };
       (wallet as any).signMessage = signMessageSpy;
@@ -126,6 +146,19 @@ describe("signAptosTransactionWithSolana fallback behavior", () => {
       await expect(callSign(wallet)).rejects.toThrow("not implemented");
     });
 
+    it("should rethrow synchronous error if signMessage is not available", async () => {
+      const wallet = createConnectedMockSolanaWallet({
+        keypair: TEST_SOLANA_KEYPAIR,
+        supportSignIn: true,
+      });
+      (wallet as any).signIn = () => {
+        throw new Error("not implemented");
+      };
+      (wallet as any).signMessage = undefined;
+
+      await expect(callSign(wallet)).rejects.toThrow("not implemented");
+    });
+
     it("should NOT fall back when signIn throws a WalletError (non-standard rejection)", async () => {
       const wallet = createConnectedMockSolanaWallet({
         keypair: TEST_SOLANA_KEYPAIR,
@@ -133,6 +166,21 @@ describe("signAptosTransactionWithSolana fallback behavior", () => {
       });
       const signMessageSpy = vi.fn(wallet.signMessage!);
       (wallet as any).signIn = async () => {
+        throw new WalletError("Request denied by user");
+      };
+      (wallet as any).signMessage = signMessageSpy;
+
+      await expect(callSign(wallet)).rejects.toThrow("Request denied by user");
+      expect(signMessageSpy).not.toHaveBeenCalled();
+    });
+
+    it("should NOT fall back when signIn throws a synchronous WalletError", async () => {
+      const wallet = createConnectedMockSolanaWallet({
+        keypair: TEST_SOLANA_KEYPAIR,
+        supportSignIn: true,
+      });
+      const signMessageSpy = vi.fn(wallet.signMessage!);
+      (wallet as any).signIn = () => {
         throw new WalletError("Request denied by user");
       };
       (wallet as any).signMessage = signMessageSpy;

--- a/packages/derived-wallet-solana/tests/signAptosTransactionFallback.test.ts
+++ b/packages/derived-wallet-solana/tests/signAptosTransactionFallback.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi } from "vitest";
+import { UserResponseStatus } from "@aptos-labs/wallet-standard";
+import {
+  AnyRawTransaction,
+  AccountAuthenticatorAbstraction,
+} from "@aptos-labs/ts-sdk";
+import type { StandardWalletAdapter } from "@solana/wallet-standard-wallet-adapter-base";
+import { signAptosTransactionWithSolana } from "../src/signAptosTransaction";
+import { defaultSolanaAuthenticationFunction } from "../src/shared";
+import {
+  createConnectedMockSolanaWallet,
+  TEST_SOLANA_KEYPAIR,
+} from "./mocks/solanaWallet";
+
+vi.mock("@aptos-labs/ts-sdk", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    generateSigningMessageForTransaction: vi.fn(() => new Uint8Array(32)),
+    hashValues: vi.fn(() => new Uint8Array(32).fill(0xaa)),
+    AbstractedAccount: {
+      generateAccountAbstractionMessage: vi.fn(() => new Uint8Array(32)),
+    },
+  };
+});
+
+vi.mock("../src/createSiwsEnvelope", () => ({
+  createSiwsEnvelopeForAptosTransaction: vi.fn(() => ({
+    domain: "test.example.com",
+    address: "test-address",
+    nonce: "0x" + "aa".repeat(32),
+    statement: "Test transaction statement",
+  })),
+}));
+
+const TEST_DOMAIN = "test.example.com";
+const FAKE_TX = {} as AnyRawTransaction;
+
+function callSign(wallet: StandardWalletAdapter) {
+  return signAptosTransactionWithSolana({
+    solanaWallet: wallet,
+    authenticationFunction: defaultSolanaAuthenticationFunction,
+    rawTransaction: FAKE_TX,
+    domain: TEST_DOMAIN,
+  });
+}
+
+describe("signAptosTransactionWithSolana fallback behavior", () => {
+  describe("when signIn succeeds", () => {
+    it("should return an approved authenticator via signIn", async () => {
+      const wallet = createConnectedMockSolanaWallet({
+        keypair: TEST_SOLANA_KEYPAIR,
+        supportSignIn: true,
+      });
+
+      const result = await callSign(wallet);
+
+      expect(result.status).toBe(UserResponseStatus.APPROVED);
+      if (result.status === UserResponseStatus.APPROVED) {
+        expect(result.args).toBeInstanceOf(AccountAuthenticatorAbstraction);
+      }
+    });
+
+    it("should not call signMessage when signIn succeeds", async () => {
+      const wallet = createConnectedMockSolanaWallet({
+        keypair: TEST_SOLANA_KEYPAIR,
+        supportSignIn: true,
+      });
+      const signMessageSpy = vi.fn(wallet.signMessage!);
+      (wallet as any).signMessage = signMessageSpy;
+
+      await callSign(wallet);
+
+      expect(signMessageSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("when signIn is not available", () => {
+    it("should use signMessage", async () => {
+      const wallet = createConnectedMockSolanaWallet({
+        keypair: TEST_SOLANA_KEYPAIR,
+        supportSignIn: false,
+      });
+
+      const result = await callSign(wallet);
+
+      expect(result.status).toBe(UserResponseStatus.APPROVED);
+      if (result.status === UserResponseStatus.APPROVED) {
+        expect(result.args).toBeInstanceOf(AccountAuthenticatorAbstraction);
+      }
+    });
+  });
+
+  describe("when signIn throws at runtime", () => {
+    it("should fall back to signMessage", async () => {
+      const wallet = createConnectedMockSolanaWallet({
+        keypair: TEST_SOLANA_KEYPAIR,
+        supportSignIn: true,
+      });
+      const signMessageSpy = vi.fn(wallet.signMessage!);
+      (wallet as any).signIn = async () => {
+        throw new Error("not implemented");
+      };
+      (wallet as any).signMessage = signMessageSpy;
+
+      const result = await callSign(wallet);
+
+      expect(signMessageSpy).toHaveBeenCalled();
+      expect(result.status).toBe(UserResponseStatus.APPROVED);
+      if (result.status === UserResponseStatus.APPROVED) {
+        expect(result.args).toBeInstanceOf(AccountAuthenticatorAbstraction);
+      }
+    });
+
+    it("should rethrow if signMessage is not available", async () => {
+      const wallet = createConnectedMockSolanaWallet({
+        keypair: TEST_SOLANA_KEYPAIR,
+        supportSignIn: true,
+      });
+      (wallet as any).signIn = async () => {
+        throw new Error("not implemented");
+      };
+      (wallet as any).signMessage = undefined;
+
+      await expect(callSign(wallet)).rejects.toThrow("not implemented");
+    });
+  });
+
+  describe("when neither signIn nor signMessage is available", () => {
+    it("should throw 'does not support' error", async () => {
+      const wallet = createConnectedMockSolanaWallet({
+        keypair: TEST_SOLANA_KEYPAIR,
+        supportSignIn: false,
+      });
+      (wallet as any).signMessage = undefined;
+
+      await expect(callSign(wallet)).rejects.toThrow(
+        "does not support SIWS or signMessage",
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- update Solana derived transaction signing to try `signIn` first and gracefully fall back to `signMessage` when `signIn` throws at runtime
- remove wallet-name specific handling so compatibility is based on runtime behavior instead of a hardcoded denylist
- add a changeset for `@aptos-labs/derived-wallet-solana`

## Test plan
- [x] Verify linting reports no issues in `packages/derived-wallet-solana/src/signAptosTransaction.ts`
- [x] Confirm branch diff includes only the fallback logic change and changeset
- [x] Manually validate with a wallet that supports `signIn`
- [x] Manually validate with Trust Wallet (or equivalent wallet with unimplemented `signIn`) to confirm fallback path

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the Solana-based transaction signing path and error handling, which can affect whether users are prompted or rejected correctly. Risk is mitigated by targeted fallback logic and new tests covering sync/async throw and rejection cases.
> 
> **Overview**
> Solana Aptos-transaction signing now **tries SIWS `signIn` first** and **falls back to `signMessage`** when wallets expose `signIn` but throw at runtime (including synchronous throws). The fallback is *suppressed for `WalletError`* so wallet/user rejections propagate (and standard rejections still map to `REJECTED`) instead of triggering a second `signMessage` prompt.
> 
> Adds a changeset for a patch release and introduces a dedicated test suite covering successful `signIn`, missing `signIn`, runtime-throw fallback, and no-fallback behavior for `WalletError` and missing `signMessage`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e747f134302b7171820d20114a834a00de945c3d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->