### PR TITLE
feat(cross-chain-core): thread CrossChainCore through to AptosLocalSigner

### DIFF
--- a/.changeset/thread-crosschaincore-to-aptos-local-signer.md
+++ b/.changeset/thread-crosschaincore-to-aptos-local-signer.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/cross-chain-core": minor
+---
+
+Thread `CrossChainCore` through to `AptosLocalSigner`, replacing individual `dappNetwork` and `getExpireTimestamp` constructor parameters with a single `crossChainCore` instance. Also removed unused `options` parameter from `EthereumSigner.signAndSendTransaction`.

--- a/packages/cross-chain-core/src/providers/wormhole/signers/AptosLocalSigner.ts
+++ b/packages/cross-chain-core/src/providers/wormhole/signers/AptosLocalSigner.ts
@@ -18,7 +18,6 @@ import {
   AptosChains,
 } from "@wormhole-foundation/sdk-aptos";
 import {
-  GasStationApiKey,
   OnTransactionSigned,
   validateExpireTimestamp,
 } from "../types";
@@ -31,7 +30,7 @@ export class AptosLocalSigner<
   _chain: C;
   _options: any;
   _wallet: Account;
-  _sponsorAccount: Account | GasStationApiKey | undefined;
+  _sponsorAccount: Account | undefined;
   _onTransactionSigned: OnTransactionSigned | undefined;
   _crossChainCore: CrossChainCore;
   _claimedTransactionHashes: string[] = [];
@@ -39,7 +38,7 @@ export class AptosLocalSigner<
     chain: C,
     options: any,
     wallet: Account,
