### PR TITLE
feat(cross-chain-core): track source chain tx ID for error recovery

### DIFF
--- a/.changeset/track-source-chain-tx-id.md
+++ b/.changeset/track-source-chain-tx-id.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/cross-chain-core": minor
+---
+
+Track last source-chain transaction ID on `CrossChainCore` for error recovery. Added `TransferError` class (analogous to `WithdrawError`) that preserves the source-chain burn hash when the transfer claim phase fails. Consumers can now recover the tx hash via `error.originChainTxnId` or `crossChainCore._lastSourceChainTxId`.

--- a/packages/cross-chain-core/src/CrossChainCore.ts
+++ b/packages/cross-chain-core/src/CrossChainCore.ts
@@ -197,6 +197,14 @@ export class CrossChainCore {
   readonly CHAINS: ChainsConfig = testnetChains;
   readonly TOKENS: Record<string, TokenConfig> = testnetTokens;
 
+  /**
+   * Last known source-chain transaction ID, set by signers immediately after
+   * a transaction is submitted. Acts as a recovery side-channel so that
+   * callers can retrieve the tx hash even when the orchestration layer throws
+   * before returning it (e.g. claim failure after a successful burn).
+   */
+  _lastSourceChainTxId: string | undefined;
+
   constructor(args: { dappConfig: CrossChainDappConfig }) {
     this._dappConfig = args.dappConfig;
     if (args.dappConfig?.aptosNetwork === Network.MAINNET) {

--- a/packages/cross-chain-core/src/providers/wormhole/signers/Signer.ts
+++ b/packages/cross-chain-core/src/providers/wormhole/signers/Signer.ts
@@ -39,6 +39,13 @@ export class Signer<
   _sponsorAccount: Account | GasStationApiKey | undefined;
   _onTransactionSigned: OnTransactionSigned | undefined;
   _claimedTransactionHashes: string[] = [];
+  /**
+   * When true, signed tx hashes are written to
+   * `_crossChainCore._lastSourceChainTxId` as a recovery side-channel.
+   * Set to false for destination-chain claim signers so they don't
+   * overwrite the source-chain burn hash.
+   */
+  _trackAsSourceChain: boolean;
 
   constructor(
     chain: ChainConfig,
@@ -48,6 +55,7 @@ export class Signer<
     crossChainCore: CrossChainCore,
     sponsorAccount?: Account | GasStationApiKey | undefined,
     onTransactionSigned?: OnTransactionSigned,
+    trackAsSourceChain: boolean = true,
   ) {
     this._chain = chain;
     this._address = address;
@@ -56,6 +64,7 @@ export class Signer<
     this._crossChainCore = crossChainCore;
     this._sponsorAccount = sponsorAccount;
     this._onTransactionSigned = onTransactionSigned;
+    this._trackAsSourceChain = trackAsSourceChain;
   }
 
   chain(): C {
@@ -83,7 +92,9 @@ export class Signer<
         this._crossChainCore,
         this._sponsorAccount,
       );
-      this._crossChainCore._lastSourceChainTxId = txId;
+      if (this._trackAsSourceChain) {
+        this._crossChainCore._lastSourceChainTxId = txId;
+      }
       this._onTransactionSigned?.(tx.description, txId);
       txHashes.push(txId);
       this._claimedTransactionHashes.push(txId);

--- a/packages/cross-chain-core/src/providers/wormhole/signers/Signer.ts
+++ b/packages/cross-chain-core/src/providers/wormhole/signers/Signer.ts
@@ -83,6 +83,7 @@ export class Signer<
         this._crossChainCore,
         this._sponsorAccount,
       );
+      this._crossChainCore._lastSourceChainTxId = txId;
       this._onTransactionSigned?.(tx.description, txId);
       txHashes.push(txId);
       this._claimedTransactionHashes.push(txId);

--- a/packages/cross-chain-core/src/providers/wormhole/types.ts
+++ b/packages/cross-chain-core/src/providers/wormhole/types.ts
@@ -158,15 +158,6 @@ export interface RetryWithdrawClaimResponse extends WormholeClaimWithdrawRespons
 }
 
 /**
- * Error thrown when the withdraw flow fails *after* the Aptos burn
- * transaction has already been submitted (i.e. during attestation tracking
- * or destination-chain claiming).
- *
- * Consumers should check `instanceof WithdrawError` in their catch block
- * to recover the `originChainTxnId` and display an explorer link so the
- * user can verify their burn on-chain.
- */
-/**
  * Validates that a value returned by `getExpireTimestamp` is a non-negative
  * integer suitable for use as an epoch-second expiration timestamp.
  * Throws immediately for NaN, Infinity, negative values, or floats so that
@@ -212,6 +203,15 @@ export class TransferError extends Error {
   }
 }
 
+/**
+ * Error thrown when the withdraw flow fails *after* the Aptos burn
+ * transaction has already been submitted (i.e. during attestation tracking
+ * or destination-chain claiming).
+ *
+ * Consumers should check `instanceof WithdrawError` in their catch block
+ * to recover the `originChainTxnId` and display an explorer link so the
+ * user can verify their burn on-chain.
+ */
 export class WithdrawError extends Error {
   /** Aptos burn transaction hash — always available when this error is thrown. */
   readonly originChainTxnId: string;

--- a/packages/cross-chain-core/src/providers/wormhole/types.ts
+++ b/packages/cross-chain-core/src/providers/wormhole/types.ts
@@ -181,6 +181,37 @@ export function validateExpireTimestamp(value: number): void {
   }
 }
 
+/**
+ * Error thrown when the transfer (deposit) flow fails *after* the source-chain
+ * burn transaction has already been submitted (i.e. during attestation tracking
+ * or Aptos claiming).
+ *
+ * Consumers should check `instanceof TransferError` in their catch block
+ * to recover the `originChainTxnId` and display an explorer link so the
+ * user can verify their burn on-chain.
+ */
+export class TransferError extends Error {
+  /** Source-chain burn transaction hash — available when the burn succeeded before the failure. */
+  readonly originChainTxnId: string;
+  /**
+   * The underlying error that caused this failure.
+   * Mirrors ES2022 Error.cause — declared explicitly because the project's
+   * TypeScript lib target does not include ES2022 ErrorOptions.
+   */
+  readonly cause?: unknown;
+
+  constructor(
+    message: string,
+    originChainTxnId: string,
+    cause?: unknown,
+  ) {
+    super(message);
+    this.name = "TransferError";
+    this.originChainTxnId = originChainTxnId;
+    this.cause = cause;
+  }
+}
+
 export class WithdrawError extends Error {
   /** Aptos burn transaction hash — always available when this error is thrown. */
   readonly originChainTxnId: string;

--- a/packages/cross-chain-core/src/providers/wormhole/wormhole.ts
+++ b/packages/cross-chain-core/src/providers/wormhole/wormhole.ts
@@ -43,6 +43,7 @@ import {
   RetryWithdrawClaimRequest,
   RetryWithdrawClaimResponse,
   WithdrawError,
+  TransferError,
 } from "./types";
 import { SolanaDerivedWallet } from "@aptos-labs/derived-wallet-solana";
 import { EIP1193DerivedWallet } from "@aptos-labs/derived-wallet-ethereum";
@@ -335,13 +336,21 @@ export class WormholeProvider implements CrossChainProvider<
     // Submit transfer transaction from origin chain
     let { originChainTxnId, receipt } = await this.submitCCTPTransfer(input);
     // Claim transfer transaction on destination chain
-    const { destinationChainTxnId } = await this.claimCCTPTransfer({
-      receipt,
-      mainSigner: input.mainSigner,
-      sponsorAccount: input.sponsorAccount,
-      onTransactionSigned: input.onTransactionSigned,
-    });
-    return { originChainTxnId, destinationChainTxnId };
+    try {
+      const { destinationChainTxnId } = await this.claimCCTPTransfer({
+        receipt,
+        mainSigner: input.mainSigner,
+        sponsorAccount: input.sponsorAccount,
+        onTransactionSigned: input.onTransactionSigned,
+      });
+      return { originChainTxnId, destinationChainTxnId };
+    } catch (error: any) {
+      throw new TransferError(
+        error?.message ?? "Transfer claim failed after source-chain burn",
+        originChainTxnId,
+        error,
+      );
+    }
   }
 
   // --- Split withdraw flow: initiateWithdraw + trackWithdraw + claimWithdraw ---
@@ -492,6 +501,7 @@ export class WormholeProvider implements CrossChainProvider<
       this.crossChainCore,
       undefined,
       input.onTransactionSigned,
+      false,
     );
 
     if (routes.isManual(this.wormholeRoute)) {

--- a/packages/cross-chain-core/src/providers/wormhole/wormhole.ts
+++ b/packages/cross-chain-core/src/providers/wormhole/wormhole.ts
@@ -43,6 +43,7 @@ import {
   RetryWithdrawClaimRequest,
   RetryWithdrawClaimResponse,
   WithdrawError,
+  TransferError,
 } from "./types";
 import { SolanaDerivedWallet } from "@aptos-labs/derived-wallet-solana";
 import { EIP1193DerivedWallet } from "@aptos-labs/derived-wallet-ethereum";
@@ -333,14 +334,25 @@ export class WormholeProvider implements CrossChainProvider<
     }
     // Submit transfer transaction from origin chain
     let { originChainTxnId, receipt } = await this.submitCCTPTransfer(input);
