### PR TITLE
fix(derived-wallet-ethereum): forward domain in SIWE envelope so Node flows don't hit window.location.host

### DIFF
--- a/.changeset/fix-siwe-envelope-domain-node.md
+++ b/.changeset/fix-siwe-envelope-domain-node.md
@@ -1,0 +1,5 @@
+---
+"@aptos-labs/derived-wallet-ethereum": patch
+---
+
+Forward `domain` in `createSiweEnvelopeForAptosTransaction` so `createTransactionStatement` no longer falls back to `window.location.host`, which is undefined in Node and crashes server-side / programmatic flows (e.g. `EIP1193DerivedAccount.signTransactionWithAuthenticator`).

--- a/packages/derived-wallet-ethereum/src/createSiweEnvelope.ts
+++ b/packages/derived-wallet-ethereum/src/createSiweEnvelope.ts
@@ -56,7 +56,7 @@ export function createSiweEnvelopeForAptosTransaction(
     rawTransaction: AnyRawTransaction;
   },
 ) {
-  const { rawTransaction, ...rest } = input;
-  const statement = createTransactionStatement(rawTransaction);
-  return createSiweEnvelope({ ...rest, statement });
+  const { rawTransaction, domain, ...rest } = input;
+  const statement = createTransactionStatement(rawTransaction, domain);
+  return createSiweEnvelope({ ...rest, statement, domain });
 }


### PR DESCRIPTION
## Summary

`createSiweEnvelopeForAptosTransaction` forwards `domain` into `createSiweEnvelope` but not into `createTransactionStatement`. `createTransactionStatement` then falls back to `window.location.host`, which is **undefined in Node** and throws `ReferenceError: window is not defined`.

This blocks programmatic / server-side flows that use `EIP1193DerivedAccount.signTransactionWithAuthenticator`, even when the caller explicitly passes a `domain` to the account.

Browser usage was unaffected because `window.location.host` resolves there, so the bug only surfaces server-side.

## Change

Thread `domain` through both call sites:

```diff
-  const { rawTransaction, ...rest } = input;
-  const statement = createTransactionStatement(rawTransaction);
-  return createSiweEnvelope({ ...rest, statement });
+  const { rawTransaction, domain, ...rest } = input;
+  const statement = createTransactionStatement(rawTransaction, domain);
+  return createSiweEnvelope({ ...rest, statement, domain });
```

`createTransactionStatement` already accepts an optional `domain` argument (`packages/derived-wallet-base/src/envelope.ts`), so no API change is needed in the base package.

`createSiweEnvelopeForAptosStructuredMessage` is unaffected — `createStructuredMessageStatement` doesn't reference `window`.

## Repro

In Node (no browser globals):

```ts
import { Wallet } from "ethers";
import { EIP1193DerivedAccount } from "@aptos-labs/derived-wallet-ethereum";

const account = new EIP1193DerivedAccount({
  ethereumWallet: Wallet.createRandom(),
  domain: "my-dapp.com",
});

// Build any AnyRawTransaction with the SDK, then:
account.signTransactionWithAuthenticator(transaction);
// ReferenceError: window is not defined
//   at createTransactionStatement (.../derived-wallet-base/dist/index.mjs:91:...)
//   at createSiweEnvelopeForAptosTransaction (...)
```

After this fix, the same code completes successfully and produces a SIWE envelope with the explicit `domain`.

## Test plan

- [ ] CI green
- [x] Manually verified: `EIP1193DerivedAccount.signTransactionWithAuthenticator` runs end-to-end in Node and produces a transaction that the on-chain authenticator accepts
- [ ] Add a Node-side unit test for `createSiweEnvelopeForAptosTransaction` (happy to add in a follow-up if reviewers prefer)

## Changeset

`@aptos-labs/derived-wallet-ethereum` — patch

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the SIWE message content for transaction signing by threading `domain` into `createTransactionStatement`, which could affect signature/envelope compatibility for callers that implicitly relied on the previous `window.location.host` behavior. Low surface area, but it touches signing payload construction and fixes a Node crash.
> 
> **Overview**
> Fixes server-side / programmatic transaction signing by forwarding `domain` through `createSiweEnvelopeForAptosTransaction` into `createTransactionStatement`, avoiding the `window.location.host` fallback that crashes in Node.
> 
> Adds a changeset for a patch release of `@aptos-labs/derived-wallet-ethereum`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a3617271ac374eb3f97c8b93c4c224acaab7d4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->