### PR TITLE
[CrossChainCore] Add skipServerClaim option to claimWithdraw

### DIFF
--- a/.changeset/skip-server-claim.md
+++ b/.changeset/skip-server-claim.md
@@ -2,4 +2,4 @@
 "@aptos-labs/cross-chain-core": minor
 ---
 
-Add `skipServerClaim` option to `claimWithdraw` in WormholeProvider. When set to `true`, bypasses the server-side claim endpoint and falls back to a client-side wallet-signed claim, allowing users to complete withdrawals when the server is unreachable.
+Added `skipServerClaim` option to `WormholeClaimWithdrawRequest`. When `true`, `claimWithdraw` bypasses the configured `serverClaimUrl` endpoint and falls through to the client-side wallet-signed claim path. This enables UI-level fallback when the server endpoint is unreachable — users can complete the claim by signing the transaction themselves and paying gas (e.g. SOL on Solana). Default behavior is unchanged; when omitted or `false`, server-side claims are used when available.

--- a/.changeset/skip-server-claim.md
+++ b/.changeset/skip-server-claim.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/cross-chain-core": minor
+---
+
+Add `skipServerClaim` option to `claimWithdraw` in WormholeProvider. When set to `true`, bypasses the server-side claim endpoint and falls back to a client-side wallet-signed claim, allowing users to complete withdrawals when the server is unreachable.