-    // Claim transfer transaction on destination chain
-    const { destinationChainTxnId } = await this.claimCCTPTransfer({
-      receipt,
-      mainSigner: input.mainSigner,
-      sponsorAccount: input.sponsorAccount,
-      onTransactionSigned: input.onTransactionSigned,
-    });
-    return { originChainTxnId, destinationChainTxnId };
+    // Claim is wrapped so that, if it fails, the caller still receives
+    // the originChainTxnId (the irreversible source-chain burn).
+    try {
+      const { destinationChainTxnId } = await this.claimCCTPTransfer({
+        receipt,
+        mainSigner: input.mainSigner,
+        sponsorAccount: input.sponsorAccount,
+        onTransactionSigned: input.onTransactionSigned,
+      });
+      return { originChainTxnId, destinationChainTxnId };
+    } catch (error: any) {
+      throw new TransferError(
+        error?.message ?? "Transfer claim failed after source chain burn",
+        originChainTxnId ||
+          this.crossChainCore._lastSourceChainTxId ||
+          "",
+        error,
+      );
+    }
   }
 
   // --- Split withdraw flow: initiateWithdraw + trackWithdraw + claimWithdraw ---

--- a/packages/cross-chain-core/src/providers/wormhole/wormhole.ts
+++ b/packages/cross-chain-core/src/providers/wormhole/wormhole.ts
@@ -43,7 +43,6 @@ import {
   RetryWithdrawClaimRequest,
   RetryWithdrawClaimResponse,
   WithdrawError,
-  TransferError,
 } from "./types";
 import { SolanaDerivedWallet } from "@aptos-labs/derived-wallet-solana";
 import { EIP1193DerivedWallet } from "@aptos-labs/derived-wallet-ethereum";
