### PR TITLE
fix(derived-wallets): unregister old derived wallets on re-announcement

### DIFF
--- a/.changeset/fix-unregister-derived-wallets.md
+++ b/.changeset/fix-unregister-derived-wallets.md
@@ -1,0 +1,7 @@
+---
+"@aptos-labs/derived-wallet-ethereum": patch
+"@aptos-labs/derived-wallet-solana": patch
+"@aptos-labs/derived-wallet-sui": patch
+---
+
+Unregister old derived wallets before re-registering on provider re-announcement, preventing stale wallets from remaining in the registry.

--- a/packages/derived-wallet-ethereum/src/setupAutomaticDerivation.ts
+++ b/packages/derived-wallet-ethereum/src/setupAutomaticDerivation.ts
@@ -17,6 +17,7 @@ export function setupAutomaticEthereumWalletDerivation(
 
   const deriveAndRegisterWallet = (detail: EIP6963ProviderDetail) => {
     const derivedWallet = new EIP1193DerivedWallet(detail, options);
+    registrations[detail.info.rdns]?.(); // unregister old wallet first
     registrations[detail.info.rdns] = walletsApi.register(derivedWallet);
   };
 

--- a/packages/derived-wallet-solana/src/setupAutomaticDerivation.ts
+++ b/packages/derived-wallet-solana/src/setupAutomaticDerivation.ts
@@ -27,6 +27,7 @@ export function setupAutomaticSolanaWalletDerivation(
   ) => {
     const adapter = new StandardWalletAdapter({ wallet });
     const derivedWallet = new SolanaDerivedWallet(adapter, options);
+    registrations[wallet.name]?.(); // unregister old wallet first
     registrations[wallet.name] = api.register(derivedWallet);
   };
 

--- a/packages/derived-wallet-sui/src/setupAutomaticDerivation.ts
+++ b/packages/derived-wallet-sui/src/setupAutomaticDerivation.ts
@@ -12,6 +12,7 @@ export function setupAutomaticSuiWalletDerivation(
 
   const deriveAndRegisterWallet = (wallet: Wallet) => {
     const derivedWallet = new SuiDerivedWallet(wallet, options);
+    registrations[wallet.name]?.(); // unregister old wallet first
     registrations[wallet.name] = api.register(derivedWallet);
   };
 


### PR DESCRIPTION
## Summary

- Fixes a bug where `setupAutomaticDerivation` in all three derived wallet packages (Ethereum, Solana, Sui) did not unregister previously registered derived wallets when a provider re-announced with the same identifier
- The old unregister callback stored in the `registrations` map was silently overwritten, leaving stale wallets in the wallet-standard registry
- Added a single line to each `deriveAndRegisterWallet` function to call the existing unregister callback before overwriting

Fixes #780

## Test plan

- [ ] Verify WalletConnect disconnect → reconnect no longer leaves stale Ethereum derived wallets in the registry
- [ ] Verify `connect(walletName)` finds the fresh derived wallet after provider re-announcement
- [ ] Confirm no regressions for wallets that only register once (the `?.()` is a no-op when no prior registration exists)


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk bugfix that only adjusts wallet registration lifecycle by invoking the previous unregister callback before overwriting it. Main risk is unintended wallet disappearance if a provider re-announces unexpectedly, but the change is minimal and guarded with optional calls.
> 
> **Overview**
> Prevents stale derived wallets from lingering in the wallet-standard registry by **unregistering any existing derived wallet** (via the stored unsubscribe callback) before registering a replacement when the same provider/wallet is re-announced.
> 
> Applies this fix consistently across the Ethereum (`detail.info.rdns`), Solana (`wallet.name`), and Sui (`wallet.name`) automatic-derivation flows, and publishes patch releases via a changeset.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 06fc3bf0102176d7a5051b256c6565c35c7a00b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->