### PR TITLE
fix(wallet-adapter-core): deduplicate Aptos Connect chain ID prefetch…

### DIFF
--- a/.changeset/dull-planes-happen.md
+++ b/.changeset/dull-planes-happen.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/wallet-adapter-core": patch
+---
+
+Deduplicate Aptos Connect chain ID prefetch requests during SDK wallet initialization.

--- a/.changeset/green-sheep-marry.md
+++ b/.changeset/green-sheep-marry.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/wallet-adapter-core": patch
+---
+
+Deduplicate Aptos Connect chain ID prefetch requests during SDK wallet initialization.

--- a/packages/wallet-adapter-core/src/sdkWallets.ts
+++ b/packages/wallet-adapter-core/src/sdkWallets.ts
@@ -3,32 +3,7 @@ import {
   AptosConnectGenericWallet,
   AptosConnectGoogleWallet,
 } from "@aptos-connect/wallet-adapter-plugin";
-import { Aptos } from "@aptos-labs/ts-sdk";
 import type { AdapterWallet, DappConfig } from "./WalletCore";
-
-function withDedupedChainIdPrefetch<T>(callback: () => T): T {
-  const originalGetChainId = Aptos.prototype.getChainId;
-  let sharedChainIdPromise: ReturnType<typeof originalGetChainId> | undefined;
-
-  // Aptos Connect eagerly prefetches the chain ID in each wallet constructor.
-  // Reuse the first request during SDK wallet creation so we only hit the node once.
-  Aptos.prototype.getChainId = function getDedupedChainId(this: Aptos) {
-    if (!sharedChainIdPromise) {
-      sharedChainIdPromise = originalGetChainId.call(this).catch((error) => {
-        sharedChainIdPromise = undefined;
-        throw error;
-      });
-    }
-
-    return sharedChainIdPromise;
-  };
-
-  try {
-    return callback();
-  } finally {
-    Aptos.prototype.getChainId = originalGetChainId;
-  }
-}
 
 export function getSDKWallets(dappConfig?: DappConfig) {
   const sdkWallets: AdapterWallet[] = [];
@@ -42,11 +17,9 @@ export function getSDKWallets(dappConfig?: DappConfig) {
     };
 
     sdkWallets.push(
-      ...withDedupedChainIdPrefetch(() => [
-        new AptosConnectGoogleWallet(aptosConnectConfig),
-        new AptosConnectAppleWallet(aptosConnectConfig),
-        new AptosConnectGenericWallet(aptosConnectConfig),
-      ]),
+      new AptosConnectGoogleWallet(aptosConnectConfig),
+      new AptosConnectAppleWallet(aptosConnectConfig),
+      new AptosConnectGenericWallet(aptosConnectConfig),
     );
   }
 

--- a/packages/wallet-adapter-core/src/sdkWallets.ts
+++ b/packages/wallet-adapter-core/src/sdkWallets.ts
@@ -3,29 +3,50 @@ import {
   AptosConnectGenericWallet,
   AptosConnectGoogleWallet,
 } from "@aptos-connect/wallet-adapter-plugin";
+import { Aptos } from "@aptos-labs/ts-sdk";
 import type { AdapterWallet, DappConfig } from "./WalletCore";