@@ -98,7 +97,8 @@ export class WormholeProvider implements CrossChainProvider<
 
     const evmChainsConfig: Record<string, { rpc: string }> = {};
     for (const name of EVM_CHAIN_NAMES) {
-      const rpc = dappConfig?.evmConfig?.[name]?.rpc ?? chains[name]?.defaultRpc;
+      const rpc =
+        dappConfig?.evmConfig?.[name]?.rpc ?? chains[name]?.defaultRpc;
       if (rpc) {
         evmChainsConfig[name] = { rpc };
       }
@@ -334,25 +334,14 @@ export class WormholeProvider implements CrossChainProvider<
     }
     // Submit transfer transaction from origin chain
     let { originChainTxnId, receipt } = await this.submitCCTPTransfer(input);
-    // Claim is wrapped so that, if it fails, the caller still receives
-    // the originChainTxnId (the irreversible source-chain burn).
-    try {
-      const { destinationChainTxnId } = await this.claimCCTPTransfer({
-        receipt,
-        mainSigner: input.mainSigner,
-        sponsorAccount: input.sponsorAccount,
-        onTransactionSigned: input.onTransactionSigned,
-      });
-      return { originChainTxnId, destinationChainTxnId };
-    } catch (error: any) {
-      throw new TransferError(
-        error?.message ?? "Transfer claim failed after source chain burn",
-        originChainTxnId ||
-          this.crossChainCore._lastSourceChainTxId ||
-          "",
-        error,
-      );
-    }
+    // Claim transfer transaction on destination chain
+    const { destinationChainTxnId } = await this.claimCCTPTransfer({
+      receipt,
+      mainSigner: input.mainSigner,
+      sponsorAccount: input.sponsorAccount,
+      onTransactionSigned: input.onTransactionSigned,
+    });
+    return { originChainTxnId, destinationChainTxnId };
   }
 
   // --- Split withdraw flow: initiateWithdraw + trackWithdraw + claimWithdraw ---

