### PR TITLE
fix(wallet-adapter-react): use React JSX intrinsic types in headless component utils

### DIFF
--- a/.changeset/cold-planes-share.md
+++ b/.changeset/cold-planes-share.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/wallet-adapter-react": patch
+---
+
+Fix React JSX intrinsic element typing by importing `JSX` and `ClassAttributes` types directly from React to avoid namespace resolution issues across TypeScript/React setups.

--- a/packages/wallet-adapter-react/src/components/utils.tsx
+++ b/packages/wallet-adapter-react/src/components/utils.tsx
@@ -1,5 +1,6 @@
 import { Slot } from "@radix-ui/react-slot";
-import { ReactNode, cloneElement, forwardRef, isValidElement } from "react";
+import { cloneElement, forwardRef, isValidElement } from "react";
+import type { ClassAttributes, JSX as ReactJSX, ReactNode } from "react";
 
 export interface HeadlessComponentProps {
   /** A class name for styling the element. */
@@ -17,19 +18,19 @@ export interface HeadlessComponentProps {
  * @example
  * HTMLElementFromTag<"img"> // resolved type: HTMLImageElement
  */
-type HTMLElementFromTag<T extends keyof JSX.IntrinsicElements> =
-  JSX.IntrinsicElements[T] extends React.ClassAttributes<infer Element>
+type HTMLElementFromTag<T extends keyof ReactJSX.IntrinsicElements> =
+  ReactJSX.IntrinsicElements[T] extends ClassAttributes<infer Element>
     ? Element
     : HTMLElement;
 
 export function createHeadlessComponent<
-  TElement extends keyof JSX.IntrinsicElements,
+  TElement extends keyof ReactJSX.IntrinsicElements,
 >(
   displayName: string,
   elementType: TElement,
   props?:
-    | JSX.IntrinsicElements[TElement]
-    | ((displayName: string) => JSX.IntrinsicElements[TElement]),
+    | ReactJSX.IntrinsicElements[TElement]
+    | ((displayName: string) => ReactJSX.IntrinsicElements[TElement]),
 ) {
   const component = forwardRef<
     HTMLElementFromTag<TElement>,


### PR DESCRIPTION
## Summary

  This PR fixes JSX intrinsic element typing in `@aptos-labs/wallet-adapter-react` by importing `JSX` and `ClassAttributes` directly from
  React and replacing global `JSX.IntrinsicElements` references with `ReactJSX.IntrinsicElements`.

  ## Why

  In some TypeScript/React setups, the global `JSX` namespace may resolve inconsistently and cause type errors for consumers. Using React-
  scoped JSX types improves compatibility and stability.

  ## Changes

  - Updated `packages/wallet-adapter-react/src/components/utils.tsx`
    - `import type { ClassAttributes, JSX as ReactJSX, ReactNode } from "react"`
    - Replaced:
      - `keyof JSX.IntrinsicElements` -> `keyof ReactJSX.IntrinsicElements`
      - `JSX.IntrinsicElements[...]` -> `ReactJSX.IntrinsicElements[...]`
      - `React.ClassAttributes` -> `ClassAttributes`
  - Added a patch changeset:
    - `.changeset/cold-planes-share.md`

  ## Validation

  - `pnpm --filter @aptos-labs/wallet-adapter-core build`
  - `pnpm --filter @aptos-labs/wallet-adapter-react build:declarations`

  Both commands completed successfully.

  ## Impact

  - Type-only change in `wallet-adapter-react`
  - No runtime behavior changes expected

  Closes #781

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: type-only changes to `createHeadlessComponent` generics plus a patch changeset; no runtime logic is modified.
> 
> **Overview**
> Improves TypeScript compatibility in `wallet-adapter-react` by **replacing global `JSX.IntrinsicElements` usage with React-scoped `React.JSX`/`ClassAttributes` imports** in the headless component utility, avoiding namespace resolution issues in some TS/React setups.
> 
> Adds a **patch changeset** to publish the typing fix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 792855a1f121a0022c9356d2001f36905adf3613. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->