--- a/packages/cross-chain-core/src/providers/wormhole/types.ts
+++ b/packages/cross-chain-core/src/providers/wormhole/types.ts
@@ -145,6 +145,12 @@ export interface WormholeClaimWithdrawRequest {
   wallet?: AdapterWallet;
   /** Optional callback fired before and after each individual transaction is signed. */
   onTransactionSigned?: OnTransactionSigned;
+  /**
+   * When true, skip the server-side claim path (serverClaimUrl) and instead
+   * perform a client-side wallet-signed claim. Useful as a fallback when the
+   * server endpoint is unreachable. Requires `wallet` to be provided.
+   */
+  skipServerClaim?: boolean;
 }
 
 export interface WormholeClaimWithdrawResponse {

--- a/packages/cross-chain-core/src/providers/wormhole/wormhole.ts
+++ b/packages/cross-chain-core/src/providers/wormhole/wormhole.ts
@@ -459,7 +459,7 @@ export class WormholeProvider
     const serverClaimUrl =
       this.crossChainCore._dappConfig?.solanaConfig?.serverClaimUrl;
 
-    if (claimChain === "Solana" && serverClaimUrl) {
+    if (claimChain === "Solana" && serverClaimUrl && !input.skipServerClaim) {
       logger.log("claimWithdraw: using server-side claim via", serverClaimUrl);
 
       const response = await fetch(serverClaimUrl, {

--- a/packages/cross-chain-core/tests/WormholeProvider.test.ts
+++ b/packages/cross-chain-core/tests/WormholeProvider.test.ts
@@ -1,5 +1,5 @@
 import { Network } from "@aptos-labs/ts-sdk";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { CrossChainCore } from "../src/CrossChainCore";
 import { mainnetChains, testnetChains } from "../src/config";
 import { WormholeProvider } from "../src/providers/wormhole";
@@ -106,6 +106,119 @@ describe("WormholeProvider", () => {
       expect(() => {
         testnetProvider.getChainConfig("Ethereum");
       }).toThrow("Chain config not found");
+    });
+  });
+
+  describe("claimWithdraw", () => {
+    const mockReceipt = { state: 3 } as any;
+
+    it("should use server-side claim for Solana when serverClaimUrl is configured", async () => {
+      const core = new CrossChainCore({
+        dappConfig: {
+          aptosNetwork: Network.TESTNET,
+          solanaConfig: { serverClaimUrl: "https://example.com/api/claim" },
+        },
+      });
+      const provider = new WormholeProvider(core);
+
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({ destinationChainTxnId: "server-tx-123" }),
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const result = await provider.claimWithdraw({
+        claimChain: "Solana",
+        destinationAddress: "SolAddr123",
+        receipt: mockReceipt,
+      });
+
+      expect(mockFetch).toHaveBeenCalledOnce();
+      expect(result.destinationChainTxnId).toBe("server-tx-123");
+
+      vi.unstubAllGlobals();
+    });
+
+    it("should skip server-side claim when skipServerClaim is true", async () => {
+      const core = new CrossChainCore({
+        dappConfig: {
+          aptosNetwork: Network.TESTNET,
+          solanaConfig: { serverClaimUrl: "https://example.com/api/claim" },
+        },
+      });
+      const provider = new WormholeProvider(core);
+
+      const mockFetch = vi.fn();
+      vi.stubGlobal("fetch", mockFetch);
+
+      // Without a wormholeRoute initialized, the wallet-based path throws
+      await expect(
+        provider.claimWithdraw({
+          claimChain: "Solana",
+          destinationAddress: "SolAddr123",
+          receipt: mockReceipt,
+          skipServerClaim: true,
+        }),
+      ).rejects.toThrow("Wormhole route not initialized");
+
+      // fetch should never have been called — server path was skipped
+      expect(mockFetch).not.toHaveBeenCalled();
+
+      vi.unstubAllGlobals();
+    });
+
+    it("should require wallet when skipServerClaim bypasses server path", async () => {
+      const core = new CrossChainCore({
+        dappConfig: {
+          aptosNetwork: Network.TESTNET,
+          solanaConfig: { serverClaimUrl: "https://example.com/api/claim" },
+        },
+      });
+      const provider = new WormholeProvider(core);
+
+      // Inject a mock route so we get past the route check
+      (provider as any).wormholeRoute = {};
+
+      await expect(
+        provider.claimWithdraw({
+          claimChain: "Solana",
+          destinationAddress: "SolAddr123",
+          receipt: mockReceipt,
+          skipServerClaim: true,
+        }),
+      ).rejects.toThrow("Wallet is required");
+
+      vi.unstubAllGlobals();
+    });
+
+    it("should still use server path when skipServerClaim is false", async () => {
+      const core = new CrossChainCore({
+        dappConfig: {
+          aptosNetwork: Network.TESTNET,
+          solanaConfig: { serverClaimUrl: "https://example.com/api/claim" },
+        },
+      });
+      const provider = new WormholeProvider(core);
+
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({ destinationChainTxnId: "server-tx-456" }),
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const result = await provider.claimWithdraw({
+        claimChain: "Solana",
+        destinationAddress: "SolAddr123",
+        receipt: mockReceipt,
+        skipServerClaim: false,
+      });
+
+      expect(mockFetch).toHaveBeenCalledOnce();
+      expect(result.destinationChainTxnId).toBe("server-tx-456");
+
+      vi.unstubAllGlobals();
     });
   });
 


### PR DESCRIPTION
## Summary

Adds optional `skipServerClaim` flag to `WormholeClaimWithdrawRequest` that bypasses the server-side claim path for Solana, providing a fallback when the server endpoint is unreachable. Users can now complete claims by paying gas themselves via wallet-signed transactions.

When `skipServerClaim: true`, the method skips server URL checks and falls through to the client-side wallet-based Signer path. Default behavior is unchanged — server claims are used when available.

Includes unit tests covering server path usage, skipping behavior, wallet requirement validation, and explicit false value handling.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it alters withdraw-claim routing logic for Solana, which is part of the fund-claim flow, though default behavior remains unchanged unless `skipServerClaim` is set.
> 
> **Overview**
> Adds an optional `skipServerClaim` flag to `WormholeClaimWithdrawRequest` to force `claimWithdraw` to bypass the configured Solana `serverClaimUrl` and instead use the client-side wallet-signed claim path.
> 
> Updates `WormholeProvider.claimWithdraw` to gate the server-side POST flow on `!skipServerClaim`, and adds unit tests covering default server usage, explicit skipping (ensuring `fetch` is not called), the wallet-required error when falling back to client-side claiming, and `skipServerClaim: false` behavior. Includes a changeset bump for `@aptos-labs/cross-chain-core`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a8b7c3c5fef7378160bb35f227d8c4e46888d215. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->