--- a/packages/cross-chain-core/tests/CrossChainCore.test.ts
+++ b/packages/cross-chain-core/tests/CrossChainCore.test.ts
@@ -193,4 +193,35 @@ describe("CrossChainCore", () => {
     // Note: Full balance tests require mocking external RPC calls
     // These are covered in integration tests
   });
+
+  describe("_lastSourceChainTxId", () => {
+    it("should be undefined initially", () => {
+      const core = new CrossChainCore({
+        dappConfig: { aptosNetwork: Network.TESTNET },
+      });
+
+      expect(core._lastSourceChainTxId).toBeUndefined();
+    });
+
+    it("should be settable", () => {
+      const core = new CrossChainCore({
+        dappConfig: { aptosNetwork: Network.TESTNET },
+      });
+
+      core._lastSourceChainTxId = "0xabc123";
+
+      expect(core._lastSourceChainTxId).toBe("0xabc123");
+    });
+
+    it("should be overwritable with a new value", () => {
+      const core = new CrossChainCore({
+        dappConfig: { aptosNetwork: Network.TESTNET },
+      });
+
+      core._lastSourceChainTxId = "0xfirst";
+      core._lastSourceChainTxId = "0xsecond";
+
+      expect(core._lastSourceChainTxId).toBe("0xsecond");
+    });
+  });
 });

--- a/packages/cross-chain-core/tests/TransferError.test.ts
+++ b/packages/cross-chain-core/tests/TransferError.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import {
+  TransferError,
+  WithdrawError,
+} from "../src/providers/wormhole/types";
+
+describe("TransferError", () => {
+  it("should create an error with message and originChainTxnId", () => {
+    const error = new TransferError(
+      "Claim failed",
+      "0xsource123",
+    );
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(TransferError);
+    expect(error.message).toBe("Claim failed");
+    expect(error.name).toBe("TransferError");
+    expect(error.originChainTxnId).toBe("0xsource123");
+    expect(error.cause).toBeUndefined();
+  });
+
+  it("should preserve the underlying cause", () => {
+    const underlying = new Error("RPC timeout");
+    const error = new TransferError(
+      "Claim failed after source burn",
+      "0xburntx456",
+      underlying,
+    );
+
+    expect(error.cause).toBe(underlying);
+    expect(error.originChainTxnId).toBe("0xburntx456");
+  });
+
+  it("should be distinguishable from WithdrawError", () => {
+    const transferErr = new TransferError("t", "0x1");
+    const withdrawErr = new WithdrawError("w", "0x2", "tracking");
+
+    expect(transferErr).toBeInstanceOf(TransferError);
+    expect(transferErr).not.toBeInstanceOf(WithdrawError);
+    expect(withdrawErr).toBeInstanceOf(WithdrawError);
+    expect(withdrawErr).not.toBeInstanceOf(TransferError);
+  });
+
+  it("should work with empty originChainTxnId", () => {
+    const error = new TransferError("Claim failed", "");
+
+    expect(error.originChainTxnId).toBe("");
+  });
+});