-    feePayerAccount: Account | GasStationApiKey | undefined,
+    feePayerAccount: Account | undefined,
     crossChainCore: CrossChainCore,
     onTransactionSigned?: OnTransactionSigned,
   ) {
@@ -85,7 +84,7 @@ export class AptosLocalSigner<
 export async function signAndSendTransaction(
   request: UnsignedTransaction<Network, AptosChains>,
   wallet: Account,
-  sponsorAccount: Account | GasStationApiKey | undefined,
+  sponsorAccount: Account | undefined,
   crossChainCore: CrossChainCore,
 ) {
   if (!wallet) {
@@ -138,10 +137,8 @@ export async function signAndSendTransaction(
   };
 
   if (sponsorAccount) {
-    // Gas station is currently impossible to use, since the transaction we get from
-    // Wormhole is a script transaction and gas station only supports entry function transactions
     const feePayerSignerAuthenticator = aptos.transaction.signAsFeePayer({
-      signer: sponsorAccount as Account,
+      signer: sponsorAccount,
       transaction: txnToSign,
     });
     txnToSubmit.feePayerAuthenticator = feePayerSignerAuthenticator;

--- a/packages/cross-chain-core/src/providers/wormhole/signers/AptosLocalSigner.ts
+++ b/packages/cross-chain-core/src/providers/wormhole/signers/AptosLocalSigner.ts
@@ -3,7 +3,6 @@ import {
   AnyRawTransaction,
   Aptos,
   AptosConfig,
-  Network as AptosNetwork,
   Account,
 } from "@aptos-labs/ts-sdk";
 
@@ -23,7 +22,7 @@ import {
   OnTransactionSigned,
   validateExpireTimestamp,
 } from "../types";
-import { isAccount } from "./AptosSigner";
+import { CrossChainCore } from "../../../CrossChainCore";
 
 export class AptosLocalSigner<
   N extends Network,
@@ -34,25 +33,22 @@ export class AptosLocalSigner<
   _wallet: Account;
   _sponsorAccount: Account | GasStationApiKey | undefined;
   _onTransactionSigned: OnTransactionSigned | undefined;
-  _getExpireTimestamp: (() => number) | undefined;
+  _crossChainCore: CrossChainCore;
   _claimedTransactionHashes: string[] = [];
-  _dappNetwork: AptosNetwork;
   constructor(
     chain: C,
     options: any,
     wallet: Account,
     feePayerAccount: Account | GasStationApiKey | undefined,
-    dappNetwork: AptosNetwork,
+    crossChainCore: CrossChainCore,
     onTransactionSigned?: OnTransactionSigned,
-    getExpireTimestamp?: () => number,
   ) {
     this._chain = chain;
     this._options = options;
     this._wallet = wallet;
     this._sponsorAccount = feePayerAccount;
-    this._dappNetwork = dappNetwork;
+    this._crossChainCore = crossChainCore;
     this._onTransactionSigned = onTransactionSigned;
-    this._getExpireTimestamp = getExpireTimestamp;
   }
 
   chain(): C {
@@ -76,8 +72,7 @@ export class AptosLocalSigner<
         tx as AptosUnsignedTransaction<Network, AptosChains>,
         this._wallet,
         this._sponsorAccount,
-        this._dappNetwork,
-        this._getExpireTimestamp,
+        this._crossChainCore,
       );
       this._onTransactionSigned?.(tx.description, txId);
       txHashes.push(txId);
@@ -91,8 +86,7 @@ export async function signAndSendTransaction(
   request: UnsignedTransaction<Network, AptosChains>,
   wallet: Account,
   sponsorAccount: Account | GasStationApiKey | undefined,
-  dappNetwork: AptosNetwork,
-  getExpireTimestamp?: () => number,
+  crossChainCore: CrossChainCore,
 ) {
   if (!wallet) {
     throw new Error("Wallet is undefined");
@@ -110,12 +104,13 @@ export async function signAndSendTransaction(
     }
   });
 
+  const dappNetwork = crossChainCore._dappConfig.aptosNetwork;
   const aptosConfig = new AptosConfig({
     network: dappNetwork,
   });
   const aptos = new Aptos(aptosConfig);
 
-  const expireTimestamp = getExpireTimestamp?.();
+  const expireTimestamp = crossChainCore._dappConfig.getExpireTimestamp?.();
   if (typeof expireTimestamp !== "undefined") {
     validateExpireTimestamp(expireTimestamp);
   }

--- a/packages/cross-chain-core/src/providers/wormhole/signers/EthereumSigner.ts
+++ b/packages/cross-chain-core/src/providers/wormhole/signers/EthereumSigner.ts
@@ -6,11 +6,11 @@ import { Network } from "@wormhole-foundation/sdk";
 import { ethers, getBigInt } from "ethers";
 import { AdapterWallet } from "@aptos-labs/wallet-adapter-core";
 import { EIP1193DerivedWallet } from "@aptos-labs/derived-wallet-ethereum";
+
 export async function signAndSendTransaction(
   request: EvmUnsignedTransaction<Network, EvmChains>,
   wallet: AdapterWallet,
   chainName: string,
-  options: any,
 ): Promise<string> {
   if (!wallet) {
     throw new Error("wallet.sendTransaction is undefined");
@@ -23,8 +23,7 @@ export async function signAndSendTransaction(
   });
   const actualChainId = parseInt(chainId, 16);
 
-  if (!actualChainId)
-    throw new Error("No signer found for chain" + chainName);
+  if (!actualChainId) throw new Error("No signer found for chain" + chainName);
   const expectedChainId = request.transaction.chainId
     ? getBigInt(request.transaction.chainId)
     : undefined;

--- a/packages/cross-chain-core/src/providers/wormhole/signers/Signer.ts
+++ b/packages/cross-chain-core/src/providers/wormhole/signers/Signer.ts
@@ -118,7 +118,6 @@ export const signAndSendTransaction = async (
       request as EvmUnsignedTransaction<Network, EvmChains>,
       wallet,
       chain.displayName,
-      options,
     );
     return tx;
   } else if (chain.context === "Sui") {

--- a/packages/cross-chain-core/src/providers/wormhole/wormhole.ts
+++ b/packages/cross-chain-core/src/providers/wormhole/wormhole.ts
@@ -268,9 +268,8 @@ export class WormholeProvider implements CrossChainProvider<
                 {},
                 mainSigner, // the account that signs the "claim" transaction
                 sponsorAccount, // the fee payer account
-                this.crossChainCore._dappConfig?.aptosNetwork,
+                this.crossChainCore,
                 onTransactionSigned,
-                this.crossChainCore._dappConfig?.getExpireTimestamp,
               );
 
               if (routes.isManual(this.wormholeRoute)) {

--- a/packages/cross-chain-core/src/providers/wormhole/wormhole.ts
+++ b/packages/cross-chain-core/src/providers/wormhole/wormhole.ts
@@ -20,6 +20,7 @@ import {
 import { logger } from "../../utils/logger";
 import { serializeReceipt } from "../../utils/receiptSerialization";
 import { AptosLocalSigner } from "./signers/AptosLocalSigner";
+import { isAccount } from "./signers/AptosSigner";
 import { Signer } from "./signers/Signer";
 import { ChainConfig } from "../../config";
 import { createCCTPRoute } from "./utils";
@@ -248,6 +249,14 @@ export class WormholeProvider implements CrossChainProvider<
     let { receipt, mainSigner, sponsorAccount, onTransactionSigned } = input;
     if (!this.wormholeRoute) {
       throw new Error("Wormhole route not initialized");
+    }
+    if (sponsorAccount && !isAccount(sponsorAccount)) {
+      throw new Error(
+        "AptosLocalSigner does not support GasStationApiKey as a sponsor account. " +
+          "Wormhole claim transactions are script-based and cannot be submitted " +
+          "via the gas station. Please provide an Account instance as the sponsor, " +
+          "or omit the sponsor account.",
+      );
     }
 
     logger.log("mainSigner", mainSigner.accountAddress.toString());

--- a/packages/cross-chain-core/tests/signers/AptosLocalSigner.test.ts
+++ b/packages/cross-chain-core/tests/signers/AptosLocalSigner.test.ts
@@ -10,6 +10,7 @@ import {
   AptosLocalSigner,
   signAndSendTransaction,
 } from "../../src/providers/wormhole/signers/AptosLocalSigner";
+import { CrossChainCore } from "../../src/CrossChainCore";
 
 const mockBuildSimple = vi.fn();
 const mockSign = vi.fn();
@@ -42,6 +43,9 @@ describe("AptosLocalSigner", () => {
   );
   const testAccount = Account.fromPrivateKey({ privateKey: testPrivateKey });
   const mockOptions = {};
+  const mockCrossChainCore = {
+    _dappConfig: { aptosNetwork: AptosNetwork.TESTNET },
+  } as unknown as CrossChainCore;
 
   describe("constructor", () => {
     it("should create signer with required properties", () => {
@@ -50,12 +54,14 @@ describe("AptosLocalSigner", () => {
         mockOptions,
         testAccount,
         undefined,
+        mockCrossChainCore,
       );
 
       expect(signer).toBeDefined();
       expect(signer._chain).toBe("Aptos");
       expect(signer._options).toBe(mockOptions);
       expect(signer._wallet).toBe(testAccount);
+      expect(signer._crossChainCore).toBe(mockCrossChainCore);
     });
 
     it("should initialize claimedTransactionHashes as empty array", () => {
@@ -64,6 +70,7 @@ describe("AptosLocalSigner", () => {
         mockOptions,
         testAccount,
         undefined,
+        mockCrossChainCore,
       );
 
       expect(signer._claimedTransactionHashes).toEqual([]);
@@ -85,19 +92,23 @@ describe("AptosLocalSigner", () => {
         mockOptions,
         testAccount,
         sponsorAccount,
+        mockCrossChainCore,
       );
 
       expect(signer._sponsorAccount).toBe(sponsorAccount);
     });
 
-    it("should accept sponsor account (string gas station key)", () => {
-      const gasStationKey = "gas-station-api-key";
+    it("should accept sponsor account (GasStationApiKey)", () => {
+      const gasStationKey = {
+        [AptosNetwork.TESTNET]: "gas-station-api-key",
+      };
 
       const signer = new AptosLocalSigner(
         "Aptos",
         mockOptions,
         testAccount,
         gasStationKey,
+        mockCrossChainCore,
       );
 
       expect(signer._sponsorAccount).toBe(gasStationKey);
@@ -111,6 +122,7 @@ describe("AptosLocalSigner", () => {
         mockOptions,
         testAccount,
         undefined,
+        mockCrossChainCore,
       );
 
       expect(signer.chain()).toBe("Aptos");
@@ -124,6 +136,7 @@ describe("AptosLocalSigner", () => {
         mockOptions,
         testAccount,
         undefined,
+        mockCrossChainCore,
       );
 
       expect(signer.address()).toBe(testAccount.accountAddress.toString());
@@ -135,6 +148,7 @@ describe("AptosLocalSigner", () => {
         mockOptions,
         testAccount,
         undefined,
+        mockCrossChainCore,
       );
 
       // Aptos addresses are 64 hex characters prefixed with 0x
@@ -149,6 +163,7 @@ describe("AptosLocalSigner", () => {
         mockOptions,
         testAccount,
         undefined,
+        mockCrossChainCore,
       );
 
       expect(signer.claimedTransactionHashes()).toBe("");
@@ -160,6 +175,7 @@ describe("AptosLocalSigner", () => {
         mockOptions,
         testAccount,
         undefined,
+        mockCrossChainCore,
       );
 
       // Directly modify internal state for testing
@@ -174,6 +190,7 @@ describe("AptosLocalSigner", () => {
         mockOptions,
         testAccount,
         undefined,
+        mockCrossChainCore,
       );
 
       signer._claimedTransactionHashes = ["0xhash1", "0xhash2"];
@@ -189,6 +206,7 @@ describe("AptosLocalSigner", () => {
         mockOptions,
         testAccount,
         undefined,
+        mockCrossChainCore,
       );
 
       expect(signer._wallet).toBe(testAccount);
@@ -202,6 +220,7 @@ describe("AptosLocalSigner", () => {
         customOptions,
         testAccount,
         undefined,
+        mockCrossChainCore,
       );
 
       expect(signer._options).toBe(customOptions);
@@ -230,15 +249,23 @@ describe("AptosLocalSigner", () => {
       } as any;
     }
 
+    function makeCrossChainCore(getExpireTimestamp?: () => number) {
+      return {
+        _dappConfig: {
+          aptosNetwork: AptosNetwork.TESTNET,
+          getExpireTimestamp,
+        },
+      } as unknown as CrossChainCore;
+    }
+
     it("should pass expireTimestamp option when getExpireTimestamp returns a value", async () => {
-      const getExpireTimestamp = () => 1700000000;
+      const crossChainCore = makeCrossChainCore(() => 1700000000);
 
       await signAndSendTransaction(
         makeRequest(),
         testAccount,
         undefined,
-        AptosNetwork.TESTNET,
-        getExpireTimestamp,
+        crossChainCore,
       );
 
       expect(mockBuildSimple).toHaveBeenCalledWith(
@@ -249,14 +276,13 @@ describe("AptosLocalSigner", () => {
     });
 
     it("should pass expireTimestamp option when getExpireTimestamp returns 0", async () => {
-      const getExpireTimestamp = () => 0;
+      const crossChainCore = makeCrossChainCore(() => 0);
 
       await signAndSendTransaction(
         makeRequest(),
         testAccount,
         undefined,
-        AptosNetwork.TESTNET,
-        getExpireTimestamp,
+        crossChainCore,
       );
 
       expect(mockBuildSimple).toHaveBeenCalledWith(
@@ -266,12 +292,14 @@ describe("AptosLocalSigner", () => {
       );
     });
 
-    it("should omit options when getExpireTimestamp is not provided", async () => {
+    it("should omit options when getExpireTimestamp is not set in config", async () => {
+      const crossChainCore = makeCrossChainCore(undefined);
+
       await signAndSendTransaction(
         makeRequest(),
         testAccount,
         undefined,
-        AptosNetwork.TESTNET,
+        crossChainCore,
       );
 
       const callArg = mockBuildSimple.mock.calls[0][0];
@@ -280,62 +308,66 @@ describe("AptosLocalSigner", () => {
 
     it("should call getExpireTimestamp at build time", async () => {
       const getExpireTimestamp = vi.fn().mockReturnValue(9999999999);
+      const crossChainCore = makeCrossChainCore(getExpireTimestamp);
 
       await signAndSendTransaction(
         makeRequest(),
         testAccount,
         undefined,
-        AptosNetwork.TESTNET,
-        getExpireTimestamp,
+        crossChainCore,
       );
 
       expect(getExpireTimestamp).toHaveBeenCalledOnce();
     });
 
     it("should throw for NaN expireTimestamp", async () => {
+      const crossChainCore = makeCrossChainCore(() => NaN);
+
       await expect(
         signAndSendTransaction(
           makeRequest(),
           testAccount,
           undefined,
-          AptosNetwork.TESTNET,
-          () => NaN,
+          crossChainCore,
         ),
       ).rejects.toThrow("getExpireTimestamp returned an invalid value");
     });
 
     it("should throw for negative expireTimestamp", async () => {
+      const crossChainCore = makeCrossChainCore(() => -1);
+
       await expect(
         signAndSendTransaction(
           makeRequest(),
           testAccount,
           undefined,
-          AptosNetwork.TESTNET,
-          () => -1,
+          crossChainCore,
         ),
       ).rejects.toThrow("getExpireTimestamp returned an invalid value");
     });
 
     it("should throw for non-integer expireTimestamp", async () => {
+      const crossChainCore = makeCrossChainCore(() => 1700000000.5);
+
       await expect(
         signAndSendTransaction(
           makeRequest(),
           testAccount,
           undefined,
-          AptosNetwork.TESTNET,
-          () => 1700000000.5,
+          crossChainCore,
         ),
       ).rejects.toThrow("getExpireTimestamp returned an invalid value");
     });
 
     it("should throw for Infinity expireTimestamp", async () => {
+      const crossChainCore = makeCrossChainCore(() => Infinity);
+
       await expect(
         signAndSendTransaction(
           makeRequest(),
           testAccount,
           undefined,
-          AptosNetwork.TESTNET,
-          () => Infinity,
+          crossChainCore,
         ),
       ).rejects.toThrow("getExpireTimestamp returned an invalid value");
     });

--- a/packages/cross-chain-core/tests/signers/AptosLocalSigner.test.ts
+++ b/packages/cross-chain-core/tests/signers/AptosLocalSigner.test.ts
@@ -98,21 +98,6 @@ describe("AptosLocalSigner", () => {
       expect(signer._sponsorAccount).toBe(sponsorAccount);
     });
 
-    it("should accept sponsor account (GasStationApiKey)", () => {
-      const gasStationKey = {
-        [AptosNetwork.TESTNET]: "gas-station-api-key",
-      };
-
-      const signer = new AptosLocalSigner(
-        "Aptos",
-        mockOptions,
-        testAccount,
-        gasStationKey,
-        mockCrossChainCore,
-      );
-
-      expect(signer._sponsorAccount).toBe(gasStationKey);
-    });
   });
 
   describe("chain()", () => {


### PR DESCRIPTION
## Summary

Closes #760

- Refactored `AptosLocalSigner` to accept a single `CrossChainCore` instance instead of individual `dappNetwork` and `getExpireTimestamp` parameters. The signer now derives both values internally from `crossChainCore._dappConfig`, matching the pattern already used by `AptosSigner` and `SolanaSigner`.
- Removed unused `options` parameter from `EthereumSigner.signAndSendTransaction` (was accepted but never read).
- Updated `wormhole.ts` instantiation site to pass `this.crossChainCore` directly instead of destructuring config values.
- Updated all `AptosLocalSigner` tests for the new signatures, including correcting the `GasStationApiKey` mock type.

## Test plan

- [x] All 158 existing `cross-chain-core` tests pass (`pnpm test`)
- [ ] Verify cross-chain transfer flow on testnet (deposit + claim path exercises `AptosLocalSigner`)
- [ ] Verify cross-chain withdraw flow on testnet (exercises `AptosSigner` — unchanged)


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors Aptos claim signing APIs and sponsor-account typing, which could break callers or change runtime behavior for fee-payer flows. Also touches transaction submission paths (Aptos/EVM), though changes are mostly parameter plumbing and validation.
> 
> **Overview**
> `AptosLocalSigner` now takes a single `CrossChainCore` instance and derives `aptosNetwork` and optional `getExpireTimestamp()` from `crossChainCore._dappConfig`, removing the old constructor parameters and updating `signAndSendTransaction` accordingly.
> 
> Aptos claim flows now only accept an `Account` as the sponsor (no `GasStationApiKey`); `wormhole.ts` adds a guard that throws with a clear message if a non-`Account` sponsor is provided and passes `this.crossChainCore` into the signer. Separately, `EthereumSigner.signAndSendTransaction` drops an unused `options` parameter and call sites/tests are updated, with a changeset bumping `@aptos-labs/cross-chain-core` minor.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 528a8103a104371026257d2d514c4d76346d434f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->