+
+function withDedupedChainIdPrefetch<T>(callback: () => T): T {
+  const originalGetChainId = Aptos.prototype.getChainId;
+  let sharedChainIdPromise: ReturnType<typeof originalGetChainId> | undefined;
+
+  // Aptos Connect eagerly prefetches the chain ID in each wallet constructor.
+  // Reuse the first request during SDK wallet creation so we only hit the node once.
+  Aptos.prototype.getChainId = function getDedupedChainId(this: Aptos) {
+    if (!sharedChainIdPromise) {
+      sharedChainIdPromise = originalGetChainId.call(this).catch((error) => {
+        sharedChainIdPromise = undefined;
+        throw error;
+      });
+    }
+
+    return sharedChainIdPromise;
+  };
+
+  try {
+    return callback();
+  } finally {
+    Aptos.prototype.getChainId = originalGetChainId;
+  }
+}
 
 export function getSDKWallets(dappConfig?: DappConfig) {
   const sdkWallets: AdapterWallet[] = [];
 
   // Need to check window is defined for AptosConnect
   if (typeof window !== "undefined") {
+    const aptosConnectConfig = {
+      network: dappConfig?.network,
+      dappId: dappConfig?.aptosConnectDappId,
+      ...dappConfig?.aptosConnect,
+    };
+
     sdkWallets.push(
-      new AptosConnectGoogleWallet({
-        network: dappConfig?.network,
-        dappId: dappConfig?.aptosConnectDappId,
-        ...dappConfig?.aptosConnect,
-      }),
-      new AptosConnectAppleWallet({
-        network: dappConfig?.network,
-        dappId: dappConfig?.aptosConnectDappId,
-        ...dappConfig?.aptosConnect,
-      }),
-      new AptosConnectGenericWallet({
-        network: dappConfig?.network,
-        dappId: dappConfig?.aptosConnectDappId,
-        ...dappConfig?.aptosConnect,
-      }),
+      ...withDedupedChainIdPrefetch(() => [
+        new AptosConnectGoogleWallet(aptosConnectConfig),
+        new AptosConnectAppleWallet(aptosConnectConfig),
+        new AptosConnectGenericWallet(aptosConnectConfig),
+      ]),
     );
   }
 

--- a/packages/wallet-adapter-core/src/sdkWallets.ts
+++ b/packages/wallet-adapter-core/src/sdkWallets.ts
@@ -3,7 +3,27 @@ import {
   AptosConnectGenericWallet,
   AptosConnectGoogleWallet,
 } from "@aptos-connect/wallet-adapter-plugin";
+import { Aptos } from "@aptos-labs/ts-sdk";
 import type { AdapterWallet, DappConfig } from "./WalletCore";
+
+function withDedupedChainIdPrefetch<T>(callback: () => T): T {
+  const originalGetChainId = Aptos.prototype.getChainId;
+  let sharedChainIdPromise: ReturnType<typeof originalGetChainId> | undefined;
+
+  Aptos.prototype.getChainId = function getDedupedChainId(
+    this: Aptos,
+    ...args: Parameters<typeof originalGetChainId>
+  ) {
+    sharedChainIdPromise ??= originalGetChainId.apply(this, args);
+    return sharedChainIdPromise;
+  };
+
+  try {
+    return callback();
+  } finally {
+    Aptos.prototype.getChainId = originalGetChainId;
+  }
+}
 
 export function getSDKWallets(dappConfig?: DappConfig) {
   const sdkWallets: AdapterWallet[] = [];
@@ -17,9 +37,11 @@ export function getSDKWallets(dappConfig?: DappConfig) {
     };
 
     sdkWallets.push(
-      new AptosConnectGoogleWallet(aptosConnectConfig),
-      new AptosConnectAppleWallet(aptosConnectConfig),
-      new AptosConnectGenericWallet(aptosConnectConfig),
+      ...withDedupedChainIdPrefetch(() => [
+        new AptosConnectGoogleWallet(aptosConnectConfig),
+        new AptosConnectAppleWallet(aptosConnectConfig),
+        new AptosConnectGenericWallet(aptosConnectConfig),
+      ]),
     );
   }
 

--- a/packages/wallet-adapter-core/tests/sdkWallets.test.ts
+++ b/packages/wallet-adapter-core/tests/sdkWallets.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const getChainIdMock = vi.fn();
+
+vi.mock("@aptos-labs/ts-sdk", () => {
+  class Aptos {
+    getChainId() {
+      return getChainIdMock();
+    }
+  }
+
+  return {
+    Aptos,
+    Network: {
+      DEVNET: "devnet",
+      MAINNET: "mainnet",
+    },
+  };
+});
+
+vi.mock("@aptos-connect/wallet-adapter-plugin", async () => {
+  const { Aptos, Network } = await import("@aptos-labs/ts-sdk");
+
+  class MockAptosConnectWallet {
+    readonly version = "1.0.0";
+    readonly chains: string[] = [];
+    readonly accounts: string[] = [];
+    readonly features = {};
+    readonly icon = "data:image/svg+xml;base64,test";
+    readonly url = "https://web.petra.app";
+    readonly name: string;
+
+    constructor(config: { network?: string }, name: string) {
+      this.name = name;
+
+      if (config.network === Network.DEVNET) {
+        void new Aptos().getChainId();
+      }
+    }
+  }
+
+  return {
+    AptosConnectGoogleWallet: class extends MockAptosConnectWallet {
+      constructor(config: { network?: string }) {
+        super(config, "Continue with Google");
+      }
+    },
+    AptosConnectAppleWallet: class extends MockAptosConnectWallet {
+      constructor(config: { network?: string }) {
+        super(config, "Continue with Apple");
+      }
+    },
+    AptosConnectGenericWallet: class extends MockAptosConnectWallet {
+      constructor(config: { network?: string }) {
+        super(config, "Petra Web");
+      }
+    },
+  };
+});
+
+import { Network } from "@aptos-labs/ts-sdk";
+import { getSDKWallets } from "../src/sdkWallets";
+
+describe("getSDKWallets", () => {
+  const originalWindow = globalThis.window;
+
+  beforeEach(() => {
+    getChainIdMock.mockResolvedValue(148);
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: originalWindow,
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: originalWindow,
+      writable: true,
+    });
+  });
+
+  it("dedupes constructor-time chain id lookups across SDK wallets", () => {
+    const wallets = getSDKWallets({ network: Network.DEVNET } as any);
+
+    expect(wallets).toHaveLength(3);
+    expect(getChainIdMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("restores Aptos.getChainId after wallet construction", async () => {
+    getSDKWallets({ network: Network.DEVNET } as any);
+
+    const { Aptos } = await import("@aptos-labs/ts-sdk");
+    await new Aptos().getChainId();
+
+    expect(getChainIdMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("skips SDK wallet creation outside the browser", () => {
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: undefined,
+      writable: true,
+    });
+
+    const wallets = getSDKWallets({ network: Network.DEVNET } as any);
+
+    expect(wallets).toEqual([]);
+    expect(getChainIdMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/wallet-adapter-core/tests/sdkWallets.test.ts
+++ b/packages/wallet-adapter-core/tests/sdkWallets.test.ts
@@ -21,6 +21,15 @@ vi.mock("@aptos-labs/ts-sdk", () => {
 vi.mock("@aptos-connect/wallet-adapter-plugin", async () => {
   const { Aptos, Network } = await import("@aptos-labs/ts-sdk");
 
+  function networkToChainId(network?: string) {
+    switch (network) {
+      case Network.MAINNET:
+        return 1;
+      default:
+        return undefined;
+    }
+  }
+
   class MockAptosConnectWallet {
     readonly version = "1.0.0";
     readonly chains: string[] = [];
@@ -33,8 +42,8 @@ vi.mock("@aptos-connect/wallet-adapter-plugin", async () => {
     constructor(config: { network?: string }, name: string) {
       this.name = name;
 
-      if (config.network === Network.DEVNET) {
-        void new Aptos().getChainId();
+      if (networkToChainId(config.network) === undefined) {
+        void new Aptos().getChainId().catch(() => undefined);
       }
     }
   }
@@ -65,6 +74,7 @@ describe("getSDKWallets", () => {
   const originalWindow = globalThis.window;
 
   beforeEach(() => {
+    getChainIdMock.mockReset();
     getChainIdMock.mockResolvedValue(148);
     Object.defineProperty(globalThis, "window", {
       configurable: true,
@@ -88,8 +98,29 @@ describe("getSDKWallets", () => {
     expect(getChainIdMock).toHaveBeenCalledTimes(1);
   });
 
+  it("preserves the plugin fast path for known networks", () => {
+    const wallets = getSDKWallets({ network: Network.MAINNET } as any);
+
+    expect(wallets).toHaveLength(3);
+    expect(getChainIdMock).not.toHaveBeenCalled();
+  });
+
   it("restores Aptos.getChainId after wallet construction", async () => {
     getSDKWallets({ network: Network.DEVNET } as any);
+
+    const { Aptos } = await import("@aptos-labs/ts-sdk");
+    await new Aptos().getChainId();
+
+    expect(getChainIdMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("allows retries after a failed constructor-time chain id prefetch", async () => {
+    getChainIdMock
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockResolvedValueOnce(148);
+
+    getSDKWallets({ network: Network.DEVNET } as any);
+    await Promise.resolve();
 
     const { Aptos } = await import("@aptos-labs/ts-sdk");
     await new Aptos().getChainId();


### PR DESCRIPTION
 fix(wallet-adapter-core): deduplicate Aptos Connect chain ID prefetch on init" 
Fixes #727
## Problem
During initialization, \`getSDKWallets()\` constructs three wallet instances (Google, Apple, Generic), each of which eagerly calls \`aptosClient.getChainId()\` in its constructor. Since each wallet creates its own Aptos client with no shared caching, this results in **3 duplicate HTTP requests** to the full node on every page load.
## Fix
Added a \`withDedupedChainIdPrefetch\` helper in \`sdkWallets.ts\` that temporarily patches \`Aptos.prototype.getChainId\` during wallet construction so all three wallets share a single Promise. The original method is restored immediately in a \`finally\` block — no permanent side effects.
- Works for **all networks** (including devnet/custom), not just mainnet/testnet
- Requires no changes to upstream \`@aptos-connect/wallet-adapter-plugin\`
- Prototype is fully restored after construction
- Error case resets the shared promise so future calls retry cleanly
## Tests
Added \`tests/sdkWallets.test.ts\` covering:
- Deduplication: \`getChainId\` called exactly once across 3 wallets
- Prototype restore: subsequent calls after construction are unaffected  
- SSR safety: no wallets created outside browser environment"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped prototype monkey-patch only during wallet construction with `finally` restore; no auth or persistence changes, covered by new unit tests.
> 
> **Overview**
> **Reduces redundant full-node traffic** when Aptos Connect SDK wallets are registered: `getSDKWallets()` now builds Google, Apple, and Generic wallets inside a short-lived `withDedupedChainIdPrefetch` wrapper that shares one `getChainId()` promise via a temporary `Aptos.prototype` patch, then restores the original method.
> 
> Shared **Aptos Connect config** is hoisted into `aptosConnectConfig` so all three plugins get the same object. New **`sdkWallets.test.ts`** asserts a single chain-ID lookup on devnet, no prefetch on mainnet’s known-network path, prototype restoration, retry after prefetch failure, and no wallets when `window` is undefined. Patch **changesets** document the `@aptos-labs/wallet-adapter-core` release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 841a6869b45e19216f96fe5a76cc0b3435dfabad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->