--- a/packages/cross-chain-core/tests/signers/Signer.test.ts
+++ b/packages/cross-chain-core/tests/signers/Signer.test.ts
@@ -216,6 +216,35 @@ describe("Signer", () => {
     });
   });
 
+  describe("_trackAsSourceChain", () => {
+    it("should default to true when not specified", () => {
+      const signer = new Signer(
+        mockChainConfig,
+        mockAddress,
+        mockOptions,
+        mockWallet,
+        {} as any, // crossChainCore
+      );
+
+      expect(signer._trackAsSourceChain).toBe(true);
+    });
+
+    it("should be false when explicitly set", () => {
+      const signer = new Signer(
+        mockChainConfig,
+        mockAddress,
+        mockOptions,
+        mockWallet,
+        {} as any,
+        undefined,
+        undefined,
+        false,
+      );
+
+      expect(signer._trackAsSourceChain).toBe(false);
+    });
+  });
+
   // Note: signAndSend tests require mocking chain-specific implementations
   // and are covered in integration tests
 });


### PR DESCRIPTION
## Summary

Closes #761

When the transfer (deposit) flow's claim phase fails after the source-chain burn has already been submitted, the transaction hash was previously lost — the error propagated unwrapped and callers had no way to recover the source chain tx ID.

This PR adds two recovery mechanisms:

- **`_lastSourceChainTxId` on `CrossChainCore`**: A side-channel set by `Signer.signAndSend()` immediately after each successful tx submission. Callers can read it from the `crossChainCore` instance even when errors are thrown.
- **`TransferError` class**: Analogous to the existing `WithdrawError`, wraps claim-phase failures in `transfer()` and preserves `originChainTxnId`. Consumers check `instanceof TransferError` to recover the hash.

### Changes
- `CrossChainCore`: Added `_lastSourceChainTxId` field
- `Signer.signAndSend()`: Sets `_lastSourceChainTxId` after each tx submission
- `types.ts`: New `TransferError` class (exported via barrel)
- `wormhole.ts`: `transfer()` claim phase wrapped in try/catch, throws `TransferError` with preserved source hash
- Tests for `TransferError` class and `_lastSourceChainTxId` field

### Note
The withdraw flow already handles this correctly via `WithdrawError` — this PR brings the transfer (deposit) flow to parity.

## Test plan

- [x] All 165 existing `cross-chain-core` tests pass
- [ ] Verify transfer flow on testnet — successful path returns both tx IDs
- [ ] Verify transfer flow error recovery — simulate claim failure, confirm `TransferError.originChainTxnId` is populated


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes error semantics for the transfer (deposit) flow by wrapping claim-phase failures in a new `TransferError`, and introduces a mutable side-channel tx-hash field that could be overwritten/misused if signers are misconfigured.
> 
> **Overview**
> Adds a recovery side-channel for bridge transfers by tracking the last submitted *source-chain* transaction hash on `CrossChainCore` (`_lastSourceChainTxId`) and having `Signer.signAndSend()` populate it after each successful submission (configurable via new `trackAsSourceChain` flag).
> 
> Updates the Wormhole `transfer()` flow to wrap claim-phase failures in a new `TransferError` that preserves `originChainTxnId` (and the underlying `cause`), and ensures destination-chain claim signers don’t overwrite the source burn hash. Includes a changeset for a minor bump and new unit tests covering `_lastSourceChainTxId`, `TransferError`, and the signer tracking flag.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b975c3105b4b8c5e990d6796b1ba2dfb6589dde2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->